### PR TITLE
Added method to retrieve a workflow

### DIFF
--- a/api-module-library/ironclad/api.js
+++ b/api-module-library/ironclad/api.js
@@ -87,7 +87,7 @@ class Api extends ApiKeyRequester {
         return response;
     }
 
-    async retrireveWorkflow(id) {
+    async retrieveWorkflow(id) {
         const options = {
             url: this.baseUrl + this.URLs.workflowsByID(id)
         }

--- a/api-module-library/ironclad/api.js
+++ b/api-module-library/ironclad/api.js
@@ -87,6 +87,14 @@ class Api extends ApiKeyRequester {
         return response;
     }
 
+    async retrireveWorkflow(id) {
+        const options = {
+            url: this.baseUrl + this.URLs.workflowsByID(id)
+        }
+        const response = await this._get(options);
+        return response;
+    }
+
     async createWorkflow(body) {
         const options = {
             url: this.baseUrl + this.URLs.workflows,

--- a/api-module-library/ironclad/test/api.test.js
+++ b/api-module-library/ironclad/test/api.test.js
@@ -109,6 +109,26 @@ describe('Ironclad API class', () => {
             expect(response).to.have.property('schema');
         })
 
+        it('should retrieve a workflow', async () => {
+            const response = await api.retrireveWorkflow(workflowID);
+            expect(response).to.have.property('id');
+            expect(response).to.have.property('title');
+            expect(response).to.have.property('template');
+            expect(response).to.have.property('step');
+            expect(response).to.have.property('schema');
+            expect(response).to.have.property('attributes');
+            expect(response).to.have.property('isCancelled');
+            expect(response).to.have.property('isComplete');
+            expect(response).to.have.property('status');
+            expect(response).to.have.property('creator');
+            expect(response).to.have.property('created');
+            expect(response).to.have.property('lastUpdated');
+            expect(response).to.have.property('roles');
+            expect(response).to.have.property('approvals');
+            expect(response).to.have.property('signatures');
+            expect(response).to.have.property('isRevertibleToReview')
+        })
+
         it('should list all workflow approvals', async () => {
             const response = await api.listAllWorkflowApprovals(workflowID);
             expect(response).to.have.property('workflowId');

--- a/api-module-library/ironclad/test/api.test.js
+++ b/api-module-library/ironclad/test/api.test.js
@@ -110,7 +110,7 @@ describe('Ironclad API class', () => {
         })
 
         it('should retrieve a workflow', async () => {
-            const response = await api.retrireveWorkflow(workflowID);
+            const response = await api.retrieveWorkflow(workflowID);
             expect(response).to.have.property('id');
             expect(response).to.have.property('title');
             expect(response).to.have.property('template');


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-ironclad@0.0.3-canary.53.2a9bba7.0
  # or 
  yarn add @friggframework/api-module-ironclad@0.0.3-canary.53.2a9bba7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
