### PR TITLE
Ironclad - Retrieve Workflow Document

### DIFF
--- a/api-module-library/ironclad/api.js
+++ b/api-module-library/ironclad/api.js
@@ -138,6 +138,14 @@ class Api extends ApiKeyRequester {
         return response;
     }
 
+    async retrieveWorkflowDocument(workflowID, documentKey) {
+        const options = {
+            url: this.baseUrl + this.URLs.workflowsByID(workflowID) + `/document/${documentKey}/download`
+        };
+        const response = await this._get(options);
+        return response;
+    }
+
     async listAllRecords() {
         const options = {
             url: this.baseUrl + this.URLs.records,

--- a/api-module-library/ironclad/test/api.test.js
+++ b/api-module-library/ironclad/test/api.test.js
@@ -47,6 +47,7 @@ describe('Ironclad API class', () => {
     describe('Workflows', () => {
         let workflowSchemaID;
         let workflowID;
+        let documentKey;
         it('should list all workflows', async () => {
             const response = await api.listAllWorkflows();
             expect(response).to.have.property('page');
@@ -126,15 +127,21 @@ describe('Ironclad API class', () => {
             expect(response).to.have.property('approvals');
             expect(response).to.have.property('signatures');
             expect(response).to.have.property('isRevertibleToReview');
+            documentKey = response.attributes.draft[0].download.split('/')[7];
         });
 
-        it('should list all workflow approvals', async () => {
+        it.skip('should list all workflow approvals', async () => {
             const response = await api.listAllWorkflowApprovals(workflowID);
             expect(response).to.have.property('workflowId');
             expect(response).to.have.property('title');
             expect(response).to.have.property('approvalGroups');
             expect(response).to.have.property('roles');
         });
+
+        it('should retrieve a workflow document', async () => {
+            const response = await api.retrieveWorkflowDocument(workflowID, documentKey);
+            expect(response).to.exist
+        })
     });
 
     describe('Records', () => {


### PR DESCRIPTION
Added a Method to retrieve a Workflow Document
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-ironclad@0.0.8-canary.58.d22b52d.0
  # or 
  yarn add @friggframework/api-module-ironclad@0.0.8-canary.58.d22b52d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
