### PR TITLE
Refresh Auth attempt only once, instead of potential for infinite loop

### DIFF
--- a/packages/module-plugin/requester/requester.js
+++ b/packages/module-plugin/requester/requester.js
@@ -57,10 +57,7 @@ class Requester extends Delegate {
                 await this.notify(this.DLGT_INVALID_AUTH);
             } else {
                 this.refreshCount++;
-                // this.isRefreshable = false; // Set so that if we 401 during refresh request, we hit the above block
                 await this.refreshAuth();
-                // this.isRefreshable = true;// Set so that we can retry later? in case it's a fast expiring auth
-                this.refreshCount = 0;
                 return this._request(url, options, i + 1); // Retries
             }
         }


### PR DESCRIPTION
Dangerous commit, because it changes _all_ requesters out there. I'm not sure if anyone is relying on this logic, and we don't have it tested in isolation and across each API module.

That needs to change over time.

In this case, the idea is that if we get a 401 from the API, we should attempt an auth refresh only once, instead of the potential for an infinite loop.

The catch is that this only works for APIs who adhere to the normal REST response status conventions. Some use 400 to tell you auth is broken. Some use 200 with an error body. and on and on.