### PR TITLE
wip: trying to throw a helpful error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local
@@ -21,4 +22,5 @@ yarn-error.log*
 # webstorm local config
 .idea/
 
-.env
+# Vscode local config
+.vscode

--- a/packages/encrypt/Cryptor.js
+++ b/packages/encrypt/Cryptor.js
@@ -20,7 +20,7 @@ class Cryptor {
     }
 
     async generateDataKey() {
-        if (this.shouldUseAws) {
+        if (this?.shouldUseAws) {
             const kmsClient = new AWS.KMS();
             const dataKey = await kmsClient
                 .generateDataKey({
@@ -36,7 +36,14 @@ class Cryptor {
         }
 
         const { AES_KEY, AES_KEY_ID } = process.env;
+        console.log('JON >>> process.env.AES_KEY', process.env.AES_KEY);
         const randomKey = crypto.randomBytes(32).toString('hex').slice(0, 32);
+
+        if (!AES_KEY || !AES_KEY_ID) {
+            throw new Error(
+                `Environment variables not set for AES_KEY or AES_KEY_ID`
+            );
+        }
 
         return {
             keyId: Buffer.from(AES_KEY_ID).toString('base64'),

--- a/packages/encrypt/Cryptor.test.js
+++ b/packages/encrypt/Cryptor.test.js
@@ -29,4 +29,25 @@ describe('Cryptor', () => {
             );
         });
     });
+
+    describe('generateDataKey()', () => {
+        it('raises error on missing environment', () => {
+            const cryptor = new Cryptor({ fields: ['a.b.c.d', 'e'] });
+            
+            // save the env variables for later
+            const AES_KEY = process.env.AES_KEY
+            const AES_KEY_ID = process.env.AES_KEY_ID
+            
+            // Fake out the situation where the keys are undefined
+            process.env.AES_KEY = undefined
+            process.env.AES_KEY_ID = undefined
+            expect(cryptor.generateDataKey).toThrow(
+                'Environment variables not set for AES_KEY or AES_KEY_ID'
+            );
+
+            // reset those env variables
+            process.env.AES_KEY = AES_KEY
+            process.env.AES_KEY_ID = AES_KEY_ID
+        });
+    });
 });

--- a/packages/encrypt/aes.js
+++ b/packages/encrypt/aes.js
@@ -3,6 +3,7 @@ const crypto = require('crypto');
 const algorithm = 'aes-256-ctr';
 
 function encrypt(text, key) {
+    console.log('JON >>> text, key', text, key);
     const iv = crypto.randomBytes(16);
     const randomString = iv.toString('hex');
 


### PR DESCRIPTION
If you don't have AES_KEY and AES_KEY_ID set, the encrypt method fails.

It took me quite a long time to figure this out as a new developer so I think a helpful error message here goes a long way.

I can't seem to get my test to pass even when I pass in the keys in the command line like this:

`AES_KEY=Testing123456789Testing123456789 AES_KEY_ID=xxx-xxx-xxx-xxx-xxx jest /Users/jon/Code/lefthook/frigg/packages/encrypt/Cryptor.test.js`

I need some help to get this merged 😄 