### PR TITLE
log error thrown from slack get token from code call

### DIFF
--- a/api-module-library/slack/manager.js
+++ b/api-module-library/slack/manager.js
@@ -66,6 +66,7 @@ class Manager extends ModuleManager {
         try {
             await this.api.getTokenFromCode(code);
         } catch (e) {
+            flushDebugLog(e);
             throw new Error('Auth Error');
         }
         const authRes = await this.testAuth();


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-slack@0.1.14-canary.101.37b3d82.0
  # or 
  yarn add @friggframework/api-module-slack@0.1.14-canary.101.37b3d82.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
