### PR TITLE
change to x-www-form-urlencoded

### DIFF
--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -81,7 +81,8 @@ class Api extends OAuth2Requester {
             return this._request(url, options, i + 1);
         } else if (
             parsedResponse.error === 'invalid_auth' ||
-            parsedResponse.error === 'auth_expired'
+            parsedResponse.error === 'auth_expired' ||
+            parsedResponse.error === 'token_expired'
         ) {
             if (!this.isRefreshable || this.refreshCount > 0) {
                 await this.notify(this.DLGT_INVALID_AUTH);
@@ -144,7 +145,7 @@ class Api extends OAuth2Requester {
             url: this.baseUrl + this.URLs.lookupUserByEmail,
             body,
             headers: {
-                'Content-Type': 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded',
                 Accept: 'application/json',
             },
         };

--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -142,7 +142,7 @@ class Api extends OAuth2Requester {
 
     async lookupUserByEmail(body) {
         const options = {
-            url: this.baseUrl + this.URLs.lookupUserByEmail,
+            url: this.baseUrl + this.URLs.lookupUserByEmail + `?email=${body.email}`,
             body,
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',

--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -140,10 +140,9 @@ class Api extends OAuth2Requester {
         return response;
     }
 
-    async lookupUserByEmail(body) {
+    async lookupUserByEmail(email) {
         const options = {
-            url: this.baseUrl + this.URLs.lookupUserByEmail + `?email=${body.email}`,
-            body,
+            url: this.baseUrl + this.URLs.lookupUserByEmail + `?email=${email}`,
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
                 Accept: 'application/json',


### PR DESCRIPTION
https://api.slack-gov.com/methods/users.lookupByEmail requires x-www-form-urlencoded
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-ironclad@0.0.24-canary.107.75550ee.0
  npm install @friggframework/api-module-slack@0.1.16-canary.107.75550ee.0
  # or 
  yarn add @friggframework/api-module-ironclad@0.0.24-canary.107.75550ee.0
  yarn add @friggframework/api-module-slack@0.1.16-canary.107.75550ee.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
