### PR TITLE
Fixed a Slack bug via requester improvement

### DIFF
--- a/api-module-library/slack/test/manager.test.js
+++ b/api-module-library/slack/test/manager.test.js
@@ -49,6 +49,7 @@ describe(`Should fully test the ${config.label} Manager`, () => {
             manager.api.access_token = 'nope';
             await manager.testAuth();
             expect(manager.api.access_token).to.not.equal('nope');
+            expect(manager.api.access_token).to.exist;
         });
         it('should refresh token after a fresh database retrieval', async () => {
             const newManager = await Manager.getInstance({
@@ -58,22 +59,27 @@ describe(`Should fully test the ${config.label} Manager`, () => {
             newManager.api.access_token = 'nope';
             await newManager.testAuth();
             expect(newManager.api.access_token).to.not.equal('nope');
+            expect(newManager.api.access_token).to.exist;
         });
 
         it('should refresh token after it expires', async () => {
-            const oldToken = `${manager.api.access_token}`;
-            const testAuthNock = nock(manager.api.baseUrl, {
+            const newManager = await Manager.getInstance({
+                userId: manager.userId,
+                entityId: manager.entity.id,
+            });
+            const oldToken = `${newManager.api.access_token}`;
+            const testAuthNock = nock(newManager.api.baseUrl, {
                 allowUnmocked: true,
             })
-                .post(manager.api.URLs.authTest)
+                .post(newManager.api.URLs.authTest)
                 .reply(200, {
                     ok: false,
                     error: 'token_expired',
                 });
-            manager.api.access_token = null;
-            await manager.testAuth();
+            await newManager.testAuth();
             expect(testAuthNock.isDone());
-            expect(manager.api.access_token).to.not.equal(oldToken);
+            expect(newManager.api.access_token).to.not.equal(oldToken);
+            expect(newManager.api.access_token).to.exist;
         });
         it('auth refresh should fail if redirect URI changes', async () => {
             const newManager = await Manager.getInstance({

--- a/packages/module-plugin/requester/oauth-2.js
+++ b/packages/module-plugin/requester/oauth-2.js
@@ -111,6 +111,9 @@ class OAuth2Requester extends Requester {
         const options = {
             body: params,
             url: this.tokenUri,
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
         };
         const response = await this._post(options, false);
         await this.setTokens(response);


### PR DESCRIPTION
- In order to not write the content-type headers for every Slack request, we default wrote them in Slack's addAuthHeader method
- This had a side effect of breaking auth refresh, since that request in the OAuth2 requester class did not set the headers for www-form-encoded stuff, which meant we attempted to refresh tokens in Slack with an application/json Content-Type header. Which Slack didn't like.