### PR TITLE
StrictQuery issue resolution

### DIFF
--- a/packages/database/mongo.js
+++ b/packages/database/mongo.js
@@ -29,6 +29,7 @@ const connectToDatabase = async () => {
     }
 
     debug('=> using new database connection');
+    mongoose.set('strictQuery', false);
     await mongoose.connect(process.env.MONGO_URI, mongoConfig);
     mongoose.connection.on('error', (error) => flushDebugLog(error));
 };


### PR DESCRIPTION
In Mongoose 5, strictQuery was false. Mongoose changed it to "true" in Mongoose 6. Will change it back in Mongoose 7.

StrictQuery being "true" means that if your filter query is at all partially broken (you send in a null value, etc), it will return all items, whereas the expectation would be any of the filter conditions match (ignoring broken ones).

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)