### PR TITLE
Support as-user-workflow-schemas and connection info

### DIFF
--- a/api-module-library/ironclad/api.js
+++ b/api-module-library/ironclad/api.js
@@ -36,9 +36,9 @@ class Api extends ApiKeyRequester {
             records: '/public/api/v1/records',
             recordByID: (recordId) => `/public/api/v1/records/${recordId}`,
             recordSchemas: '/public/api/v1/records/metadata',
-            workflowParticipantsByID: (workflowId) => 
+            workflowParticipantsByID: (workflowId) =>
                 `/public/api/v1/workflows/${workflowId}/participants`,
-            userByID: (userId) => `/scim/v2/Users/${userId}`
+            userByID: (userId) => `/scim/v2/Users/${userId}`,
         };
     }
 
@@ -130,11 +130,17 @@ class Api extends ApiKeyRequester {
         return response;
     }
 
-    async listAllWorkflowSchemas(params) {
+    async listAllWorkflowSchemas(params, asUserEmail, asUserId) {
         const options = {
             url: this.baseUrl() + this.URLs.workflowSchemas,
             query: params,
         };
+        if (asUserEmail) {
+            options.headers['x-as-user-email'] = asUserEmail;
+        }
+        if (asUserId) {
+            options.headers['x-as-user-id'] = asUserId;
+        }
         const response = await this._get(options);
         return response;
     }
@@ -201,7 +207,9 @@ class Api extends ApiKeyRequester {
 
     async getWorkflowComment(workflowId, commentId) {
         const options = {
-            url: this.baseUrl() + this.URLs.workflowCommentByID(workflowId, commentId),
+            url:
+                this.baseUrl() +
+                this.URLs.workflowCommentByID(workflowId, commentId),
             headers: {
                 'content-type': 'application/json',
             },
@@ -289,19 +297,20 @@ class Api extends ApiKeyRequester {
         return response;
     }
 
-    async getWorkflowParticipants(workflowId){
+    async getWorkflowParticipants(workflowId) {
         // TODO: Handle pagination for this api call
         const options = {
-            url: this.baseUrl() + this.URLs.workflowParticipantsByID(workflowId)
-        }
+            url:
+                this.baseUrl() + this.URLs.workflowParticipantsByID(workflowId),
+        };
         const response = await this._get(options);
         return response;
     }
 
-    async getUser(userId){
+    async getUser(userId) {
         const options = {
-            url: this.baseUrl() + this.URLs.userByID(userId)
-        }
+            url: this.baseUrl() + this.URLs.userByID(userId),
+        };
         const response = await this._get(options);
         return response;
     }

--- a/api-module-library/ironclad/api.js
+++ b/api-module-library/ironclad/api.js
@@ -19,6 +19,7 @@ class Api extends ApiKeyRequester {
         };
 
         this.URLs = {
+            me: '/public/api/v1/me',
             webhooks: '/public/api/v1/webhooks',
             webhookByID: (webhookId) => `/public/api/v1/webhooks/${webhookId}`,
             workflows: '/public/api/v1/workflows',
@@ -47,6 +48,14 @@ class Api extends ApiKeyRequester {
             headers.Authorization = `Bearer ${this.API_KEY_VALUE}`;
         }
         return headers;
+    }
+
+    async getConnectionInformation() {
+        const options = {
+            url: this.baseUrl() + this.URLs.me,
+        };
+        const response = await this._get(options);
+        return response;
     }
 
     async listWebhooks() {

--- a/api-module-library/ironclad/manager.js
+++ b/api-module-library/ironclad/manager.js
@@ -65,6 +65,7 @@ class Manager extends ModuleManager {
 
         // Grab identifying information if available.
         // Currently not available in the Ironclad API
+        const connectionInfo = await this.api.getConnectionInformation();
 
         await this.findOrCreateCredential({
             apiKey,
@@ -72,9 +73,12 @@ class Manager extends ModuleManager {
             subdomain,
         });
         await this.findOrCreateEntity({
-            apiKey,
+            externalId:
+                connectionInfo?.companyId ||
+                createHash('sha256').update(apiKey).digest('hex'),
             subType,
             subdomain,
+            name: connectionInfo?.companyName || null,
         });
         const returnObj = {
             credential_id: this.credential.id,
@@ -120,10 +124,9 @@ class Manager extends ModuleManager {
     }
 
     async findOrCreateEntity(params) {
-        const apiKey = get(params, 'apiKey', null);
         const name = get(params, 'name', null);
         const subType = get(params, 'subType', null);
-        const externalId = createHash('sha256').update(apiKey).digest('hex');
+        const externalId = get(params, 'externalId', null);
 
         const search = await Entity.find({
             user: this.userId,

--- a/api-module-library/ironclad/manager.js
+++ b/api-module-library/ironclad/manager.js
@@ -9,7 +9,7 @@ const {
 } = require('@friggframework/module-plugin');
 const AuthFields = require('./authFields');
 const Config = require('./defaultConfig.json');
-const { flushDebugLog } = require('@friggframework/logs');
+const { flushDebugLog, debug } = require('@friggframework/logs');
 const { createHash } = require('crypto');
 
 class Manager extends ModuleManager {
@@ -64,8 +64,13 @@ class Manager extends ModuleManager {
         if (!authRes) throw new Error('Auth Error');
 
         // Grab identifying information if available.
-        // Currently not available in the Ironclad API
-        const connectionInfo = await this.api.getConnectionInformation();
+        // Some credentials will not have proper access/permissions
+        let connectionInfo;
+        try {
+            connectionInfo = await this.api.getConnectionInformation();
+        } catch (e) {
+            debug('No permission to get connection information');
+        }
 
         await this.findOrCreateCredential({
             apiKey,


### PR DESCRIPTION
Adds support for:
- Retrieving workflow schemas as userId or userEmail
- Retrieving connection information via /me if proper permissions and using those for name and externalId for Entity

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)