### PR TITLE
add token_revoked event for slack

### DIFF
--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -101,7 +101,8 @@ class Api extends OAuth2Requester {
         } else if (
             parsedResponse.error === 'invalid_auth' ||
             parsedResponse.error === 'auth_expired' ||
-            parsedResponse.error === 'token_expired'
+            parsedResponse.error === 'token_expired' ||
+            parsedResponse.error === 'token_revoked'
         ) {
             if (!this.isRefreshable || this.refreshCount > 0) {
                 await this.notify(this.DLGT_INVALID_AUTH);


### PR DESCRIPTION
It looks like we get a `token_revoked` event from slack when we relink Slack (current hypothesis). We see the error when trying to call getUserProfileById.
Adding `token_revoked` event to see if we're able to refresh the token after and get a successful call.