### PR TITLE
Implement postEphemeral method for Slack

### DIFF
--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -39,6 +39,7 @@ class Api extends OAuth2Requester {
             // Chats
             getMessagePermalink: '/chat.getPermalink',
             postMessage: '/chat.postMessage',
+            postEphemeral: 'chat.postEphemeral',
             updateMessage: '/chat.update',
             deleteMessage: '/chat.delete',
 
@@ -228,6 +229,29 @@ class Api extends OAuth2Requester {
     async postMessage(body) {
         const options = {
             url: this.baseUrl + this.URLs.postMessage,
+            body,
+        };
+        const response = await this._post(options);
+        return response;
+    }
+
+    // Args:
+    // channel: string, required
+    // user: string, required
+    // At least one required:
+    //      attachments: string
+    //      blocks: blocks[] as string
+    //      text: string
+    // as_user: boolean, optional
+    // icon_emoji: string, optional
+    // icon_url: string, optional
+    // link_names: boolean, optional
+    // parse: string, optional
+    // thread_ts: string, optional
+    // username: string, optional
+    async postEphemeral(body) {
+        const options = {
+            url: this.baseUrl + this.URLs.postEphemeral,
             body,
         };
         const response = await this._post(options);


### PR DESCRIPTION
Could it be that simple @seanspeaks ?
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-slack@0.1.26-canary.137.9272ed2.0
  # or 
  yarn add @friggframework/api-module-slack@0.1.26-canary.137.9272ed2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
