### PR TITLE
improve error thrown for invalid integration

### DIFF
--- a/packages/integrations/manager.js
+++ b/packages/integrations/manager.js
@@ -325,7 +325,7 @@ class IntegrationManager extends Delegate {
          const integration = await Integration.findById(integration_id);
 
          if (!integration) {
-             throw new Error(`Integration with ID ${id} does not exist.`);
+             throw new Error(`Integration with ID ${integration_id} does not exist.`);
          }
 
          if (integration.user.toString() !== userId.toString()) {

--- a/packages/integrations/test/manager.test.js
+++ b/packages/integrations/test/manager.test.js
@@ -98,11 +98,12 @@ describe(`Should fully test the IntegrationManager`, () => {
 
     describe('upsertIntegrationMapping()', () => {
         it('should throw error if integrationId does not match', async () => {
+            const id = new mongoose.Types.ObjectId();
             try {
-                await IntegrationManager.upsertIntegrationMapping(new mongoose.Types.ObjectId(), userId, 'validId', {});
+                await IntegrationManager.upsertIntegrationMapping(id, userId, 'validId', {});
                 fail('should have thrown error')
             } catch(err) {
-                expect(err.message).to.contain('id is not defined');
+                expect(err.message).to.contain(`Integration with ID ${id} does not exist`);
             }
         });
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/integrations@1.0.24-canary.145.c67e0ea.0
  # or 
  yarn add @friggframework/integrations@1.0.24-canary.145.c67e0ea.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
