### PR TITLE
Fix Slack getChannelHistory call

### DIFF
--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -1,3 +1,5 @@
+const qs = require('qs');
+
 const { OAuth2Requester } = require('@friggframework/module-plugin');
 const { get } = require('@friggframework/assertions');
 const { FetchError } = require('@friggframework/errors');
@@ -474,15 +476,9 @@ class Api extends OAuth2Requester {
     // oldest: integer, optional
     // inclusive: boolean, optional
     async getChannelHistory(body) {
-        const params = new URLSearchParams();
-        Object.entries(body).forEach(entry => {
-            const [key, value] = entry;
-            params.append(key, value);
-        });
-
         const options = {
             url: this.baseUrl + this.URLs.getChannelHistory,
-            body: params,
+            body: qs.stringify(body),
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded'
             }

--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -474,9 +474,15 @@ class Api extends OAuth2Requester {
     // oldest: integer, optional
     // inclusive: boolean, optional
     async getChannelHistory(body) {
+        const params = new URLSearchParams();
+        Object.entries(body).forEach(entry => {
+            const [key, value] = entry;
+            params.append(key, value);
+        });
+
         const options = {
             url: this.baseUrl + this.URLs.getChannelHistory,
-            body,
+            body: params,
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded'
             }

--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -477,6 +477,9 @@ class Api extends OAuth2Requester {
         const options = {
             url: this.baseUrl + this.URLs.getChannelHistory,
             body,
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            }
         };
         const response = await this._post(options);
         return response;

--- a/api-module-library/slack/package.json
+++ b/api-module-library/slack/package.json
@@ -20,7 +20,8 @@
 	},
 	"dependencies": {
 		"@friggframework/assertions": "^1.0.8",
-		"@friggframework/module-plugin": "^1.0.25"
+		"@friggframework/module-plugin": "^1.0.25",
+		"qs": "^6.11.1"
 	},
 	"gitHead": "1ff6f32fa238512761a9c361f0e07f49b6bf5ed7"
 }

--- a/api-module-library/slack/test/api.test.js
+++ b/api-module-library/slack/test/api.test.js
@@ -38,7 +38,7 @@ describe(`Should fully test the ${config.label} API Class`, () => {
             expect(redirectUri).exists;
 
             const response = await api.authTest();
-            expect(response).toBeTruthy();
+            expect(response.ok).toBeTruthy();
         });
         it.skip('should refresh auth when token expires', async () => {
             api.access_token = 'broken';
@@ -51,7 +51,7 @@ describe(`Should fully test the ${config.label} API Class`, () => {
         it('should return channels', async () => {
             const channels = await api.listChannels();
 
-            expect(channels).toBeTruthy();
+            expect(channels.ok).toBeTruthy();
         });
         describe('Direct Message Channel Tests', () => {
             let messageChannel;
@@ -63,7 +63,7 @@ describe(`Should fully test the ${config.label} API Class`, () => {
                     channel: userDetails.user.id,
                     text: 'Hello World!',
                 });
-                expect(messageResponse).toBeTruthy();
+                expect(messageResponse.ok).toBeTruthy();
                 messageChannel = messageResponse.channel;
             });
             afterEach(async () => {
@@ -74,7 +74,7 @@ describe(`Should fully test the ${config.label} API Class`, () => {
                 });
             });
             it('should create a direct message to a user', async () => {
-                expect(messageResponse).toBeTruthy();
+                expect(messageResponse.ok).toBeTruthy();
             });
             it('should return channel history', async () => {
                 const history = await api.getChannelHistory({
@@ -83,7 +83,7 @@ describe(`Should fully test the ${config.label} API Class`, () => {
                     oldest: messageResponse.ts,
                     inclusive: true,
                 });
-                expect(history).toBeTruthy();
+                expect(history.ok).toBeTruthy();
             });
         });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -494,7 +494,8 @@
       "license": "MIT",
       "dependencies": {
         "@friggframework/assertions": "^1.0.8",
-        "@friggframework/module-plugin": "^1.0.25"
+        "@friggframework/module-plugin": "^1.0.25",
+        "qs": "^6.11.1"
       },
       "devDependencies": {
         "@friggframework/eslint-config": "^1.0.8",
@@ -503,6 +504,20 @@
         "jest": "^28.1.3",
         "prettier": "^2.7.1",
         "sinon": "^14.0.0"
+      }
+    },
+    "api-module-library/slack/node_modules/qs": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+      "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "api-module-library/terminus": {
@@ -17897,7 +17912,6 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -19802,7 +19816,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",

--- a/packages/integrations/manager.js
+++ b/packages/integrations/manager.js
@@ -325,7 +325,7 @@ class IntegrationManager extends Delegate {
          const integration = await Integration.findById(integration_id);
 
          if (!integration) {
-             throw new Error(`Integration with ID ${id} does not exist.`);
+             throw new Error(`Integration with ID ${integration_id} does not exist.`);
          }
 
          if (integration.user.toString() !== userId.toString()) {

--- a/packages/integrations/test/manager.test.js
+++ b/packages/integrations/test/manager.test.js
@@ -98,11 +98,12 @@ describe(`Should fully test the IntegrationManager`, () => {
 
     describe('upsertIntegrationMapping()', () => {
         it('should throw error if integrationId does not match', async () => {
+            const id = new mongoose.Types.ObjectId();
             try {
-                await IntegrationManager.upsertIntegrationMapping(new mongoose.Types.ObjectId(), userId, 'validId', {});
+                await IntegrationManager.upsertIntegrationMapping(id, userId, 'validId', {});
                 fail('should have thrown error')
             } catch(err) {
-                expect(err.message).to.contain('id is not defined');
+                expect(err.message).to.contain(`Integration with ID ${id} does not exist`);
             }
         });
 


### PR DESCRIPTION
Slack API always returns 200 status regardless if error.

Based on https://api.slack.com/methods/conversations.history, it looks like we should be calling with `application/x-www-form-urlencoded` Content-Type header

Looks like I'm not able to verify if slack test are passing. Will try out in ironclad-frigg to verify

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-hubspot@0.8.27-canary.147.2e4d710.0
  npm install @friggframework/api-module-slack@0.1.32-canary.147.2e4d710.0
  npm install @friggframework/integrations@1.0.24-canary.147.2e4d710.0
  # or 
  yarn add @friggframework/api-module-hubspot@0.8.27-canary.147.2e4d710.0
  yarn add @friggframework/api-module-slack@0.1.32-canary.147.2e4d710.0
  yarn add @friggframework/integrations@1.0.24-canary.147.2e4d710.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
