### PR TITLE
fix slack channel history call

### DIFF
--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -483,7 +483,7 @@ class Api extends OAuth2Requester {
                 'Content-Type': 'application/x-www-form-urlencoded'
             }
         };
-        const response = await this._post(options);
+        const response = await this._post(options, false);
         return response;
     }
     async listChannels(query) {


### PR DESCRIPTION
Looks like we might need to not stringify body 