### PR TITLE
Fix slack refresh behavior to allow refresh after first refresh

### DIFF
--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -127,6 +127,9 @@ class Api extends OAuth2Requester {
             });
         }
 
+        // reset refresh count after successful call
+        this.refreshCount = 0;
+
         return parsedResponse;
     }
 

--- a/api-module-library/slack/test/manager.test.js
+++ b/api-module-library/slack/test/manager.test.js
@@ -237,7 +237,6 @@ describe(`Should fully test the ${config.label} Manager`, () => {
             expect(validated).to.be.true;
 
             validated = await newManager.testAuth();
-            // expect(testAuthNock.isDone());
             expect(newManager.api.access_token).to.not.equal(oldToken);
             expect(newManager.api.access_token).to.exist;
             expect(validated).to.be.true;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-slack@0.1.34-canary.150.78ffecb.0
  # or 
  yarn add @friggframework/api-module-slack@0.1.34-canary.150.78ffecb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
