### PR TITLE
add requests for app installation and removal

### DIFF
--- a/api-module-library/microsoft-teams/api/botFramework.js
+++ b/api-module-library/microsoft-teams/api/botFramework.js
@@ -4,7 +4,7 @@ class botFrameworkApi extends OAuth2Requester {
     constructor(params) {
         super(params);
 
-        this.tenant_id = get(params, 'tenant_id');
+        this.tenant_id = get(params, 'tenant_id', null);
         // will have localization issues with this
         this.baseUrl = 'https://smba.trafficmanager.net/amer/v3'
         this.scope = 'https://api.botframework.com/.default'

--- a/api-module-library/microsoft-teams/api/graph.js
+++ b/api-module-library/microsoft-teams/api/graph.js
@@ -28,6 +28,8 @@ class graphApi extends OAuth2Requester {
             };
             this.authorizationUri = `https://login.microsoftonline.com/${this.tenant_id}/oauth2/v2.0/authorize`;
             this.tokenUri = `https://login.microsoftonline.com/${this.tenant_id}/oauth2/v2.0/token`;
+            this.grantConestUrl = `https://login.microsoftonline.com/${this.tenant_id}/adminconsent?\
+            client_id=${this.client_id}&redirect_uri=${this.redirect_uri}`
         }
         this.generateUrls();
     }

--- a/api-module-library/microsoft-teams/api/graph.js
+++ b/api-module-library/microsoft-teams/api/graph.js
@@ -23,6 +23,7 @@ class graphApi extends OAuth2Requester {
                 channel: (channelId) => `/teams/${this.team_id}/channels/${channelId}/`,
                 channelMembers: (channelId) => `/teams/${this.team_id}/channels/${channelId}/members`,
                 installedAppsForUser: (userId) => `/users/${userId}/teamwork/installedApps`,
+                installedAppsForTeam: (teamId) => `/teams/${teamId}/installedApps`,
                 appCatalog: '/appCatalogs/teamsApps',
             };
             this.authorizationUri = `https://login.microsoftonline.com/${this.tenant_id}/oauth2/v2.0/authorize`;
@@ -89,9 +90,10 @@ class graphApi extends OAuth2Requester {
         return response.value[0];
     }
 
-    async getGroups() {
+    async getGroups(query) {
         const options = {
-            url: `${this.baseUrl}${this.URLs.groups}`
+            url: `${this.baseUrl}${this.URLs.groups}`,
+            query
         };
         const response = await this._get(options);
         return response;
@@ -134,8 +136,8 @@ class graphApi extends OAuth2Requester {
             },
             headers: {
                 'Content-Type': 'application/json',
-                Accept: 'application/json',
-            }
+            },
+            returnFullRes: true
         };
         const response = await this._post(options);
         return response;
@@ -144,6 +146,39 @@ class graphApi extends OAuth2Requester {
     async removeAppForUser(userId, teamsAppInstallationId) {
         const options = {
             url: `${this.baseUrl}${this.URLs.installedAppsForUser(userId)}/${teamsAppInstallationId}`,
+        };
+        const response = await this._delete(options);
+        return response;
+    }
+
+    async getInstalledAppsForTeam(teamId, query) {
+        //this is also valid for /me but not implementing yet
+        const options = {
+            url: `${this.baseUrl}${this.URLs.installedAppsForTeam(teamId)}`,
+            query
+        };
+        const response = await this._get(options);
+        return response;
+    }
+
+    async installAppForTeam(teamId, teamsAppId) {
+        const options = {
+            url: `${this.baseUrl}${this.URLs.installedAppsForTeam(teamId)}`,
+            body: {
+                'teamsApp@odata.bind': `https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/${teamsAppId}`
+            },
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            returnFullRes: true
+        };
+        const response = await this._post(options);
+        return response;
+    }
+
+    async removeAppForTeam(teamId, teamsAppInstallationId) {
+        const options = {
+            url: `${this.baseUrl}${this.URLs.installedAppsForTeam(teamId)}/${teamsAppInstallationId}`,
         };
         const response = await this._delete(options);
         return response;

--- a/api-module-library/microsoft-teams/api/graph.js
+++ b/api-module-library/microsoft-teams/api/graph.js
@@ -23,6 +23,7 @@ class graphApi extends OAuth2Requester {
                 channel: (channelId) => `/teams/${this.team_id}/channels/${channelId}/`,
                 channelMembers: (channelId) => `/teams/${this.team_id}/channels/${channelId}/members`,
                 installedAppsForUser: (userId) => `/users/${userId}/teamwork/installedApps`,
+                appCatalog: '/appCatalogs/teamsApps',
             };
             this.authorizationUri = `https://login.microsoftonline.com/${this.tenant_id}/oauth2/v2.0/authorize`;
             this.tokenUri = `https://login.microsoftonline.com/${this.tenant_id}/oauth2/v2.0/token`;
@@ -106,6 +107,15 @@ class graphApi extends OAuth2Requester {
         return response;
     }
 
+    async getAppCatalog(query) {
+        const options = {
+            url: `${this.baseUrl}${this.URLs.appCatalog}`,
+            query
+        };
+        const response = await this._get(options);
+        return response;
+    }
+
     async getInstalledAppsForUser(userId, query) {
         //this is also valid for /me but not implementing yet
         const options = {
@@ -128,6 +138,14 @@ class graphApi extends OAuth2Requester {
             }
         };
         const response = await this._post(options);
+        return response;
+    }
+
+    async removeAppForUser(userId, teamsAppInstallationId) {
+        const options = {
+            url: `${this.baseUrl}${this.URLs.installedAppsForUser(userId)}/${teamsAppInstallationId}`,
+        };
+        const response = await this._delete(options);
         return response;
     }
 

--- a/api-module-library/microsoft-teams/test/graph-app.test.js
+++ b/api-module-library/microsoft-teams/test/graph-app.test.js
@@ -7,8 +7,8 @@ describe(`${config.label} API Tests`, () => {
     const apiParams = {
         client_id: process.env.TEAMS_CLIENT_ID,
         client_secret: process.env.TEAMS_CLIENT_SECRET,
-        team_id: process.env.TEAMS_ID,
-        tenant_id: process.env.TENANT_ID,
+        team_id: process.env.TEAMS_TEAM_ID,
+        tenant_id: process.env.TEAMS_TENANT_ID,
         scope: process.env.TEAMS_CRED_SCOPE,
         forceConsent: false
     };


### PR DESCRIPTION
support regeneration of URLs such that tenant and team ids can be set after instantiation
add url for admin consent
add query params for group and channel selection
all delegated auth tests use Jest expect