### PR TITLE
Handle ironclad localhost

### DIFF
--- a/api-module-library/ironclad/api.js
+++ b/api-module-library/ironclad/api.js
@@ -12,7 +12,7 @@ class Api extends ApiKeyRequester {
         this.baseUrl = () => {
             if (this.SUBDOMAIN) {
                 const subdomain = this.SUBDOMAIN.toLowerCase();
-                return `https://${subdomain}.ironcladapp.com`;
+                return `https://${subdomain}${subdomain !== 'localhost' ? '.ironcladapp.com' : ''}`;
             } else {
                 return 'https://ironcladapp.com';
             }

--- a/api-module-library/ironclad/test/api.test.js
+++ b/api-module-library/ironclad/test/api.test.js
@@ -10,6 +10,24 @@ describe('Ironclad API class', () => {
         subdomain: process.env.IRONCLAD_SUBDOMAIN,
     });
 
+    describe('Base URL', () => {
+        it('should allow localhost subdomain', async () => {
+            const api = new Api({
+                apiKey: process.env.IRONCLAD_API_KEY,
+                subdomain: 'localhost'
+            })
+            expect(api.baseUrl()).to.equal('https://localhost');
+        });
+
+        it('should have ironcladapp.com to baseUrl for non local envs', async () => {
+            const api = new Api({
+                apiKey: process.env.IRONCLAD_API_KEY,
+                subdomain: 'preview'
+            })
+            expect(api.baseUrl()).to.equal('https://preview.ironcladapp.com');
+        });
+    })
+
     describe('Webhooks', () => {
         let webhookID;
         it('should list all webhooks', async () => {


### PR DESCRIPTION
For local ironclad testing, we need to support localhost
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-ironclad@0.0.36-canary.156.6e1ba77.0
  # or 
  yarn add @friggframework/api-module-ironclad@0.0.36-canary.156.6e1ba77.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
