### PR TITLE
return the mapping object directly from getIntegrationMapping

### DIFF
--- a/packages/integrations/integration-mapping.js
+++ b/packages/integrations/integration-mapping.js
@@ -22,7 +22,7 @@ schema.static({
         if (mappings.length === 0) {
             return null;
         } else if (mappings.length === 1) {
-            return mappings[0];
+            return mappings[0].mapping;
         } else {
             throw new Error('multiple integration mappings with same sourceId');
         }

--- a/packages/integrations/test/manager.test.js
+++ b/packages/integrations/test/manager.test.js
@@ -88,11 +88,7 @@ describe(`Should fully test the IntegrationManager`, () => {
         it('should return if valid ids', async () => {
             await IntegrationManager.upsertIntegrationMapping(integration._id, userId, 'validId', {});
             const mapping = await IntegrationManager.getIntegrationMapping(integration.id, 'validId');
-            expect(_.pick(mapping, ['integration', 'sourceId', 'mapping'])).to.eql({
-                integration: integration._id,
-                sourceId: 'validId',
-                mapping: {}
-            })
+            expect(mapping).to.eql({})
         });
     })
 


### PR DESCRIPTION
In looking to use the integration mapping feature within the Teams integration, I wanted to propose changing the mapping retrieval to return the mapping object directly. This is just what made sense to me so feel free to reject!

I put a PR into ironclad--frigg to handle this change in the SlackIntegrationManager, for convenience if accepted