### PR TITLE
google drive - auth fixes

### DIFF
--- a/api-module-library/google-drive/api.js
+++ b/api-module-library/google-drive/api.js
@@ -26,15 +26,12 @@ class Api extends OAuth2Requester {
         /* eslint-enable camelcase */
     }
 
-    async getTokenFromCode(code) {
-        return this.getTokenFromCodeBasicAuthHeader(code);
-    }
     setState(state) {
         this.state = state;
     }
     getAuthorizationUri() {
         return encodeURI(
-            `https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=${this.client_id}&redirect_uri=${this.redirect_uri}&scope=${this.scope}&access_type=offline&include_granted_scopes=true&state=${this.state}`
+            `https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=${this.client_id}&redirect_uri=${this.redirect_uri}&scope=${this.scope}&access_type=offline&include_granted_scopes=true&state=${this.state}&prompt=consent`
         );
     }
 

--- a/api-module-library/google-drive/api.js
+++ b/api-module-library/google-drive/api.js
@@ -106,6 +106,28 @@ class Api extends OAuth2Requester {
         };
         return this._get(options);
     }
+
+    async getFileUploadSession(headers) {
+        const options = {
+            url: this.baseUrl + this.URLs.fileUpload,
+            query: {
+                uploadType: 'resumable'
+            },
+            headers,
+            returnFullRes: true,
+        }
+        return this._post(options);
+    }
+
+    async uploadFileToSession(sessionURI, headers, body) {
+        const options = {
+            url: sessionURI,
+            headers,
+            body,
+            returnFullRes: true,
+        }
+        return this._put(options)
+    }
 }
 
 module.exports = { Api };

--- a/api-module-library/google-drive/api.js
+++ b/api-module-library/google-drive/api.js
@@ -107,7 +107,7 @@ class Api extends OAuth2Requester {
         return this._get(options);
     }
 
-    async getFileUploadSession(headers) {
+    async getFileUploadSession(headers, metadataBody) {
         const options = {
             url: this.baseUrl + this.URLs.fileUpload,
             query: {
@@ -116,6 +116,13 @@ class Api extends OAuth2Requester {
             headers,
             returnFullRes: true,
         }
+        if (metadataBody) {
+            options.body = metadataBody;
+            options.headers['Content-Type'] =
+                'application/json; charset=UTF-8';
+            // TODO: might require adding Content-Length
+        }
+        // if file exists already, this needs to be a _put
         return this._post(options);
     }
 
@@ -126,6 +133,21 @@ class Api extends OAuth2Requester {
             body,
             returnFullRes: true,
         }
+        return this._put(options)
+    }
+
+    async getUploadSessionStatus(sessionURI) {
+        const options = {
+            url: sessionURI,
+            headers : {
+                'Content-Range': '*/*'
+            },
+            returnFullRes: true,
+        }
+        // status of 200 or 201 indicates upload complete
+        // status of 404 indicates upload session expired
+        // status of 308 indicates incomplete but resumable upload
+        // - where the Range header will indicate completed bytes
         return this._put(options)
     }
 }

--- a/api-module-library/google-drive/manager.js
+++ b/api-module-library/google-drive/manager.js
@@ -164,14 +164,14 @@ class Manager extends ModuleManager {
                             );
                         } else {
                             debug(
-                                'Somebody else already created a credential with the same permission ID:',
+                                'Somebody else already created a credential with the same externalId (email address):',
                                 userDetails.emailAddress
                             );
                         }
                     } else {
                         // Handling multiple credentials found with an error for the time being
                         debug(
-                            'Multiple credentials found with the same permission ID:',
+                            'Multiple credentials found with the same externalId (email address):',
                             userDetails.emailAddress
                         );
                     }

--- a/api-module-library/google-drive/manager.js
+++ b/api-module-library/google-drive/manager.js
@@ -140,6 +140,7 @@ class Manager extends ModuleManager {
                 const updatedToken = {
                     user: this.userId.toString(),
                     access_token: this.api.access_token,
+                    refresh_token: this.api.refresh_token,
                     expires_in: this.api.expires_in,
                     auth_is_valid: true,
                 };
@@ -175,9 +176,10 @@ class Manager extends ModuleManager {
                         );
                     }
                 } else {
-                    this.credential = await Credential.update(
-                        this.credential,
-                        updatedToken
+                    this.credential = await Credential.findOneAndUpdate(
+                        { _id: this.credential },
+                        { $set: updatedToken },
+                        { useFindAndModify: true, new: true }
                     );
                 }
             }

--- a/api-module-library/google-drive/models/credential.js
+++ b/api-module-library/google-drive/models/credential.js
@@ -7,6 +7,12 @@ const schema = new mongoose.Schema({
         trim: true,
         lhEncrypt: true,
     },
+    refresh_token: {
+        type: String,
+        trim: true,
+        lhEncrypt: true,
+    },
+
     expires_at: { type: Number },
 });
 

--- a/api-module-library/google-drive/models/credential.js
+++ b/api-module-library/google-drive/models/credential.js
@@ -12,7 +12,6 @@ const schema = new mongoose.Schema({
         trim: true,
         lhEncrypt: true,
     },
-
     expires_at: { type: Number },
 });
 

--- a/api-module-library/google-drive/tests/api.test.js
+++ b/api-module-library/google-drive/tests/api.test.js
@@ -25,6 +25,15 @@ describe('Google Drive API tests', () => {
         await api.getTokenFromCode(response.data.code);
     });
 
+    describe('Confirm Authentication Requests', () => {
+        it('Check Access Token', () => {
+            expect(api.access_token).toBeDefined();
+        });
+        it('Check Refresh Token', () => {
+            expect(api.refresh_token).toBeDefined();
+        });
+    });
+
     describe('Drive User Info', () => {
         it('should return the user details', async () => {
             const user = await api.getUserDetails();

--- a/api-module-library/google-drive/tests/api.test.js
+++ b/api-module-library/google-drive/tests/api.test.js
@@ -111,4 +111,13 @@ describe('Google Drive API tests', () => {
             expect(response.labels).toBeDefined();
         });
     });
+
+    describe('Drive File Upload', () => {
+        it('should retrieve a upload session id', async () => {
+            const response = await api.getFileUploadSession();
+            expect(response).toBeDefined();
+            expect(response.status).toBeDefined();
+            expect(response.headers.get('location')).toBeDefined();
+        });
+    });
 });


### PR DESCRIPTION
Force prompting for consent to allow for offline access in previously authenticated users
Fix db model and retrieval of credential to store refresh_token
Add test coverage for refresh_tokens and more thoroughly for entity and credential retrieval
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-google-drive@0.0.8-canary.170.70b7446.0
  # or 
  yarn add @friggframework/api-module-google-drive@0.0.8-canary.170.70b7446.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
