### PR TITLE
Feature/lef 260 list root container contents

### DIFF
--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -52,7 +52,14 @@ class Api extends OAuth2Requester {
     }
 
     async getUser() {
-        const query = 'query CurrentUser { currentUser { id email name }}';
+        const query = `query CurrentUser {
+                         currentUser {
+                           id
+                           email
+                           name
+                         }
+                       }`;
+
         const response = await this._post(this.buildRequestOptions(query));
         return {
             user: response.data.currentUser,
@@ -60,13 +67,30 @@ class Api extends OAuth2Requester {
     }
 
     async listBrands() {
-        const ql = 'query Brands { brands { id avatar name }}';
+        const ql = `query Brands {
+                      brands {
+                        id
+                        avatar
+                        name
+                      }
+                    }`;
+
         const response = await this._post(this.buildRequestOptions(ql));
         return response.data;
     }
 
     async listProjects(query) {
-        const ql = `query Projects { brand(id: "${query.brandId}") { workspaceProjects { items { id name }}}}`;
+        const ql = `query Projects {
+                      brand(id: "${query.brandId}") {
+                        workspaceProjects {
+                          items {
+                            id
+                            name
+                          }
+                        }
+                      }
+                    }`;
+
         const response = await this._post(this.buildRequestOptions(ql));
         return {
             projects: response.data.brand.workspaceProjects.items,
@@ -74,13 +98,34 @@ class Api extends OAuth2Requester {
     }
 
     async listLibraries(query) {
-        const ql = `query Libraries { brand(id: "${query.brandId}") { libraries { items { id name }}}}`;
+        const ql = `query Libraries {
+                      brand(id: "${query.brandId}") {
+                        libraries {
+                          items {
+                            id
+                            name
+                          }
+                        }
+                      }
+                    }`;
+
         const response = await this._post(this.buildRequestOptions(ql));
         return response.data.brand.libraries.items;
     }
 
     async listProjectAssets(query) {
-        const ql = `query ProjectAssets { workspaceProject(id: "${query.projectId}") { assets { items { id title description }}}}`;
+        const ql = `query ProjectAssets {
+                      workspaceProject(id: "${query.projectId}") {
+                        assets {
+                          items {
+                            id
+                            title
+                            description
+                          }
+                        }
+                      }
+                    }`;
+
         const response = await this._post(this.buildRequestOptions(ql));
         return {
             assets: response.data.workspaceProject.assets.items,
@@ -88,7 +133,18 @@ class Api extends OAuth2Requester {
     }
 
     async listLibraryAssets(query) {
-        const ql = `query LibraryAssets { library(id: "${query.libraryId}") { assets { items { id title description }}}}`;
+        const ql = `query LibraryAssets {
+                      library(id: "${query.libraryId}") {
+                        assets {
+                          items {
+                            id
+                            title
+                            description
+                          }
+                        }
+                      }
+                    }`;
+
         const response = await this._post(this.buildRequestOptions(ql));
         return {
             assets: response.data.library.assets.items,

--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -121,6 +121,7 @@ class Api extends OAuth2Requester {
                             id
                             title
                             description
+                            __typename
                           }
                         }
                       }
@@ -140,6 +141,7 @@ class Api extends OAuth2Requester {
                             id
                             title
                             description
+                            __typename
                           }
                         }
                       }

--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -133,6 +133,27 @@ class Api extends OAuth2Requester {
         };
     }
 
+    async listProjectFolders(query) {
+        const ql = `query ProjectFolders {
+                      workspaceProject(id: "${query.projectId}") {
+                        browse {
+                          folders {
+                            items {
+                              id
+                              name
+                              __typename
+                            }
+                          }
+                        }
+                      }
+                    }`;
+
+        const response = await this._post(this.buildRequestOptions(ql));
+        return {
+            folders: response.data.workspaceProject.browse.folders.items
+        };
+    }
+
     async listLibraryAssets(query) {
         const ql = `query LibraryAssets {
                       library(id: "${query.libraryId}") {
@@ -150,6 +171,27 @@ class Api extends OAuth2Requester {
         const response = await this._post(this.buildRequestOptions(ql));
         return {
             assets: response.data.library.assets.items,
+        };
+    }
+
+    async listLibraryFolders(query) {
+        const ql = `query LibraryFolders {
+                      library(id: "${query.libraryId}") {
+                        browse {
+                          folders {
+                            items {
+                              id
+                              name
+                              __typename
+                            }
+                          }
+                        }
+                      }
+                    }`;
+
+        const response = await this._post(this.buildRequestOptions(ql));
+        return {
+            folders: response.data.library.browse.folders.items
         };
     }
 }

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -300,6 +300,7 @@ describe(`${Config.label} API Tests`, () => {
                                         id
                                         title
                                         description
+                                        __typename
                                       }
                                     }
                                   }
@@ -338,6 +339,7 @@ describe(`${Config.label} API Tests`, () => {
                                         id
                                         title
                                         description
+                                        __typename
                                       }
                                     }
                                   }

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -157,10 +157,16 @@ describe(`${Config.label} API Tests`, () => {
                 let scope;
 
                 beforeEach(() => {
+                    const ql = `query CurrentUser {
+                                   currentUser {
+                                     id
+                                     email
+                                     name
+                                   }
+                                 }`;
+
                     scope = nock(baseUrl)
-                        .post('', {
-                            query: 'query CurrentUser { currentUser { id email name }}',
-                        })
+                        .post('', (body ) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 currentUser: 'currentUser'
@@ -181,10 +187,16 @@ describe(`${Config.label} API Tests`, () => {
                 let scope;
 
                 beforeEach(() => {
+                    const ql = `query Brands {
+                                  brands {
+                                    id
+                                    avatar
+                                    name
+                                  }
+                                }`;
+
                     scope = nock(baseUrl)
-                        .post('', {
-                            query: 'query Brands { brands { id avatar name }}',
-                        })
+                        .post('', (body ) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 brands: 'brands'
@@ -205,10 +217,19 @@ describe(`${Config.label} API Tests`, () => {
                 let scope;
 
                 beforeEach(() => {
+                    const ql = `query Projects {
+                                  brand(id: "brandId") {
+                                    workspaceProjects {
+                                      items {
+                                        id
+                                        name
+                                      }
+                                    }
+                                  }
+                                }`;
+
                     scope = nock(baseUrl)
-                        .post('', {
-                            query: 'query Projects { brand(id: "brandId") { workspaceProjects { items { id name }}}}',
-                        })
+                        .post('', (body ) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 brand: {
@@ -233,10 +254,19 @@ describe(`${Config.label} API Tests`, () => {
                 let scope;
 
                 beforeEach(() => {
+                    const ql = `query Libraries {
+                                  brand(id: "brandId") {
+                                    libraries {
+                                      items {
+                                        id
+                                        name
+                                      }
+                                    }
+                                  }
+                                }`;
+
                     scope = nock(baseUrl)
-                        .post('', {
-                            query: 'query Libraries { brand(id: "brandId") { libraries { items { id name }}}}',
-                        })
+                        .post('', (body ) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 brand: {
@@ -263,10 +293,20 @@ describe(`${Config.label} API Tests`, () => {
                 let scope;
 
                 beforeEach(() => {
+                    const ql = `query ProjectAssets {
+                                  workspaceProject(id: "projectId") {
+                                    assets {
+                                      items {
+                                        id
+                                        title
+                                        description
+                                      }
+                                    }
+                                  }
+                                }`;
+
                     scope = nock(baseUrl)
-                        .post('', {
-                            query: 'query ProjectAssets { workspaceProject(id: "projectId") { assets { items { id title description }}}}',
-                        })
+                        .post('', (body ) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 workspaceProject: {
@@ -291,10 +331,20 @@ describe(`${Config.label} API Tests`, () => {
                 let scope;
 
                 beforeEach(() => {
+                    const ql = `query LibraryAssets {
+                                  library(id: "libraryId") {
+                                    assets {
+                                      items {
+                                        id
+                                        title
+                                        description
+                                      }
+                                    }
+                                  }
+                                }`;
+
                     scope = nock(baseUrl)
-                        .post('', {
-                            query: 'query LibraryAssets { library(id: "libraryId") { assets { items { id title description }}}}',
-                        })
+                        .post('', (body ) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 library: {

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -327,6 +327,48 @@ describe(`${Config.label} API Tests`, () => {
             });
         });
 
+        describe('#listProjectFolders', () => {
+            describe('Retrieve information about project folders', () => {
+                let scope;
+
+                beforeEach(() => {
+                    const ql = `query ProjectFolders {
+                                  workspaceProject(id: "projectId") {
+                                    browse {
+                                      folders {
+                                        items {
+                                          id
+                                          name
+                                          __typename
+                                        }
+                                      }
+                                    }
+                                  }
+                                }`;
+
+                    scope = nock(baseUrl)
+                        .post('', (body ) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                workspaceProject: {
+                                    browse: {
+                                        folders: {
+                                            items: 'items'
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                });
+
+                it('should hit the correct endpoint', async () => {
+                    const projectFolders = await api.listProjectFolders({ projectId: 'projectId' });
+                    expect(projectFolders).toEqual({ folders: 'items' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+        });
+
         describe('#listLibraryAssets', () => {
             describe('Retrieve information about library assets', () => {
                 let scope;
@@ -361,6 +403,48 @@ describe(`${Config.label} API Tests`, () => {
                 it('should hit the correct endpoint', async () => {
                     const libraryAssets = await api.listLibraryAssets({ libraryId: 'libraryId' });
                     expect(libraryAssets).toEqual({ assets: 'items' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+        });
+
+        describe('#listLibraryFolders', () => {
+            describe('Retrieve information about library folders', () => {
+                let scope;
+
+                beforeEach(() => {
+                    const ql = `query LibraryFolders {
+                                  library(id: "libraryId") {
+                                    browse {
+                                      folders {
+                                        items {
+                                          id
+                                          name
+                                          __typename
+                                        }
+                                      }
+                                    }
+                                  }
+                                }`;
+
+                    scope = nock(baseUrl)
+                        .post('', (body ) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                library: {
+                                    browse: {
+                                        folders: {
+                                            items: 'items'
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                });
+
+                it('should hit the correct endpoint', async () => {
+                    const libraryFolders = await api.listLibraryFolders({ libraryId: 'libraryId' });
+                    expect(libraryFolders).toEqual({ folders: 'items' });
                     expect(scope.isDone()).toBe(true);
                 });
             });

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -289,7 +289,7 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#listProjectAssets', () => {
-            describe('Retrieve information about project assets', () => {
+            describe('Retrieve information about a project\'s assets', () => {
                 let scope;
 
                 beforeEach(() => {
@@ -328,7 +328,7 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#listProjectFolders', () => {
-            describe('Retrieve information about project folders', () => {
+            describe('Retrieve information about a project\'s folders', () => {
                 let scope;
 
                 beforeEach(() => {
@@ -370,7 +370,7 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#listLibraryAssets', () => {
-            describe('Retrieve information about library assets', () => {
+            describe('Retrieve information about a library\'s assets', () => {
                 let scope;
 
                 beforeEach(() => {
@@ -409,7 +409,7 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#listLibraryFolders', () => {
-            describe('Retrieve information about library folders', () => {
+            describe('Retrieve information about a library\'s folders', () => {
                 let scope;
 
                 beforeEach(() => {

--- a/api-module-library/frontify/manager.js
+++ b/api-module-library/frontify/manager.js
@@ -76,7 +76,7 @@ class Manager extends ModuleManager {
                 uiSchema: {
                     domain: {
                         'ui:help':
-                            'An Frontify domain, e.g: lefthook.frontify.com',
+                            'A Frontify domain, e.g: lefthook.frontify.com',
                         'ui:placeholder': 'Your Frontify domain...',
                     },
                 }

--- a/api-module-library/frontify/manager.test.js
+++ b/api-module-library/frontify/manager.test.js
@@ -99,10 +99,16 @@ describe(`Should fully test the ${Config.label} Manager`, () => {
 
                 manager.api.setDomain('mine-domain');
 
+                const qlUser = `query CurrentUser {
+                                  currentUser {
+                                    id
+                                    email
+                                    name
+                                  }
+                                }`;
+
                 scope = nock(baseUrl)
-                    .post('', {
-                        query: 'query CurrentUser { currentUser { id email name }}',
-                    })
+                    .post('', (body ) => body.query.replace(/\s/g, '') === qlUser.replace(/\s/g, ''))
                     .reply(200, {
                         data: {
                             currentUser: 'currentUser'
@@ -218,10 +224,16 @@ describe(`Should fully test the ${Config.label} Manager`, () => {
                         expires_in: 'expires_in'
                     });
 
+                const qlUser = `query CurrentUser {
+                                  currentUser {
+                                    id
+                                    email
+                                    name
+                                  }
+                                }`;
+
                 userScope = nock(baseUrl)
-                    .post('', {
-                        query: 'query CurrentUser { currentUser { id email name }}',
-                    })
+                    .post('', (body ) => body.query.replace(/\s/g, '') === qlUser.replace(/\s/g, ''))
                     .reply(200, {
                         data: {
                             currentUser: {
@@ -282,10 +294,16 @@ describe(`Should fully test the ${Config.label} Manager`, () => {
                         expires_in: 'expires_in'
                     });
 
+                const qlUser = `query CurrentUser {
+                                  currentUser {
+                                    id
+                                    email
+                                    name
+                                  }
+                                }`;
+
                 userScope = nock(baseUrl)
-                    .post('', {
-                        query: 'query CurrentUser { currentUser { id email name }}',
-                    })
+                    .post('', (body ) => body.query.replace(/\s/g, '') === qlUser.replace(/\s/g, ''))
                     .reply(200, {
                         data: {
                             currentUser: {


### PR DESCRIPTION
Necessary changes in Frontify's API module in order for the following to work:

- [List Root Container Contents](https://linear.app/lefthook/issue/LEF-260/list-root-container-contents)
- [List Container Contents](https://linear.app/lefthook/issue/LEF-261/list-container-contents)

Basically:

- Enhance the GraphQL queries legibility
- Implement `listLibraryFolders` for fetching subfolders from a Library
- Implement `listProjectFolders` for fetching subfolders from a Project

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@0.0.3-canary.176.e134a04.0
  # or 
  yarn add @friggframework/api-module-frontify@0.0.3-canary.176.e134a04.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
