### PR TITLE
Fix save entity if user removes GD permissions and attempt to connect again

### DIFF
--- a/api-module-library/google-drive/manager.js
+++ b/api-module-library/google-drive/manager.js
@@ -110,7 +110,13 @@ class Manager extends ModuleManager {
             };
             this.entity = await Entity.create(createObj);
         } else if (search.length === 1) {
-            this.entity = search[0];
+            this.entity = await Entity.findOneAndUpdate(
+                { _id: search[0] },
+                { $set: {
+                        credential: this.credential.id
+                    }},
+                { useFindAndModify: true, new: true }
+            );
         } else {
             debug(
                 'Multiple entities found with the same external ID:',


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-google-drive@0.0.10-canary.186.31231e4.0
  # or 
  yarn add @friggframework/api-module-google-drive@0.0.10-canary.186.31231e4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
