### PR TITLE
Feature/lef 388 upload assets function

### DIFF
--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -376,21 +376,25 @@ class Api extends OAuth2Requester {
     // stream. The code invoking this method should take care of this
     // using a correct "highWaterMark".
     async uploadFile(stream, urls) {
+        const responses = [];
+
         for await (const chunk of stream) {
             // AWS url
             const url = urls.shift();
 
             // Using fetch to avoid sending Frontify auth headers to AWS
-            await fetch(url, {
+            const resp = await fetch(url, {
                 method: 'PUT',
                 headers: {
                     'content-type': 'binary'
                 },
                 body: chunk
             });
+
+            responses.push(resp);
         }
 
-        return Promise.resolve();
+        return responses;
     }
 }
 

--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -372,7 +372,7 @@ class Api extends OAuth2Requester {
         return response.data.uploadFile;
     }
 
-    async uploadFile(stream, urls, chunkSize) {
+    async uploadFile(stream, urls) {
         for await (const chunk of stream) {
             // AWS url
             const url = urls.shift();

--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -372,20 +372,18 @@ class Api extends OAuth2Requester {
         return response.data.uploadFile;
     }
 
-    async uploadFile(stream, urls, chunkSize) {
-        for await (const data of stream) {
-            // AWS url
-            const url = urls.shift();
+    async uploadFile(buff, urls, chunkSize) {
+        // AWS url
+        const url = urls.shift();
 
-            // Using fetch to avoid sending Frontify auth headers to AWS
-            await fetch(url, {
-                method: 'PUT',
-                headers: {
-                    'content-type': 'binary'
-                },
-                body: data
-            });
-        }
+        // Using fetch to avoid sending Frontify auth headers to AWS
+        await fetch(url, {
+            method: 'PUT',
+            headers: {
+                'content-type': 'binary'
+            },
+            body: buff
+        });
 
         return Promise.resolve();
     }

--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -372,18 +372,20 @@ class Api extends OAuth2Requester {
         return response.data.uploadFile;
     }
 
-    async uploadFile(buff, urls, chunkSize) {
-        // AWS url
-        const url = urls.shift();
+    async uploadFile(stream, urls, chunkSize) {
+        for await (const chunk of stream) {
+            // AWS url
+            const url = urls.shift();
 
-        // Using fetch to avoid sending Frontify auth headers to AWS
-        await fetch(url, {
-            method: 'PUT',
-            headers: {
-                'content-type': 'binary'
-            },
-            body: buff
-        });
+            // Using fetch to avoid sending Frontify auth headers to AWS
+            await fetch(url, {
+                method: 'PUT',
+                headers: {
+                    'content-type': 'binary'
+                },
+                body: chunk
+            });
+        }
 
         return Promise.resolve();
     }

--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -372,6 +372,9 @@ class Api extends OAuth2Requester {
         return response.data.uploadFile;
     }
 
+    // Total of addresses in urls should match the number of chunks in
+    // stream. The code invoking this method should take care of this
+    // using a correct "highWaterMark".
     async uploadFile(stream, urls) {
         for await (const chunk of stream) {
             // AWS url

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -1056,23 +1056,12 @@ describe(`${Config.label} API Tests`, () => {
         });
 
       describe('#uploadFile', () => {
-          const ql = `mutation UploadFile {
-                        uploadFile(input: {
-                          filename: "filename",
-                          size: size,
-                          chunkSize: chunkSize
-                        }) {
-                          id
-                          urls
-                        }
-                      }`;
-
             describe('Create a file ID', () => {
                 let scopeOne, scopeTwo;
 
                 beforeEach(() => {
                     scopeOne = nock('http://foo')
-                        .post('/bar', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .put('/bar', 'foo')
                         .reply(200, {
                             data: {
                                 uploadFile: {
@@ -1082,7 +1071,7 @@ describe(`${Config.label} API Tests`, () => {
                         });
 
                     scopeTwo = nock('http://bar')
-                        .post('/foo', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .put('/foo', 'bar')
                         .reply(200, {
                             data: {
                                 uploadFile: {
@@ -1099,7 +1088,7 @@ describe(`${Config.label} API Tests`, () => {
                         chunkSize: 'chunkSize'
                     };
 
-                    await api.uploadFile(input);
+                    await api.uploadFile(input.stream, input.urls);
                     expect(scopeOne.isDone()).toBe(true);
                     expect(scopeTwo.isDone()).toBe(true);
                 });

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -1060,7 +1060,7 @@ describe(`${Config.label} API Tests`, () => {
                 let scopeOne, scopeTwo;
 
                 beforeEach(() => {
-                    scopeOne = nock('http://foo')
+                    scopeOne = nock('https://foo')
                         .put('/bar', 'foo')
                         .reply(200, {
                             data: {
@@ -1070,7 +1070,7 @@ describe(`${Config.label} API Tests`, () => {
                             }
                         });
 
-                    scopeTwo = nock('http://bar')
+                    scopeTwo = nock('https://bar')
                         .put('/foo', 'bar')
                         .reply(200, {
                             data: {
@@ -1084,7 +1084,7 @@ describe(`${Config.label} API Tests`, () => {
                 it('should fetch files from correct endpoints', async () => {
                     const input = {
                         stream: ['foo', 'bar'],
-                        urls: ['http://foo/bar', 'http://bar/foo'],
+                        urls: ['https://foo/bar', 'https://bar/foo'],
                         chunkSize: 'chunkSize'
                     };
 

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -969,5 +969,141 @@ describe(`${Config.label} API Tests`, () => {
                 });
             });
         });
+
+        describe('#createAsset', () => {
+            const ql = `mutation CreateAsset {
+                          createAsset(input: {
+                            fileId: "fileId",
+                            title: "title",
+                            projectId: "projectId"
+                          }) {
+                            job {
+                              assetId
+                            }
+                          }
+                        }`;
+
+            describe('Create a new asset', () => {
+                let scope;
+
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                createAsset: {
+                                    job: {
+                                        assetId: 'assetId'
+                                    }
+                                }
+                            }
+                        });
+                });
+
+                it('should hit the correct endpoint', async () => {
+                    const asset = {
+                        id: 'fileId',
+                        title: 'title',
+                        projectId: 'projectId'
+                    };
+
+                    const results = await api.createAsset(asset);
+                    expect(results).toEqual({ id: 'assetId' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+        });
+
+      describe('#createFileId', () => {
+          const ql = `mutation UploadFile {
+                        uploadFile(input: {
+                          filename: "filename",
+                          size: size,
+                          chunkSize: chunkSize
+                        }) {
+                          id
+                          urls
+                        }
+                      }`;
+
+            describe('Create a file ID', () => {
+                let scope;
+
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                uploadFile: {
+                                  uploadFile: 'uploadFile'
+                                }
+                            }
+                        });
+                });
+
+                it('should hit the correct endpoint', async () => {
+                    const input = {
+                        filename: 'filename',
+                        size: 'size',
+                        chunkSize: 'chunkSize'
+                    };
+
+                    const results = await api.createFileId(input);
+                    expect(results).toEqual({ uploadFile: 'uploadFile' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+        });
+
+      describe('#uploadFile', () => {
+          const ql = `mutation UploadFile {
+                        uploadFile(input: {
+                          filename: "filename",
+                          size: size,
+                          chunkSize: chunkSize
+                        }) {
+                          id
+                          urls
+                        }
+                      }`;
+
+            describe('Create a file ID', () => {
+                let scopeOne, scopeTwo;
+
+                beforeEach(() => {
+                    scopeOne = nock('http://foo')
+                        .post('/bar', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                uploadFile: {
+                                  uploadFile: 'uploadFile'
+                                }
+                            }
+                        });
+
+                    scopeTwo = nock('http://bar')
+                        .post('/foo', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                uploadFile: {
+                                  uploadFile: 'uploadFile'
+                                }
+                            }
+                        });
+                });
+
+                it('should fetch files from correct endpoints', async () => {
+                    const input = {
+                        stream: ['foo', 'bar'],
+                        urls: ['http://foo/bar', 'http://bar/foo'],
+                        chunkSize: 'chunkSize'
+                    };
+
+                    await api.uploadFile(input);
+                    expect(scopeOne.isDone()).toBe(true);
+                    expect(scopeTwo.isDone()).toBe(true);
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
Implement the following methods to upload a file coming from Canva to Frontify:

* createFileId
* uploadFile
* createAsset
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@0.0.7-canary.187.ce0b6a0.0
  # or 
  yarn add @friggframework/api-module-frontify@0.0.7-canary.187.ce0b6a0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
