### PR TITLE
Add listSubFolderAssets and getResponseUsingQuery,

### DIFF
--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -260,6 +260,10 @@ class Api extends OAuth2Requester {
                             __typename
                             ... on Image {
                               previewUrl
+                              downloadUrl
+                              filename
+                              width
+                              height
                             }
                           }
                         }
@@ -341,6 +345,51 @@ class Api extends OAuth2Requester {
         };
     }
 
+    async listSubFolderAssets(query) {
+        const ql = `query FolderById {
+                                  node(id: "${query.subFolderId}") {
+                                    ... on Folder {
+                                      name
+                                      assets {
+                                        items {
+                                          id
+                                          title
+                                          __typename
+                                          ... on Image {
+                                            id
+                                            previewUrl
+                                            width
+                                            height
+                                            extension
+                                            filename
+                                            downloadUrl
+                                          }
+                                        }
+                                      }
+                                      folders {
+                                        items {
+                                          id
+                                          name
+                                          __typename
+                                        }
+                                      }
+                                    }
+                                  }
+                                }`;
+        const response = await this._post(this.buildRequestOptions(ql));
+        this.assertResponse(response);
+        return {
+            assets: response.data.node.assets.items,
+            folders: response.data.node.folders.items
+        };
+    }
+
+    async getResponseUsingQuery(ql) {
+        const response = await this._post(this.buildRequestOptions(ql));
+        this.assertResponse(response);
+        return response;
+    }
+
     async searchInBrand(query) {
         const ql = `query BrandLevelSearch {
                       brand(id: "${query.brandId}") {
@@ -378,8 +427,8 @@ class Api extends OAuth2Requester {
                                 previewUrl,
                                 extension
                                 downloadUrl(validityInDays: null, permanent: true)
-                                author,
-
+                                author
+                                filename
                               }
 
                             }

--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -366,6 +366,21 @@ class Api extends OAuth2Requester {
                                           }
                                         }
                                       }
+                                    }
+                                  }
+                                }`;
+        const response = await this._post(this.buildRequestOptions(ql));
+        this.assertResponse(response);
+        return {
+            assets: response.data.node.assets.items,
+        };
+    }
+
+    async listSubFolderFolders(query) {
+        const ql = `query FolderById {
+                                  node(id: "${query.subFolderId}") {
+                                    ... on Folder {
+                                      name
                                       folders {
                                         items {
                                           id
@@ -379,8 +394,7 @@ class Api extends OAuth2Requester {
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);
         return {
-            assets: response.data.node.assets.items,
-            folders: response.data.node.folders.items
+            folders: response.data.node.folders.items,
         };
     }
 

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -529,7 +529,7 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#getSearchFilterOptions', () => {
-            describe('Retrieve searh and filter available options', () => {
+            describe('Retrieve search and filter available options', () => {
                 it('should return options', async () => {
                     const options = await api.getSearchFilterOptions();
                     expect(options).toEqual({
@@ -764,6 +764,13 @@ describe(`${Config.label} API Tests`, () => {
                                  title
                                  description
                                  __typename
+                                 ... on Image {
+                                   previewUrl
+                                   downloadUrl
+                                   filename
+                                   width
+                                   height
+                                 }
                                }
                              }
                            }
@@ -913,6 +920,9 @@ describe(`${Config.label} API Tests`, () => {
                                  title
                                  description
                                  __typename
+                                 ... on Image {
+                                      previewUrl
+                                    }
                                }
                              }
                            }
@@ -1090,8 +1100,8 @@ describe(`${Config.label} API Tests`, () => {
                                     previewUrl,
                                     extension
                                     downloadUrl(validityInDays: null, permanent: true)
-                                    author,
-
+                                    author
+                                    filename
                                   }
 
                                 }
@@ -1218,8 +1228,8 @@ describe(`${Config.label} API Tests`, () => {
             });
         });
 
-      describe('#createFileId', () => {
-          const ql = `mutation UploadFile {
+        describe('#createFileId', () => {
+            const ql = `mutation UploadFile {
                         uploadFile(input: {
                           filename: "filename",
                           size: size,
@@ -1259,7 +1269,7 @@ describe(`${Config.label} API Tests`, () => {
             });
         });
 
-      describe('#uploadFile', () => {
+        describe('#uploadFile', () => {
             describe('Create a file ID', () => {
                 let scopeOne, scopeTwo;
 
@@ -1296,6 +1306,129 @@ describe(`${Config.label} API Tests`, () => {
                     expect(scopeOne.isDone()).toBe(true);
                     expect(scopeTwo.isDone()).toBe(true);
                 });
+            });
+        });
+
+        describe('#getSubFolderContent', () => {
+            const ql = `query FolderById {
+                                  node(id: "subFolderId") {
+                                    ... on Folder {
+                                      name
+                                      assets {
+                                        items {
+                                          id
+                                          title
+                                          __typename
+                                          ... on Image {
+                                            id
+                                            previewUrl
+                                            width
+                                            height
+                                            extension
+                                            filename
+                                            downloadUrl
+                                          }
+                                        }
+                                      }
+                                      folders {
+                                        items {
+                                          id
+                                          name
+                                          __typename
+                                        }
+                                      }
+                                    }
+                                  }
+                                }`;
+            describe('Get a subfolder content', () => {
+                let scope;
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .reply(200, {
+                            "data": {
+                                "node": {
+                                    "name": "Libfolder",
+                                    "assets": {
+                                        "items": [
+                                            {
+                                                "id": "eyJpZGVudGlmaWVyIjoxOSwidHlwZSI6ImFzc2V0In0=",
+                                                "title": "FriggbyLeftHookLogoJuly2022",
+                                                "__typename": "Image",
+                                                "previewUrl": "https://cdn-assets-us.frontify.com/s3/frontify-enterprise-files-us/eyJvYXV0aCI6eyJjbGllbnRfaWQiOiJmcm9udGlmeS1leHBsb3JlciJ9LCJwYXRoIjoibGVmdC1ob29rXC9maWxlXC9yNXpkZDQ5djJFaFg4QjZMbW1Rdi5zdmcifQ:left-hook:2ecHvM3WRlNvkinOWJXvxhYK0QBHNwaSiyioQ3ORC_s",
+                                                "width": 400,
+                                                "height": 202
+                                            },
+                                            {
+                                                "id": "eyJpZGVudGlmaWVyIjoxOCwidHlwZSI6ImFzc2V0In0=",
+                                                "title": "custom_avatar-1661205632",
+                                                "__typename": "Image",
+                                                "previewUrl": "https://cdn-assets-us.frontify.com/s3/frontify-enterprise-files-us/eyJvYXV0aCI6eyJjbGllbnRfaWQiOiJmcm9udGlmeS1leHBsb3JlciJ9LCJwYXRoIjoibGVmdC1ob29rXC9maWxlXC95ZFR1TDlwVnJUUks2d0tvUlROYS5wbmcifQ:left-hook:PMD4S_9gflsrMNEBDNHxwxQqHlgHaCjrZFiGML8AHU0",
+                                                "width": 128,
+                                                "height": 128
+                                            }
+                                        ]
+                                    },
+                                    "folders": {
+                                        "items": []
+                                    }
+                                }
+                            },
+                            "extensions": {
+                                "complexityScore": 0
+                            }
+                        });
+                });
+
+                it('should return the correct response', async () => {
+                    const query = {
+                        subFolderId: 'subFolderId',
+                        limit: 'limit',
+                        term: 'term'
+                    };
+
+                    const results = await api.listSubFolderAssets(query);
+                    expect(results).toHaveProperty('assets');
+                    expect(results).toHaveProperty('folders');
+                    expect(results.assets).toHaveLength(2);
+                    expect(results.folders).toEqual([]);
+                    expect(scope.isDone()).toBe(true);
+
+                });
+            });
+        });
+
+        describe('#getQueryResponse', () => {
+            const ql = `query LibraryById {
+                  library: node(id: "libId") {
+                    type: __typename
+                    ... on Library {
+                      id
+                      name
+                    }
+                  }
+                }`;
+            let scope;
+            beforeEach(() => {
+                scope = nock(baseUrl)
+                    .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                    .reply(200, {
+                        "data": {
+                            "library": {
+                                "type": "Brand"
+                            }
+                        },
+                        "extensions": {
+                            "complexityScore": 0
+                        }
+                    });
+            });
+
+            it('should return the correct response', async() => {
+                const results = await api.getResponseUsingQuery(ql);
+                expect(results).toHaveProperty('data');
+                expect(results.data).toEqual({"library": {"type": "Brand"}});
+                expect(scope.isDone()).toBe(true);
             });
         });
     });


### PR DESCRIPTION
- Fix tests
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@0.0.10-canary.194.420ccd3.0
  npm install @friggframework/api-module-microsoft-sharepoint@0.0.5-canary.194.420ccd3.0
  npm install @friggframework/types@0.1.1-canary.194.420ccd3.0
  # or 
  yarn add @friggframework/api-module-frontify@0.0.10-canary.194.420ccd3.0
  yarn add @friggframework/api-module-microsoft-sharepoint@0.0.5-canary.194.420ccd3.0
  yarn add @friggframework/types@0.1.1-canary.194.420ccd3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
