### PR TITLE
Add publicshConfig: public and changed license to MIT in types package

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,7 @@
   "description": "FriggFramework type declarations",
   "types": "index.d.ts",
   "author": "Charef Bahria",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "@types/lodash": "^4.14.191",
     "@typescript-eslint/eslint-plugin": "^5.55.0",
@@ -23,5 +23,8 @@
     "@friggframework/integrations": "^1.0.22",
     "lodash": "^4.17.21",
     "lodash.get": "^4.4.2"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-microsoft-sharepoint@0.0.5-canary.195.fe28b90.0
  npm install @friggframework/types@0.1.1-canary.195.fe28b90.0
  # or 
  yarn add @friggframework/api-module-microsoft-sharepoint@0.0.5-canary.195.fe28b90.0
  yarn add @friggframework/types@0.1.1-canary.195.fe28b90.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
