### PR TITLE
Removed the usage of highWaterMark in Frontify upload

### DIFF
--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -501,21 +501,17 @@ class Api extends OAuth2Requester {
     async uploadFile(stream, urls) {
         const responses = [];
 
-        for await (const chunk of stream) {
-            // AWS url
-            const url = urls.shift();
+        const url = urls.shift();
 
-            // Using fetch to avoid sending Frontify auth headers to AWS
-            const resp = await fetch(url, {
-                method: 'PUT',
-                headers: {
-                    'content-type': 'binary'
-                },
-                body: chunk
-            });
+        const resp = await fetch(url, {
+            method: 'PUT',
+            headers: {
+                'content-type': 'binary'
+            },
+            body: stream
+        });
 
-            responses.push(resp);
-        }
+        responses.push(resp);
 
         return responses;
     }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@0.0.11-canary.196.1ecb691.0
  # or 
  yarn add @friggframework/api-module-frontify@0.0.11-canary.196.1ecb691.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
