### PR TITLE
Add a consistent files query throughout all Frontify calls

### DIFF
--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -76,19 +76,6 @@ class Api extends OAuth2Requester {
     }
 
     async getAsset(query) {
-        const commonProps = [
-            'description',
-            'downloadUrl',
-            'filename',
-            'previewUrl',
-            'size',
-        ];
-
-        const dimensionProps = [
-            'height',
-            'width',
-        ];
-
         const ql = `query Asset {
                       asset(id: "${query.assetId}") {
                         id
@@ -98,31 +85,7 @@ class Api extends OAuth2Requester {
                         tags {
                           value
                         }
-                        ... on Audio {
-                          ${commonProps.join(' ')}
-                        }
-                        ... on Document {
-                          ${commonProps.join(' ')}
-                          ${dimensionProps.join(' ')}
-                        }
-                        ... on File {
-                          ${commonProps.join(' ')}
-                        }
-                        ... on Image {
-                          ${commonProps.join(' ')}
-                          ${dimensionProps.join(' ')}
-                        }
-                        ... on Video {
-                          ${commonProps.join(' ')}
-                          ${dimensionProps.join(' ')}
-                          duration
-                          bitrate
-                        }
-                        ... on EmbeddedContent {
-                          description
-                          previewUrl
-                          status
-                        }
+                        ${this._filesQuery()}
                       }
                     }`;
 
@@ -258,13 +221,7 @@ class Api extends OAuth2Requester {
                             title
                             description
                             __typename
-                            ... on Image {
-                              previewUrl
-                              downloadUrl
-                              filename
-                              width
-                              height
-                            }
+                            ${this._filesQuery()}
                           }
                         }
                       }
@@ -308,9 +265,7 @@ class Api extends OAuth2Requester {
                             title
                             description
                             __typename
-                            ... on Image {
-                              previewUrl
-                            }
+                            ${this._filesQuery()}
                           }
                         }
                       }
@@ -355,15 +310,7 @@ class Api extends OAuth2Requester {
                                           id
                                           title
                                           __typename
-                                          ... on Image {
-                                            id
-                                            previewUrl
-                                            width
-                                            height
-                                            extension
-                                            filename
-                                            downloadUrl
-                                          }
+                                          ${this._filesQuery()}
                                         }
                                       }
                                     }
@@ -437,14 +384,7 @@ class Api extends OAuth2Requester {
                                 }
 
                               },
-                              ... on Image {
-                                previewUrl,
-                                extension
-                                downloadUrl(validityInDays: null, permanent: true)
-                                author
-                                filename
-                              }
-
+                              ${this._filesQuery()}
                             }
                           }
                         }
@@ -514,6 +454,47 @@ class Api extends OAuth2Requester {
         responses.push(resp);
 
         return responses;
+    }
+
+    _filesQuery() {
+        const commonProps = [
+            'description',
+            'downloadUrl',
+            'filename',
+            'previewUrl',
+            'size',
+            'extension',
+        ];
+
+        const dimensionProps = [
+            'height',
+            'width',
+        ];
+        return `... on Audio {
+                  ${commonProps.join(' ')}
+                }
+                ... on Document {
+                  ${commonProps.join(' ')}
+                  ${dimensionProps.join(' ')}
+                }
+                ... on File {
+                  ${commonProps.join(' ')}
+                }
+                ... on Image {
+                  ${commonProps.join(' ')}
+                  ${dimensionProps.join(' ')}
+                }
+                ... on Video {
+                  ${commonProps.join(' ')}
+                  ${dimensionProps.join(' ')}
+                  duration
+                  bitrate
+                }
+                ... on EmbeddedContent {
+                  description
+                  previewUrl
+                  status
+                }`;
     }
 }
 

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -140,9 +140,7 @@ describe(`${Config.label} API Tests`, () => {
     });
 
     describe('HTTP Requests', () => {
-        let api;
-
-        api = new Api({
+        const api = new Api({
             domain: 'domain-mine'
         });
 

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -142,10 +142,8 @@ describe(`${Config.label} API Tests`, () => {
     describe('HTTP Requests', () => {
         let api;
 
-        beforeAll(() => {
-            api = new Api({
-                domain: 'domain-mine'
-            });
+        api = new Api({
+            domain: 'domain-mine'
         });
 
         afterEach(() => {
@@ -217,19 +215,6 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#getAsset', () => {
-            const commonProps = [
-                'description',
-                'downloadUrl',
-                'filename',
-                'previewUrl',
-                'size',
-            ];
-
-            const dimensionProps = [
-                'height',
-                'width',
-            ];
-
             const ql = `query Asset {
                           asset(id: "assetId") {
                             id
@@ -239,31 +224,7 @@ describe(`${Config.label} API Tests`, () => {
                             tags {
                               value
                             }
-                            ... on Audio {
-                              ${commonProps.join(' ')}
-                            }
-                            ... on Document {
-                              ${commonProps.join(' ')}
-                              ${dimensionProps.join(' ')}
-                            }
-                            ... on File {
-                              ${commonProps.join(' ')}
-                            }
-                            ... on Image {
-                              ${commonProps.join(' ')}
-                              ${dimensionProps.join(' ')}
-                            }
-                            ... on Video {
-                              ${commonProps.join(' ')}
-                              ${dimensionProps.join(' ')}
-                              duration
-                              bitrate
-                            }
-                            ... on EmbeddedContent {
-                              description
-                              previewUrl
-                              status
-                            }
+                            ${api._filesQuery()}
                           }
                         }`;
 
@@ -764,13 +725,7 @@ describe(`${Config.label} API Tests`, () => {
                                  title
                                  description
                                  __typename
-                                 ... on Image {
-                                   previewUrl
-                                   downloadUrl
-                                   filename
-                                   width
-                                   height
-                                 }
+                                 ${api._filesQuery()}
                                }
                              }
                            }
@@ -920,9 +875,7 @@ describe(`${Config.label} API Tests`, () => {
                                  title
                                  description
                                  __typename
-                                 ... on Image {
-                                      previewUrl
-                                    }
+                                 ${api._filesQuery()}
                                }
                              }
                            }
@@ -1096,13 +1049,7 @@ describe(`${Config.label} API Tests`, () => {
                                     }
 
                                   },
-                                  ... on Image {
-                                    previewUrl,
-                                    extension
-                                    downloadUrl(validityInDays: null, permanent: true)
-                                    author
-                                    filename
-                                  }
+                                  ${api._filesQuery()}
 
                                 }
                               }
@@ -1334,15 +1281,7 @@ describe(`${Config.label} API Tests`, () => {
                                           id
                                           title
                                           __typename
-                                          ... on Image {
-                                            id
-                                            previewUrl
-                                            width
-                                            height
-                                            extension
-                                            filename
-                                            downloadUrl
-                                          }
+                                          ${api._filesQuery()}
                                         }
                                       }
                                     }


### PR DESCRIPTION
There was a need for more asset options, so I added new fields and also a new function to get the files query in every request that needs it
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@0.0.12-canary.197.cabb422.0
  # or 
  yarn add @friggframework/api-module-frontify@0.0.12-canary.197.cabb422.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
