### PR TITLE
Feature/lef 275 export functionality

### DIFF
--- a/api-module-library/sharepoint/api.js
+++ b/api-module-library/sharepoint/api.js
@@ -181,19 +181,19 @@ class Api extends OAuth2Requester {
     }
 
     // Upload large file in chunks
-    async uploadFileWithSession(session) {
+    async uploadFileWithSession(url, size, stream) {
         const responses = [];
         let current = 0;
 
-        for await (const chunk of session.stream) {
+        for await (const chunk of stream) {
             const chunkSize = chunk.length - 1;
             const options = {
-                url: session.url,
                 headers: {
                     'Content-Length': chunkSize,
-                    'Content-Range': `bytes ${current}-${current + chunkSize}/${session.size}`
+                    'Content-Range': `bytes ${current}-${current + chunkSize}/${size}`
                 },
                 body: chunk,
+                url
             };
 
             const resp = await this._put(options, false);

--- a/api-module-library/sharepoint/api.js
+++ b/api-module-library/sharepoint/api.js
@@ -136,11 +136,14 @@ class Api extends OAuth2Requester {
     }
 
     async uploadFile(query, filename, stream) {
-        const driveId = query.driveId;
-        const childId = query.folderId ? query.folderId : 'root';
+        const params = {
+            driveId: query.driveId,
+            childId: query.folderId ? query.folderId : 'root',
+            filename
+        };
 
         const options = {
-            url: `${this.baseUrl}${this.URLs.uploadFile(driveId, childId, filename)}`,
+            url: `${this.baseUrl}${this.URLs.uploadFile(params)}`,
             headers: {
                 'content-type': 'binary'
             },

--- a/api-module-library/sharepoint/api.js
+++ b/api-module-library/sharepoint/api.js
@@ -142,16 +142,24 @@ class Api extends OAuth2Requester {
             filename
         };
 
-        const options = {
-            url: `${this.baseUrl}${this.URLs.uploadFile(params)}`,
-            headers: {
-                'content-type': 'binary'
-            },
-            body: stream
-        };
+        const url = `${this.baseUrl}${this.URLs.uploadFile(params)}`;
+        const responses = [];
 
-        const response = await this._put(options);
-        return response;
+        for await (const chunk of stream) {
+            const options = {
+                headers: {
+                    'content-type': 'binary'
+                },
+                body: chunk,
+                url
+            };
+
+            const resp = await this._put(options);
+
+            responses.push(resp);
+        }
+
+        return responses;
     }
 }
 

--- a/api-module-library/sharepoint/api.js
+++ b/api-module-library/sharepoint/api.js
@@ -33,6 +33,8 @@ class Api extends OAuth2Requester {
                 `/drives/${driveId}/items/${fileId}?$expand=listItem`,
             search: ({ driveId, query }) =>
                 `/drives/${driveId}/root/search(q='${query}')?top=20&$select=id,image,name,file,parentReference,size,lastModifiedDateTime,@microsoft.graph.downloadUrl&$filter=`,
+            uploadFile: ({ driveId, childId, filename }) =>
+                `/drives/${driveId}/items/${childId}:/${filename}:/content`
         };
 
         this.authorizationUri = `https://login.microsoftonline.com/${this.tenant_id}/oauth2/v2.0/authorize`;
@@ -130,6 +132,22 @@ class Api extends OAuth2Requester {
         };
 
         const response = await this._get(options);
+        return response;
+    }
+
+    async uploadFile(query, filename, stream) {
+        const driveId = query.driveId;
+        const childId = query.folderId ? query.folderId : 'root';
+
+        const options = {
+            url: `${this.baseUrl}${this.URLs.uploadFile(driveId, childId, filename)}`,
+            headers: {
+                'content-type': 'binary'
+            },
+            body: stream
+        };
+
+        const response = await this._put(options);
         return response;
     }
 }

--- a/api-module-library/sharepoint/api.js
+++ b/api-module-library/sharepoint/api.js
@@ -148,7 +148,7 @@ class Api extends OAuth2Requester {
         const options = {
             url: `${this.baseUrl}${this.URLs.uploadFile(params)}`,
             headers: {
-                'content-type': 'binary',
+                'Content-Type': 'binary',
             },
             body: buffer,
         };

--- a/api-module-library/sharepoint/api.js
+++ b/api-module-library/sharepoint/api.js
@@ -43,6 +43,13 @@ class Api extends OAuth2Requester {
         this.tokenUri = `https://login.microsoftonline.com/${this.tenant_id}/oauth2/v2.0/token`;
     }
 
+    buildParams(query) {
+        return {
+            driveId: query.driveId,
+            childId: query.folderId ? query.folderId : 'root',
+        };
+    }
+
     getAuthUri() {
         const query = {
             client_id: this.client_id,
@@ -88,10 +95,7 @@ class Api extends OAuth2Requester {
     }
 
     async getFolder(query) {
-        const params = {
-            driveId: query.driveId,
-            childId: query.folderId ? query.folderId : 'root',
-        };
+        const params = this.buildParams(query);
 
         const options = {
             url: `${this.baseUrl}${this.URLs.rootFolders(params)}`,
@@ -139,11 +143,8 @@ class Api extends OAuth2Requester {
 
     // Upload small files in one go
     async uploadFile(query, filename, buffer) {
-        const params = {
-            driveId: query.driveId,
-            childId: query.folderId ? query.folderId : 'root',
-            filename
-        };
+        const params = this.buildParams(query);
+        params.filename = filename;
 
         const options = {
             url: `${this.baseUrl}${this.URLs.uploadFile(params)}`,
@@ -159,11 +160,8 @@ class Api extends OAuth2Requester {
     // Returns link to which a file can uploaded
     // in chunks
     async createUploadSession(query, filename) {
-        const params = {
-            driveId: query.driveId,
-            childId: query.folderId ? query.folderId : 'root',
-            filename
-        };
+        const params = this.buildParams(query);
+        params.filename = filename;
 
         const options = {
             url: `${this.baseUrl}${this.URLs.createUploadSession(params)}`,

--- a/api-module-library/sharepoint/api.js
+++ b/api-module-library/sharepoint/api.js
@@ -153,7 +153,7 @@ class Api extends OAuth2Requester {
             body: buffer,
         };
 
-        return this._put(options);
+        return this._put(options, false);
     }
 
     // Returns link to which a file can uploaded

--- a/api-module-library/sharepoint/api.test.js
+++ b/api-module-library/sharepoint/api.test.js
@@ -45,6 +45,16 @@ describe(`${Config.label} API Tests`, () => {
                     driveId: 'driveId',
                     query: 'query'
                 })).toEqual("/drives/driveId/root/search(q='query')?top=20&$select=id,image,name,file,parentReference,size,lastModifiedDateTime,@microsoft.graph.downloadUrl&$filter=");
+                expect(api.URLs.uploadFile({
+                    driveId: 'driveId',
+                    childId: 'childId',
+                    filename: 'filename'
+                })).toEqual('/drives/driveId/items/childId:/filename:/content');
+                expect(api.URLs.createUploadSession({
+                    driveId: 'driveId',
+                    childId: 'childId',
+                    filename: 'filename'
+                })).toEqual('/drives/driveId/childId:/filename:/createUploadSession');
                 expect(api.authorizationUri).toEqual('https://login.microsoftonline.com/tenant_id/oauth2/v2.0/authorize');
                 expect(api.tokenUri).toEqual('https://login.microsoftonline.com/tenant_id/oauth2/v2.0/token');
             });

--- a/api-module-library/sharepoint/api.test.js
+++ b/api-module-library/sharepoint/api.test.js
@@ -433,5 +433,68 @@ describe(`${Config.label} API Tests`, () => {
                 });
             });
         });
+
+        describe('#uploadFileWithSession', () => {
+            describe('Post stream chunks to endpoint', () => {
+                let scopeOne, scopeTwo, scopeThree;
+
+                beforeEach(() => {
+                    scopeOne = nock('https://an_url', {
+                        reqheaders: {
+                            'Content-Length': 3,
+                            'Content-Range': 'bytes 0-2/10'
+                        },
+                    })
+                        .put('/', 'one')
+                        .reply(200, {
+                            any: 'one'
+                        });
+
+                    scopeTwo = nock('https://an_url', {
+                        reqheaders: {
+                            'Content-Length': 3,
+                            'Content-Range': 'bytes 3-5/10'
+                        },
+                    })
+                        .put('/', 'two')
+                        .reply(200, {
+                            any: 'two'
+                        });
+
+                    scopeThree = nock('https://an_url', {
+                        reqheaders: {
+                            'Content-Length': 5,
+                            'Content-Range': 'bytes 6-10/10'
+                        },
+                    })
+                        .put('/', 'three')
+                        .reply(200, {
+                            any: 'three'
+                        });
+                });
+
+                it('should hit the correct endpoint', async () => {
+                    const params = {
+                        driveId: 'driveId',
+                        folderId: 'childId'
+                    };
+
+                    const result = await api.uploadFileWithSession('https://an_url/', 10, ['one', 'two', 'three']);
+
+                    expect(scopeOne.isDone()).toBe(true);
+                    expect(scopeTwo.isDone()).toBe(true);
+                    expect(scopeThree.isDone()).toBe(true);
+
+                    expect(result).toEqual([{
+                        any: 'one'
+                    }, {
+                        any: 'two'
+                    }, {
+                        any: 'three'
+                    }]);
+
+                });
+            });
+        });
     });
 });

--- a/api-module-library/sharepoint/api.test.js
+++ b/api-module-library/sharepoint/api.test.js
@@ -110,6 +110,33 @@ describe(`${Config.label} API Tests`, () => {
         });
     });
 
+    describe('#buildParams', () => {
+        describe('Folder param missing', () => {
+            it('should replace with root value', () => {
+                const api = new Api({});
+                expect(api.buildParams({
+                    driveId: 'driveId'
+                })).toEqual({
+                    driveId: 'driveId',
+                    childId: 'root'
+                });
+            });
+        });
+
+        describe('Folder param present', () => {
+            it('should replace with root value', () => {
+                const api = new Api({});
+                expect(api.buildParams({
+                    driveId: 'driveId',
+                    folderId: 'folderId'
+                })).toEqual({
+                    driveId: 'driveId',
+                    childId: 'folderId'
+                });
+            });
+        });
+    });
+
     describe('#getAuthUri', () => {
         describe('Generate Auth Url', () => {
             let api;

--- a/api-module-library/sharepoint/api.test.js
+++ b/api-module-library/sharepoint/api.test.js
@@ -379,7 +379,11 @@ describe(`${Config.label} API Tests`, () => {
                 let scope;
 
                 beforeEach(() => {
-                    scope = nock(baseUrl)
+                    scope = nock(baseUrl, {
+                        reqheaders: {
+                            'Content-Type': 'binary'
+                        },
+                    })
                         .put('/drives/driveId/items/childId:/filename:/content', 'buffer')
                         .reply(200, {
                             id: 'id'
@@ -394,6 +398,37 @@ describe(`${Config.label} API Tests`, () => {
 
                     const result = await api.uploadFile(params, 'filename', 'buffer');
                     expect(result).toEqual({ id: 'id' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+        });
+
+        describe('#createUploadSession', () => {
+            describe('Create link for uploading files', () => {
+                let scope;
+
+                beforeEach(() => {
+                    scope = nock(baseUrl, {
+                        reqheaders: {
+                            'Content-Type': 'application/json'
+                        },
+                    }).post('/drives/driveId/childId:/filename:/createUploadSession', {
+                        item: {
+                            name: 'filename'
+                        }
+                    }).reply(200, {
+                        url: 'url'
+                    });
+                });
+
+                it('should hit the correct endpoint', async () => {
+                    const params = {
+                        driveId: 'driveId',
+                        folderId: 'childId'
+                    };
+
+                    const result = await api.createUploadSession(params, 'filename');
+                    expect(result).toEqual({ url: 'url' });
                     expect(scope.isDone()).toBe(true);
                 });
             });

--- a/api-module-library/sharepoint/api.test.js
+++ b/api-module-library/sharepoint/api.test.js
@@ -373,5 +373,30 @@ describe(`${Config.label} API Tests`, () => {
                 });
             });
         });
+
+        describe('#uploadFile', () => {
+            describe('Post buffer to endpoint', () => {
+                let scope;
+
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .put('/drives/driveId/items/childId:/filename:/content', 'buffer')
+                        .reply(200, {
+                            id: 'id'
+                        });
+                });
+
+                it('should hit the correct endpoint', async () => {
+                    const params = {
+                        driveId: 'driveId',
+                        folderId: 'childId'
+                    };
+
+                    const result = await api.uploadFile(params, 'filename', 'buffer');
+                    expect(result).toEqual({ id: 'id' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
Implement and test the following methods for uploading files:

* **uploadFile**: For uploading small files in one go (using buffer).

* **createUploadSession**: Create session link for uploading files in chunks.

* **uploadFileWithSession**: Use passed in url in session for uploading files in chunks (using a stream).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-microsoft-sharepoint@0.0.6-canary.200.deaf8b7.0
  # or 
  yarn add @friggframework/api-module-microsoft-sharepoint@0.0.6-canary.200.deaf8b7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
