### PR TITLE
Feature/lef 539 return the user roles from the backend at the root container

### DIFF
--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -148,53 +148,6 @@ class Api extends OAuth2Requester {
         };
     }
 
-    async listBrandPermissions(query) {
-        const ql = `query Brands {
-                      brand(id: "${query.brandId}") {
-                        libraries {
-                          items {
-                            id
-                            name
-                            currentUserPermissions {
-                              canCreateAssets
-                              canViewCollaborators
-                              canCreateCollections
-                            }
-                          }
-                        }
-                        workspaceProjects{
-                          items{
-                            id
-                            name
-                            currentUserPermissions{
-                              canCreateAssets
-                              canViewCollaborators
-                            }
-                          }
-                        }
-                      }
-                    }`;
-
-        const response = await this._post(this.buildRequestOptions(ql));
-        this.assertResponse(response);
-
-        const { brand } = response.data;
-
-        const libraries = brand.libraries.items.map(item => ({
-            id: item.id,
-            name: item.name,
-            permissions: item.currentUserPermissions
-        }));
-
-        const projects = brand.workspaceProjects.items.map(item => ({
-            id: item.id,
-            name: item.name,
-            permissions: item.currentUserPermissions
-        }));
-
-        return { libraries, projects };
-    }
-
     async getSearchFilterOptions() {
         return {
             status: ['FINISHED', 'PROCESSING', 'PROCESSING_FAILED'],
@@ -230,6 +183,10 @@ class Api extends OAuth2Requester {
                           items {
                             id
                             name
+                            currentUserPermissions {
+                              canCreateAssets
+                              canViewCollaborators
+                            }
                           }
                         }
                       }
@@ -249,6 +206,11 @@ class Api extends OAuth2Requester {
                           items {
                             id
                             name
+                            currentUserPermissions {
+                              canCreateAssets
+                              canViewCollaborators
+                              canCreateCollections
+                            }
                           }
                         }
                       }

--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -148,6 +148,53 @@ class Api extends OAuth2Requester {
         };
     }
 
+    async listBrandPermissions(query) {
+        const ql = `query Brands {
+                      brand(id: "${query.brandId}") {
+                        libraries {
+                          items {
+                            id
+                            name
+                            currentUserPermissions {
+                              canCreateAssets
+                              canViewCollaborators
+                              canCreateCollections
+                            }
+                          }
+                        }
+                        workspaceProjects{
+                          items{
+                            id
+                            name
+                            currentUserPermissions{
+                              canCreateAssets
+                              canViewCollaborators
+                            }
+                          }
+                        }
+                      }
+                    }`;
+
+        const response = await this._post(this.buildRequestOptions(ql));
+        this.assertResponse(response);
+
+        const { brand } = response.data;
+
+        const libraries = brand.libraries.items.map(item => ({
+            id: item.id,
+            name: item.name,
+            permissions: item.currentUserPermissions
+        }));
+
+        const projects = brand.workspaceProjects.items.map(item => ({
+            id: item.id,
+            name: item.name,
+            permissions: item.currentUserPermissions
+        }));
+
+        return { libraries, projects };
+    }
+
     async getSearchFilterOptions() {
         return {
             status: ['FINISHED', 'PROCESSING', 'PROCESSING_FAILED'],

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -487,114 +487,6 @@ describe(`${Config.label} API Tests`, () => {
             });
         });
 
-        describe('#listBrandPermissions', () => {
-            const ql = `query Brands {
-                          brand(id: "brandId") {
-                            libraries {
-                              items {
-                                id
-                                name
-                                currentUserPermissions {
-                                  canCreateAssets
-                                  canViewCollaborators
-                                  canCreateCollections
-                                }
-                              }
-                            }
-                            workspaceProjects{
-                              items{
-                                id
-                                name
-                                currentUserPermissions{
-                                  canCreateAssets
-                                  canViewCollaborators
-                                }
-                              }
-                            }
-                          }
-                        }`;
-
-            describe('Retrieve all permissions in a brand', () => {
-                let scope;
-
-                beforeEach(() => {
-                    scope = nock(baseUrl)
-                        .post('', (body ) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
-                        .reply(200, {
-                            data: {
-                                brand: {
-                                    workspaceProjects: {
-                                        items: [{
-                                            id: 'project_id',
-                                            name: 'project_name',
-                                            currentUserPermissions: 'project_permissiones'
-                                        }]
-                                    },
-                                    libraries: {
-                                        items: [{
-                                            id: 'library_id',
-                                            name: 'library_name',
-                                            currentUserPermissions: 'library_permissiones'
-                                        }]
-                                    }
-                                }
-                            }
-                        });
-                });
-
-                it('should return the correct response', async () => {
-                    const permissions = await api.listBrandPermissions({ brandId: 'brandId' });
-                    expect(permissions).toEqual({
-                        libraries: [{
-                            id: 'library_id',
-                            name: 'library_name',
-                            permissions: 'library_permissiones'
-                        }],
-                        projects: [{
-                            id: 'project_id',
-                            name: 'project_name',
-                            permissions: 'project_permissiones'
-                        }]
-                    });
-                    expect(scope.isDone()).toBe(true);
-                });
-            });
-
-            describe('Get error coming from permissions endpoint', () => {
-
-                beforeEach(() => {
-                    nock(baseUrl)
-                        .post('', (body ) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
-                        .reply(200, {
-                            errors: [
-                                {
-                                    message: 'An error getting brand permissions happened!',
-                                    locations: [
-                                        {
-                                            line: 1,
-                                            column: 1
-                                        }
-                                    ],
-                                    extensions: {
-                                        category: 'graphql'
-                                    }
-                                }
-                            ],
-                            data: null,
-                            extensions: {
-                                complexityScore: 0
-                            }
-                        });
-                });
-
-                it('should handle error', () => {
-                    expect(
-                        async () => await api.listBrandPermissions({ brandId: 'brandId' })
-                    ).rejects.toThrow(new Error('An error getting brand permissions happened!'));
-                });
-            });
-        });
-
         describe('#getSearchFilterOptions', () => {
             describe('Retrieve search and filter available options', () => {
                 it('should return options', async () => {
@@ -685,6 +577,10 @@ describe(`${Config.label} API Tests`, () => {
                                items {
                                  id
                                  name
+                                 currentUserPermissions {
+                                   canCreateAssets
+                                   canViewCollaborators
+                                 }
                                }
                              }
                            }
@@ -756,6 +652,11 @@ describe(`${Config.label} API Tests`, () => {
                                items {
                                  id
                                  name
+                                 currentUserPermissions {
+                                   canCreateAssets
+                                   canViewCollaborators
+                                   canCreateCollections
+                                 }
                                }
                              }
                            }


### PR DESCRIPTION
Include permissions when calling `listProjects` and `listLibraries` methods
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@0.0.14-canary.201.2a021f8.0
  npm install @friggframework/api-module-microsoft-sharepoint@0.0.6-canary.201.2a021f8.0
  # or 
  yarn add @friggframework/api-module-frontify@0.0.14-canary.201.2a021f8.0
  yarn add @friggframework/api-module-microsoft-sharepoint@0.0.6-canary.201.2a021f8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
