### PR TITLE
Add the updated credential to an already existing entity in SharePoint integration

### DIFF
--- a/api-module-library/sharepoint/manager.js
+++ b/api-module-library/sharepoint/manager.js
@@ -109,7 +109,13 @@ class Manager extends ModuleManager {
             };
             this.entity = await Entity.create(createObj);
         } else if (search.length === 1) {
-            this.entity = search[0];
+            this.entity = await Entity.findOneAndUpdate(
+                { _id: search[0] },
+                { $set: {
+                        credential: this.credential.id
+                    }},
+                { useFindAndModify: true, new: true }
+            );
         } else {
             const message = 'Multiple entities found with the same external ID: ' + externalId;
             debug(message);


### PR DESCRIPTION
If an existing SharePoint credential is updated by the processAuthorizactionCallback, the updated credential was not being saved. This PR addresses that.