### PR TITLE
Feature/lef 598 implement pagination in the backend

### DIFF
--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -227,7 +227,7 @@ class Api extends OAuth2Requester {
     async listProjects(query) {
         const ql = `query Projects {
                       brand(id: "${query.brandId}") {
-                        workspaceProjects(page: ${query.page || 1}, limit: ${query.limit || 25}) {
+                        workspaceProjects(${this._paginationParamsQuery(query)}) {
                           items {
                             id
                             name
@@ -236,9 +236,7 @@ class Api extends OAuth2Requester {
                               canViewCollaborators
                             }
                           }
-                          total
-                          page
-                          hasNextPage
+                          ${this._paginationPropsQuery()}
                         }
                       }
                     }`;
@@ -253,7 +251,7 @@ class Api extends OAuth2Requester {
     async listLibraries(query) {
         const ql = `query Libraries {
                       brand(id: "${query.brandId}") {
-                        libraries(page: ${query.page || 1}, limit: ${query.limit || 25}) {
+                        libraries(${this._paginationParamsQuery(query)}) {
                           items {
                             id
                             name
@@ -263,9 +261,7 @@ class Api extends OAuth2Requester {
                               canCreateCollections
                             }
                           }
-                          total
-                          page
-                          hasNextPage
+                          ${this._paginationPropsQuery()}
                         }
                       }
                     }`;
@@ -296,7 +292,7 @@ class Api extends OAuth2Requester {
     async listProjectAssets(query) {
         const ql = `query ProjectAssets {
                       workspaceProject(id: "${query.projectId}") {
-                        assets(page: ${query.page || 1}, limit: ${query.limit || 25}) {
+                        assets(${this._paginationParamsQuery(query)}) {
                           items {
                             id
                             title
@@ -308,9 +304,7 @@ class Api extends OAuth2Requester {
                             __typename
                             ${this._filesQuery()}
                           }
-                          total
-                          page
-                          hasNextPage
+                          ${this._paginationPropsQuery()}
                         }
                       }
                     }`;
@@ -326,15 +320,13 @@ class Api extends OAuth2Requester {
         const ql = `query ProjectFolders {
                       workspaceProject(id: "${query.projectId}") {
                         browse {
-                          folders(page: ${query.page || 1}, limit: ${query.limit || 25}) {
+                          folders(${this._paginationParamsQuery(query)}) {
                             items {
                               id
                               name
                               __typename
                             }
-                            total
-                            page
-                            hasNextPage
+                            ${this._paginationPropsQuery()}
                           }
                         }
                       }
@@ -350,7 +342,7 @@ class Api extends OAuth2Requester {
     async listLibraryAssets(query) {
         const ql = `query LibraryAssets {
                       library(id: "${query.libraryId}") {
-                        assets(page: ${query.page || 1}, limit: ${query.limit || 25}) {
+                        assets(${this._paginationParamsQuery(query)}) {
                           items {
                             id
                             title
@@ -362,9 +354,7 @@ class Api extends OAuth2Requester {
                             __typename
                             ${this._filesQuery()}
                           }
-                          total
-                          page
-                          hasNextPage
+                          ${this._paginationPropsQuery()}
                         }
                       }
                     }`;
@@ -415,7 +405,7 @@ class Api extends OAuth2Requester {
         const ql = `query LibraryFolders {
                       library(id: "${query.libraryId}") {
                         browse {
-                          folders(page: ${query.page || 1}, limit: ${query.limit || 25}) {
+                          folders(${this._paginationParamsQuery(query)}) {
                             items {
                               id
                               name
@@ -423,9 +413,7 @@ class Api extends OAuth2Requester {
                               modifiedAt
                               __typename
                             }
-                            total
-                            page
-                            hasNextPage
+                            ${this._paginationPropsQuery()}
                           }
                         }
                       }
@@ -440,27 +428,25 @@ class Api extends OAuth2Requester {
 
     async listSubFolderAssets(query) {
         const ql = `query FolderById {
-                                  node(id: "${query.subFolderId}") {
-                                    ... on Folder {
-                                      name
-                                      assets(page: ${query.page || 1}, limit: ${query.limit || 25}) {
-                                        items {
-                                          id
-                                          title
-                                          tags {
-                                            source
-                                            value
-                                          }
-                                          __typename
-                                          ${this._filesQuery()}
-                                        }
-                                        total
-                                        page
-                                        hasNextPage
-                                      }
-                                    }
-                                  }
-                                }`;
+                      node(id: "${query.subFolderId}") {
+                        ... on Folder {
+                          name
+                          assets(${this._paginationParamsQuery(query)}) {
+                            items {
+                              id
+                              title
+                              tags {
+                                source
+                                value
+                              }
+                              __typename
+                              ${this._filesQuery()}
+                            }
+                            ${this._paginationPropsQuery()}
+                          }
+                        }
+                      }
+                    }`;
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);
         return {
@@ -470,22 +456,20 @@ class Api extends OAuth2Requester {
 
     async listSubFolderFolders(query) {
         const ql = `query FolderById {
-                                  node(id: "${query.subFolderId}") {
-                                    ... on Folder {
-                                      name
-                                      folders(page: ${query.page || 1}, limit: ${query.limit || 25}) {
-                                        items {
-                                          id
-                                          name
-                                          __typename
-                                        }
-                                        total
-                                        page
-                                        hasNextPage
-                                      }
-                                    }
-                                  }
-                                }`;
+                      node(id: "${query.subFolderId}") {
+                        ... on Folder {
+                          name
+                          folders(${this._paginationParamsQuery(query)}) {
+                            items {
+                              id
+                              name
+                              __typename
+                            }
+                            ${this._paginationPropsQuery()}
+                          }
+                        }
+                      }
+                    }`;
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);
         return {
@@ -504,7 +488,7 @@ class Api extends OAuth2Requester {
                       brand(id: "${query.brandId}") {
                         id
                         name
-                        search(page: ${query.page || 1}, limit: ${query.limit || 25}, query: {term: "${query.term}"}) {
+                        search(${this._paginationParamsQuery(query)}, query: {term: "${query.term}"}) {
                           edges {
                             title
                             node {
@@ -534,9 +518,7 @@ class Api extends OAuth2Requester {
                               ${this._filesQuery()}
                             }
                           }
-                          total
-                          page
-                          hasNextPage
+                          ${this._paginationPropsQuery()}
                         }
                       }
                     }`;
@@ -647,6 +629,16 @@ class Api extends OAuth2Requester {
                   previewUrl
                   status
                 }`;
+    }
+
+    _paginationParamsQuery(query) {
+        return `page: ${query.page || 1}, limit: ${query.limit || 25}`;
+    }
+
+    _paginationPropsQuery() {
+        return `total
+                page
+                hasNextPage`;
     }
 }
 

--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -227,7 +227,7 @@ class Api extends OAuth2Requester {
     async listProjects(query) {
         const ql = `query Projects {
                       brand(id: "${query.brandId}") {
-                        workspaceProjects {
+                        workspaceProjects(page: ${query.page || 1}, limit: ${query.limit || 25}) {
                           items {
                             id
                             name
@@ -236,6 +236,9 @@ class Api extends OAuth2Requester {
                               canViewCollaborators
                             }
                           }
+                          total
+                          page
+                          hasNextPage
                         }
                       }
                     }`;
@@ -250,7 +253,7 @@ class Api extends OAuth2Requester {
     async listLibraries(query) {
         const ql = `query Libraries {
                       brand(id: "${query.brandId}") {
-                        libraries {
+                        libraries(page: ${query.page || 1}, limit: ${query.limit || 25}) {
                           items {
                             id
                             name
@@ -260,6 +263,9 @@ class Api extends OAuth2Requester {
                               canCreateCollections
                             }
                           }
+                          total
+                          page
+                          hasNextPage
                         }
                       }
                     }`;
@@ -290,7 +296,7 @@ class Api extends OAuth2Requester {
     async listProjectAssets(query) {
         const ql = `query ProjectAssets {
                       workspaceProject(id: "${query.projectId}") {
-                        assets {
+                        assets(page: ${query.page || 1}, limit: ${query.limit || 25}) {
                           items {
                             id
                             title
@@ -302,6 +308,9 @@ class Api extends OAuth2Requester {
                             __typename
                             ${this._filesQuery()}
                           }
+                          total
+                          page
+                          hasNextPage
                         }
                       }
                     }`;
@@ -317,12 +326,15 @@ class Api extends OAuth2Requester {
         const ql = `query ProjectFolders {
                       workspaceProject(id: "${query.projectId}") {
                         browse {
-                          folders {
+                          folders(page: ${query.page || 1}, limit: ${query.limit || 25}) {
                             items {
                               id
                               name
                               __typename
                             }
+                            total
+                            page
+                            hasNextPage
                           }
                         }
                       }
@@ -338,7 +350,7 @@ class Api extends OAuth2Requester {
     async listLibraryAssets(query) {
         const ql = `query LibraryAssets {
                       library(id: "${query.libraryId}") {
-                        assets {
+                        assets(page: ${query.page || 1}, limit: ${query.limit || 25}) {
                           items {
                             id
                             title
@@ -350,6 +362,9 @@ class Api extends OAuth2Requester {
                             __typename
                             ${this._filesQuery()}
                           }
+                          total
+                          page
+                          hasNextPage
                         }
                       }
                     }`;
@@ -400,7 +415,7 @@ class Api extends OAuth2Requester {
         const ql = `query LibraryFolders {
                       library(id: "${query.libraryId}") {
                         browse {
-                          folders {
+                          folders(page: ${query.page || 1}, limit: ${query.limit || 25}) {
                             items {
                               id
                               name
@@ -408,6 +423,9 @@ class Api extends OAuth2Requester {
                               modifiedAt
                               __typename
                             }
+                            total
+                            page
+                            hasNextPage
                           }
                         }
                       }
@@ -425,7 +443,7 @@ class Api extends OAuth2Requester {
                                   node(id: "${query.subFolderId}") {
                                     ... on Folder {
                                       name
-                                      assets {
+                                      assets(page: ${query.page || 1}, limit: ${query.limit || 25}) {
                                         items {
                                           id
                                           title
@@ -436,6 +454,9 @@ class Api extends OAuth2Requester {
                                           __typename
                                           ${this._filesQuery()}
                                         }
+                                        total
+                                        page
+                                        hasNextPage
                                       }
                                     }
                                   }
@@ -452,12 +473,15 @@ class Api extends OAuth2Requester {
                                   node(id: "${query.subFolderId}") {
                                     ... on Folder {
                                       name
-                                      folders {
+                                      folders(page: ${query.page || 1}, limit: ${query.limit || 25}) {
                                         items {
                                           id
                                           name
                                           __typename
                                         }
+                                        total
+                                        page
+                                        hasNextPage
                                       }
                                     }
                                   }
@@ -480,8 +504,7 @@ class Api extends OAuth2Requester {
                       brand(id: "${query.brandId}") {
                         id
                         name
-                        search(page: 1, limit: ${query.limit}, query: {term: "${query.term}"}) {
-                          total
+                        search(page: ${query.page || 1}, limit: ${query.limit || 25}, query: {term: "${query.term}"}) {
                           edges {
                             title
                             node {
@@ -511,6 +534,9 @@ class Api extends OAuth2Requester {
                               ${this._filesQuery()}
                             }
                           }
+                          total
+                          page
+                          hasNextPage
                         }
                       }
                     }`;

--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -243,8 +243,19 @@ class Api extends OAuth2Requester {
 
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);
+
+        const {
+            items,
+            total,
+            page,
+            hasNextPage
+        } = response.data.brand.workspaceProjects;
+
         return {
-            projects: response.data.brand.workspaceProjects?.items,
+            items,
+            total,
+            page,
+            hasNextPage
         };
     }
 
@@ -268,7 +279,20 @@ class Api extends OAuth2Requester {
 
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);
-        return response.data.brand.libraries.items;
+
+        const {
+            items,
+            total,
+            page,
+            hasNextPage
+        } = response.data.brand.libraries;
+
+        return {
+            items,
+            total,
+            page,
+            hasNextPage
+        };
     }
 
     async listCollections(query) {
@@ -311,8 +335,19 @@ class Api extends OAuth2Requester {
 
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);
+
+        const {
+            items,
+            total,
+            page,
+            hasNextPage
+        } = response.data.workspaceProject.assets;
+
         return {
-            assets: response.data.workspaceProject?.assets.items,
+            items,
+            total,
+            page,
+            hasNextPage
         };
     }
 
@@ -334,8 +369,19 @@ class Api extends OAuth2Requester {
 
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);
+
+        const {
+            items,
+            total,
+            page,
+            hasNextPage
+        } = response.data.workspaceProject.browse.folders;
+
         return {
-            folders: response.data.workspaceProject?.browse.folders.items,
+            items,
+            total,
+            page,
+            hasNextPage
         };
     }
 
@@ -361,8 +407,19 @@ class Api extends OAuth2Requester {
 
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);
+
+        const {
+            items,
+            total,
+            page,
+            hasNextPage
+        } = response.data.library.assets;
+
         return {
-            assets: response.data.library.assets.items,
+            items,
+            total,
+            page,
+            hasNextPage
         };
     }
 
@@ -421,8 +478,19 @@ class Api extends OAuth2Requester {
 
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);
+
+        const {
+            items,
+            total,
+            page,
+            hasNextPage
+        } = response.data.library.browse.folders;
+
         return {
-            folders: response.data.library.browse.folders.items,
+            items,
+            total,
+            page,
+            hasNextPage
         };
     }
 
@@ -449,8 +517,19 @@ class Api extends OAuth2Requester {
                     }`;
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);
+
+        const {
+            items,
+            total,
+            page,
+            hasNextPage
+        } = response.data.node.assets;
+
         return {
-            assets: response.data.node.assets.items,
+            items,
+            total,
+            page,
+            hasNextPage
         };
     }
 
@@ -472,8 +551,19 @@ class Api extends OAuth2Requester {
                     }`;
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);
+
+        const {
+            items,
+            total,
+            page,
+            hasNextPage
+        } = response.data.node.folders;
+
         return {
-            folders: response.data.node.folders.items,
+            items,
+            total,
+            page,
+            hasNextPage
         };
     }
 
@@ -525,8 +615,19 @@ class Api extends OAuth2Requester {
 
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);
+
+        const {
+            edges: items,
+            total,
+            page,
+            hasNextPage
+        } = response.data.brand.search;
+
         return {
-            assets: response.data.brand.search.edges,
+            items,
+            total,
+            page,
+            hasNextPage
         };
     }
 

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -680,27 +680,31 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#listProjects', () => {
-            const ql = `query Projects {
-                           brand(id: "brandId") {
-                             workspaceProjects {
-                               items {
-                                 id
-                                 name
-                                 currentUserPermissions {
-                                   canCreateAssets
-                                   canViewCollaborators
-                                 }
-                               }
-                             }
-                           }
-                         }`;
+            const buildQl = (page, limit) => `
+                              query Projects {
+                                brand(id: "brandId") {
+                                  workspaceProjects(page: ${page || 1}, limit: ${limit || 25}) {
+                                    items {
+                                      id
+                                      name
+                                      currentUserPermissions {
+                                        canCreateAssets
+                                        canViewCollaborators
+                                      }
+                                    }
+                                    total
+                                    page
+                                    hasNextPage
+                                  }
+                                }
+                              }`;
 
             describe('Retrieve information about projects', () => {
                 let scope;
 
                 beforeEach(() => {
                     scope = nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 brand: {
@@ -719,11 +723,39 @@ describe(`${Config.label} API Tests`, () => {
                 });
             });
 
+            describe('Retrieve information about projects using pagination', () => {
+                let scope;
+
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl(10, 50).replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                brand: {
+                                    workspaceProjects: {
+                                        items: 'items'
+                                    }
+                                }
+                            }
+                        });
+                });
+
+                it('should return the correct response', async () => {
+                    const projects = await api.listProjects({
+                        brandId: 'brandId',
+                        page: 10,
+                        limit: 50
+                    });
+                    expect(projects).toEqual({ projects: 'items' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+
             describe('Get error coming from projects endpoint', () => {
 
                 beforeEach(() => {
                     nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             errors: [
                                 {
@@ -860,28 +892,32 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#listLibraries', () => {
-            const ql = `query Libraries {
-                           brand(id: "brandId") {
-                             libraries {
-                               items {
-                                 id
-                                 name
-                                 currentUserPermissions {
-                                   canCreateAssets
-                                   canViewCollaborators
-                                   canCreateCollections
-                                 }
-                               }
-                             }
-                           }
-                         }`;
+            const buildQl = (page, limit) => `
+                              query Libraries {
+                                brand(id: "brandId") {
+                                  libraries(page: ${page || 1}, limit: ${limit || 25}) {
+                                    items {
+                                      id
+                                      name
+                                      currentUserPermissions {
+                                        canCreateAssets
+                                        canViewCollaborators
+                                        canCreateCollections
+                                      }
+                                    }
+                                    total
+                                    page
+                                    hasNextPage
+                                  }
+                                }
+                              }`;
 
             describe('Retrieve information about libraries', () => {
                 let scope;
 
                 beforeEach(() => {
                     scope = nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 brand: {
@@ -902,11 +938,41 @@ describe(`${Config.label} API Tests`, () => {
                 });
             });
 
+            describe('Retrieve information about libraries using pagination', () => {
+                let scope;
+
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl(10, 30).replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                brand: {
+                                    libraries: {
+                                        items: {
+                                            libraries: 'libraries'
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                });
+
+                it('should return the correct response', async () => {
+                    const libraries = await api.listLibraries({
+                        brandId: 'brandId',
+                        page: 10,
+                        limit: 30
+                    });
+                    expect(libraries).toEqual({ libraries: 'libraries' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+
             describe('Get error coming from libraries endpoint', () => {
 
                 beforeEach(() => {
                     nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             errors: [
                                 {
@@ -1014,30 +1080,34 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#listProjectAssets', () => {
-            const ql = `query ProjectAssets {
-                           workspaceProject(id: "projectId") {
-                             assets {
-                               items {
-                                 id
-                                 title
-                                 description
-                                 tags {
-                                   source
-                                   value
-                                 }
-                                 __typename
-                                 ${api._filesQuery()}
-                               }
-                             }
-                           }
-                         }`;
+            const buildQl = (page, limit) => `
+                              query ProjectAssets {
+                                workspaceProject(id: "projectId") {
+                                  assets(page: ${page || 1}, limit: ${limit || 25}) {
+                                    items {
+                                      id
+                                      title
+                                      description
+                                      tags {
+                                        source
+                                        value
+                                      }
+                                      __typename
+                                      ${api._filesQuery()}
+                                    }
+                                    total
+                                    page
+                                    hasNextPage
+                                  }
+                                }
+                              }`;
 
             describe('Retrieve information about a project\'s assets', () => {
                 let scope;
 
                 beforeEach(() => {
                     scope = nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 workspaceProject: {
@@ -1056,11 +1126,39 @@ describe(`${Config.label} API Tests`, () => {
                 });
             });
 
+            describe('Retrieve information about a project\'s assets using pagination', () => {
+                let scope;
+
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl(5, 15).replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                workspaceProject: {
+                                    assets: {
+                                        items: 'items'
+                                    }
+                                }
+                            }
+                        });
+                });
+
+                it('should return the correct response', async () => {
+                    const projectAssets = await api.listProjectAssets({
+                        projectId: 'projectId',
+                        page: 5,
+                        limit: 15
+                    });
+                    expect(projectAssets).toEqual({ assets: 'items' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+
             describe('Get error coming from a project\'s assets endpoint', () => {
 
                 beforeEach(() => {
                     nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             errors: [
                                 {
@@ -1092,26 +1190,30 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#listProjectFolders', () => {
-            const ql = `query ProjectFolders {
-                           workspaceProject(id: "projectId") {
-                             browse {
-                               folders {
-                                 items {
-                                   id
-                                   name
-                                   __typename
-                                 }
-                               }
-                             }
-                           }
-                         }`;
+            const buildQl = (page, limit) => `
+                              query ProjectFolders {
+                                workspaceProject(id: "projectId") {
+                                  browse {
+                                    folders(page: ${page || 1}, limit: ${limit || 25}) {
+                                      items {
+                                        id
+                                        name
+                                        __typename
+                                      }
+                                      total
+                                      page
+                                      hasNextPage
+                                    }
+                                  }
+                                }
+                              }`;
 
             describe('Retrieve information about a project\'s folders', () => {
                 let scope;
 
                 beforeEach(() => {
                     scope = nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 workspaceProject: {
@@ -1132,11 +1234,41 @@ describe(`${Config.label} API Tests`, () => {
                 });
             });
 
+            describe('Retrieve information about a project\'s folders using pagination', () => {
+                let scope;
+
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl(2, 8).replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                workspaceProject: {
+                                    browse: {
+                                        folders: {
+                                            items: 'items'
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                });
+
+                it('should return the correct response', async () => {
+                    const projectFolders = await api.listProjectFolders({
+                        projectId: 'projectId',
+                        page: 2,
+                        limit: 8
+                    });
+                    expect(projectFolders).toEqual({ folders: 'items' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+
             describe('Get error coming from a project\'s folders endpoint', () => {
 
                 beforeEach(() => {
                     nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             errors: [
                                 {
@@ -1168,30 +1300,34 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#listLibraryAssets', () => {
-            const ql = `query LibraryAssets {
-                           library(id: "libraryId") {
-                             assets {
-                               items {
-                                 id
-                                 title
-                                 description
-                                 tags {
-                                   source
-                                   value
-                                 }
-                                 __typename
-                                 ${api._filesQuery()}
-                               }
-                             }
-                           }
-                         }`;
+            const buildQl = (page, limit) => `
+                              query LibraryAssets {
+                                library(id: "libraryId") {
+                                  assets(page: ${page || 1}, limit: ${limit || 25}) {
+                                    items {
+                                      id
+                                      title
+                                      description
+                                      tags {
+                                        source
+                                        value
+                                      }
+                                      __typename
+                                      ${api._filesQuery()}
+                                    }
+                                    total
+                                    page
+                                    hasNextPage
+                                  }
+                                }
+                              }`;
 
             describe('Retrieve information about a library\'s assets', () => {
                 let scope;
 
                 beforeEach(() => {
                     scope = nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 library: {
@@ -1210,11 +1346,39 @@ describe(`${Config.label} API Tests`, () => {
                 });
             });
 
+            describe('Retrieve information about a library\'s assets using pagination', () => {
+                let scope;
+
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl(20, 100).replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                library: {
+                                    assets: {
+                                        items: 'items'
+                                    }
+                                }
+                            }
+                        });
+                });
+
+                it('should return the correct response', async () => {
+                    const libraryAssets = await api.listLibraryAssets({
+                        libraryId: 'libraryId',
+                        page: 20,
+                        limit: 100
+                    });
+                    expect(libraryAssets).toEqual({ assets: 'items' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+
             describe('Get error coming from a library\'s assets endpoint', () => {
 
                 beforeEach(() => {
                     nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             errors: [
                                 {
@@ -1246,28 +1410,32 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#listLibraryFolders', () => {
-            const ql = `query LibraryFolders {
-                           library(id: "libraryId") {
-                             browse {
-                               folders {
-                                 items {
-                                   id
-                                   name
-                                   createdAt
-                                   modifiedAt
-                                   __typename
-                                 }
-                               }
-                             }
-                           }
-                         }`;
+            const buildQl = (page, limit) => `
+                              query LibraryFolders {
+                                library(id: "libraryId") {
+                                  browse {
+                                    folders(page: ${page || 1}, limit: ${limit || 25}) {
+                                      items {
+                                        id
+                                        name
+                                        createdAt
+                                        modifiedAt
+                                        __typename
+                                      }
+                                      total
+                                      page
+                                      hasNextPage
+                                    }
+                                  }
+                                }
+                              }`;
 
             describe('Retrieve information about a library\'s folders', () => {
                 let scope;
 
                 beforeEach(() => {
                     scope = nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 library: {
@@ -1288,11 +1456,41 @@ describe(`${Config.label} API Tests`, () => {
                 });
             });
 
+            describe('Retrieve information about a library\'s folders using pagination', () => {
+                let scope;
+
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl(15, 25).replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                library: {
+                                    browse: {
+                                        folders: {
+                                            items: 'items'
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                });
+
+                it('should return the correct response', async () => {
+                    const libraryFolders = await api.listLibraryFolders({
+                        libraryId: 'libraryId',
+                        page: 15,
+                        limit: 25
+                    });
+                    expect(libraryFolders).toEqual({ folders: 'items' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+
             describe('Get error coming from a library\'s folders endpoint', () => {
 
                 beforeEach(() => {
                     nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             errors: [
                                 {
@@ -1324,52 +1522,54 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#searchInBrand', () => {
-            const ql = `query BrandLevelSearch {
-                          brand(id: "brandId") {
-                            id
-                            name
-                            search(page: 1, limit: limit, query: {term: "term"}) {
-                              total
-                              edges {
-                                title
-                                node {
-                                  ... on Asset {
-                                    id,
-                                  modifiedAt,
-                                  description,
-                                  createdAt,
-                                  tags {
-                                    source,
-                                    value,
-                                  },
-                                  metadataValues {
-                                    id
-                                  },
-                                    externalId,
-                                    title,
-                                    status,
-                                    __typename,
-                                    creator {
-                                      id,
-                                      name,
-                                      email
+            const buildQl = (page, limit) => `
+                              query BrandLevelSearch {
+                                brand(id: "brandId") {
+                                  id
+                                  name
+                                  search(page: ${page || 1}, limit: ${limit || 25}, query: {term: "term"}) {
+                                    edges {
+                                      title
+                                      node {
+                                        ... on Asset {
+                                          id,
+                                        modifiedAt,
+                                        description,
+                                        createdAt,
+                                        tags {
+                                          source,
+                                          value,
+                                        },
+                                        metadataValues {
+                                          id
+                                        },
+                                          externalId,
+                                          title,
+                                          status,
+                                          __typename,
+                                          creator {
+                                            id,
+                                            name,
+                                            email
+                                          }
+
+                                        },
+                                        ${api._filesQuery()}
+                                      }
                                     }
-
-                                  },
-                                  ${api._filesQuery()}
-
+                                    total
+                                    page
+                                    hasNextPage
+                                  }
                                 }
-                              }
-                            }
-                          }
-                        }`;
+                              }`;
 
             describe('Retrieve information when searching in Brand', () => {
                 let scope;
 
                 beforeEach(() => {
                     scope = nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             data: {
                                 brand: {
@@ -1387,8 +1587,41 @@ describe(`${Config.label} API Tests`, () => {
                 it('should return the correct response', async () => {
                     const query = {
                         brandId: 'brandId',
-                        limit: 'limit',
                         term: 'term'
+                    };
+
+                    const results = await api.searchInBrand(query);
+                    expect(results).toEqual({ assets: 'edges' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+
+            describe('Retrieve information when searching in Brand using pagination', () => {
+                let scope;
+
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('', (body) => body.query.replace(/\s/g, '') === buildQl(5, 30).replace(/\s/g, ''))
+                        .reply(200, {
+                            data: {
+                                brand: {
+                                    id: "eyJpZGVudGlmaWVyIjoxLCJ0eXBlIjoiYnJhbmQifQ==",
+                                    name: "Left Hook",
+                                    search: {
+                                        total: 1,
+                                        edges: 'edges'
+                                    }
+                                }
+                            }
+                        });
+                });
+
+                it('should return the correct response', async () => {
+                    const query = {
+                        brandId: 'brandId',
+                        term: 'term',
+                        page: 5,
+                        limit: 30
                     };
 
                     const results = await api.searchInBrand(query);
@@ -1401,7 +1634,7 @@ describe(`${Config.label} API Tests`, () => {
 
                 beforeEach(() => {
                     nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === ql.replace(/\s/g, ''))
+                        .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {
                             errors: [
                                 {
@@ -1427,7 +1660,6 @@ describe(`${Config.label} API Tests`, () => {
                 it('should handle error', () => {
                     const query = {
                         brandId: 'brandId',
-                        limit: 'limit',
                         term: 'term'
                     };
 
@@ -1564,46 +1796,54 @@ describe(`${Config.label} API Tests`, () => {
         });
 
         describe('#getSubFolderContent', () => {
-            const qlFolders = `query FolderById {
-                                  node(id: "subFolderId") {
-                                    ... on Folder {
-                                      name
-                                      folders {
-                                        items {
-                                          id
-                                          name
-                                          __typename
-                                        }
-                                      }
-                                    }
-                                  }
-                                }`;
+            const buildQlFolders = (page, limit) => `
+                                     query FolderById {
+                                       node(id: "subFolderId") {
+                                         ... on Folder {
+                                           name
+                                           folders(page: ${page || 1}, limit: ${limit || 25}) {
+                                             items {
+                                               id
+                                               name
+                                               __typename
+                                             }
+                                             total
+                                             page
+                                             hasNextPage
+                                           }
+                                         }
+                                       }
+                                     }`;
 
-            const qlAssets = `query FolderById {
-                                  node(id: "subFolderId") {
-                                    ... on Folder {
-                                      name
-                                      assets {
-                                        items {
-                                          id
-                                          title
-                                          tags {
-                                            source
-                                            value
+            const buildQlAssets = (page, limit) => `
+                                    query FolderById {
+                                      node(id: "subFolderId") {
+                                        ... on Folder {
+                                          name
+                                          assets(page: ${page || 1}, limit: ${limit || 25}) {
+                                            items {
+                                              id
+                                              title
+                                              tags {
+                                                source
+                                                value
+                                              }
+                                              __typename
+                                              ${api._filesQuery()}
+                                            }
+                                            total
+                                            page
+                                            hasNextPage
                                           }
-                                          __typename
-                                          ${api._filesQuery()}
                                         }
                                       }
-                                    }
-                                  }
-                                }`;
+                                    }`;
 
             describe('Get subfolder assets', () => {
                 let scope;
                 beforeEach(() => {
                     scope = nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === qlAssets.replace(/\s/g, ''))
+                        .post('', (body) => body.query.replace(/\s/g, '') === buildQlAssets().replace(/\s/g, ''))
                         .reply(200, {
                             "data": {
                                 "node": {
@@ -1639,8 +1879,59 @@ describe(`${Config.label} API Tests`, () => {
                 it('should return the correct response', async () => {
                     const query = {
                         subFolderId: 'subFolderId',
-                        limit: 'limit',
                         term: 'term'
+                    };
+
+                    const results = await api.listSubFolderAssets(query);
+                    expect(results).toHaveProperty('assets');
+                    expect(results.assets).toHaveLength(2);
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+
+            describe('Get subfolder assets using pagination', () => {
+                let scope;
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('', (body) => body.query.replace(/\s/g, '') === buildQlAssets(2, 4).replace(/\s/g, ''))
+                        .reply(200, {
+                            "data": {
+                                "node": {
+                                    "name": "Libfolder",
+                                    "assets": {
+                                        "items": [
+                                            {
+                                                "id": "eyJpZGVudGlmaWVyIjoxOSwidHlwZSI6ImFzc2V0In0=",
+                                                "title": "FriggbyLeftHookLogoJuly2022",
+                                                "__typename": "Image",
+                                                "previewUrl": "https://cdn-assets-us.frontify.com/s3/frontify-enterprise-files-us/eyJvYXV0aCI6eyJjbGllbnRfaWQiOiJmcm9udGlmeS1leHBsb3JlciJ9LCJwYXRoIjoibGVmdC1ob29rXC9maWxlXC9yNXpkZDQ5djJFaFg4QjZMbW1Rdi5zdmcifQ:left-hook:2ecHvM3WRlNvkinOWJXvxhYK0QBHNwaSiyioQ3ORC_s",
+                                                "width": 400,
+                                                "height": 202
+                                            },
+                                            {
+                                                "id": "eyJpZGVudGlmaWVyIjoxOCwidHlwZSI6ImFzc2V0In0=",
+                                                "title": "custom_avatar-1661205632",
+                                                "__typename": "Image",
+                                                "previewUrl": "https://cdn-assets-us.frontify.com/s3/frontify-enterprise-files-us/eyJvYXV0aCI6eyJjbGllbnRfaWQiOiJmcm9udGlmeS1leHBsb3JlciJ9LCJwYXRoIjoibGVmdC1ob29rXC9maWxlXC95ZFR1TDlwVnJUUks2d0tvUlROYS5wbmcifQ:left-hook:PMD4S_9gflsrMNEBDNHxwxQqHlgHaCjrZFiGML8AHU0",
+                                                "width": 128,
+                                                "height": 128
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "extensions": {
+                                "complexityScore": 0
+                            }
+                        });
+                });
+
+                it('should return the correct response', async () => {
+                    const query = {
+                        subFolderId: 'subFolderId',
+                        term: 'term',
+                        page: 2,
+                        limit: 4
                     };
 
                     const results = await api.listSubFolderAssets(query);
@@ -1654,7 +1945,7 @@ describe(`${Config.label} API Tests`, () => {
                 let scope;
                 beforeEach(() => {
                     scope = nock(baseUrl)
-                        .post('', (body) => body.query.replace(/\s/g, '') === qlFolders.replace(/\s/g, ''))
+                        .post('', (body) => body.query.replace(/\s/g, '') === buildQlFolders().replace(/\s/g, ''))
                         .reply(200, {
                             "data": {
                                 "node": {
@@ -1684,8 +1975,53 @@ describe(`${Config.label} API Tests`, () => {
                 it('should return the correct response', async () => {
                     const query = {
                         subFolderId: 'subFolderId',
-                        limit: 'limit',
                         term: 'term'
+                    };
+
+                    const results = await api.listSubFolderFolders(query);
+                    expect(results).toHaveProperty('folders');
+                    expect(results.folders).toHaveLength(2);
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
+
+            describe('Get subfolder folders using pagination', () => {
+                let scope;
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('', (body) => body.query.replace(/\s/g, '') === buildQlFolders(3, 6).replace(/\s/g, ''))
+                        .reply(200, {
+                            "data": {
+                                "node": {
+                                    "name": "Libfolder",
+                                    "folders": {
+                                        "items": [
+                                            {
+                                                "id": "folderId",
+                                                "name": "FolderName",
+                                                "__typename": "SubFolder"
+                                            },
+                                            {
+                                                "id": "folderId2",
+                                                "name": "FolderName2",
+                                                "__typename": "SubFolder"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "extensions": {
+                                "complexityScore": 0
+                            }
+                        });
+                });
+
+                it('should return the correct response', async () => {
+                    const query = {
+                        subFolderId: 'subFolderId',
+                        term: 'term',
+                        page: 3,
+                        limit: 6
                     };
 
                     const results = await api.listSubFolderFolders(query);

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -709,8 +709,11 @@ describe(`${Config.label} API Tests`, () => {
                             data: {
                                 brand: {
                                     workspaceProjects: {
-                                        items: 'items'
-                                    }
+                                        items: 'items',
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
+                                    },
                                 }
                             }
                         });
@@ -718,7 +721,12 @@ describe(`${Config.label} API Tests`, () => {
 
                 it('should return the correct response', async () => {
                     const projects = await api.listProjects({ brandId: 'brandId' });
-                    expect(projects).toEqual({ projects: 'items' });
+                    expect(projects).toEqual({
+                        items: 'items',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -733,8 +741,11 @@ describe(`${Config.label} API Tests`, () => {
                             data: {
                                 brand: {
                                     workspaceProjects: {
-                                        items: 'items'
-                                    }
+                                        items: 'items',
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
+                                    },
                                 }
                             }
                         });
@@ -746,7 +757,12 @@ describe(`${Config.label} API Tests`, () => {
                         page: 10,
                         limit: 50
                     });
-                    expect(projects).toEqual({ projects: 'items' });
+                    expect(projects).toEqual({
+                        items: 'items',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -922,9 +938,10 @@ describe(`${Config.label} API Tests`, () => {
                             data: {
                                 brand: {
                                     libraries: {
-                                        items: {
-                                            libraries: 'libraries'
-                                        }
+                                        items: 'items',
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
                                     }
                                 }
                             }
@@ -933,7 +950,12 @@ describe(`${Config.label} API Tests`, () => {
 
                 it('should return the correct response', async () => {
                     const libraries = await api.listLibraries({ brandId: 'brandId' });
-                    expect(libraries).toEqual({ libraries: 'libraries' });
+                    expect(libraries).toEqual({
+                        items: 'items',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -948,9 +970,10 @@ describe(`${Config.label} API Tests`, () => {
                             data: {
                                 brand: {
                                     libraries: {
-                                        items: {
-                                            libraries: 'libraries'
-                                        }
+                                        items: 'items',
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
                                     }
                                 }
                             }
@@ -963,7 +986,12 @@ describe(`${Config.label} API Tests`, () => {
                         page: 10,
                         limit: 30
                     });
-                    expect(libraries).toEqual({ libraries: 'libraries' });
+                    expect(libraries).toEqual({
+                        items: 'items',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1112,7 +1140,10 @@ describe(`${Config.label} API Tests`, () => {
                             data: {
                                 workspaceProject: {
                                     assets: {
-                                        items: 'items'
+                                        items: 'items',
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
                                     }
                                 }
                             }
@@ -1121,7 +1152,12 @@ describe(`${Config.label} API Tests`, () => {
 
                 it('should return the correct response', async () => {
                     const projectAssets = await api.listProjectAssets({ projectId: 'projectId' });
-                    expect(projectAssets).toEqual({ assets: 'items' });
+                    expect(projectAssets).toEqual({
+                        items: 'items',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1136,7 +1172,10 @@ describe(`${Config.label} API Tests`, () => {
                             data: {
                                 workspaceProject: {
                                     assets: {
-                                        items: 'items'
+                                        items: 'items',
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
                                     }
                                 }
                             }
@@ -1149,7 +1188,12 @@ describe(`${Config.label} API Tests`, () => {
                         page: 5,
                         limit: 15
                     });
-                    expect(projectAssets).toEqual({ assets: 'items' });
+                    expect(projectAssets).toEqual({
+                        items: 'items',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1219,7 +1263,10 @@ describe(`${Config.label} API Tests`, () => {
                                 workspaceProject: {
                                     browse: {
                                         folders: {
-                                            items: 'items'
+                                            items: 'items',
+                                            total: 'total',
+                                            page: 'page',
+                                            hasNextPage: 'hasNextPage'
                                         }
                                     }
                                 }
@@ -1229,7 +1276,12 @@ describe(`${Config.label} API Tests`, () => {
 
                 it('should return the correct response', async () => {
                     const projectFolders = await api.listProjectFolders({ projectId: 'projectId' });
-                    expect(projectFolders).toEqual({ folders: 'items' });
+                    expect(projectFolders).toEqual({
+                        items: 'items',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1245,7 +1297,10 @@ describe(`${Config.label} API Tests`, () => {
                                 workspaceProject: {
                                     browse: {
                                         folders: {
-                                            items: 'items'
+                                            items: 'items',
+                                            total: 'total',
+                                            page: 'page',
+                                            hasNextPage: 'hasNextPage'
                                         }
                                     }
                                 }
@@ -1259,7 +1314,12 @@ describe(`${Config.label} API Tests`, () => {
                         page: 2,
                         limit: 8
                     });
-                    expect(projectFolders).toEqual({ folders: 'items' });
+                    expect(projectFolders).toEqual({
+                        items: 'items',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1332,7 +1392,10 @@ describe(`${Config.label} API Tests`, () => {
                             data: {
                                 library: {
                                     assets: {
-                                        items: 'items'
+                                        items: 'items',
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
                                     }
                                 }
                             }
@@ -1341,7 +1404,12 @@ describe(`${Config.label} API Tests`, () => {
 
                 it('should return the correct response', async () => {
                     const libraryAssets = await api.listLibraryAssets({ libraryId: 'libraryId' });
-                    expect(libraryAssets).toEqual({ assets: 'items' });
+                    expect(libraryAssets).toEqual({
+                        items: 'items',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1356,7 +1424,10 @@ describe(`${Config.label} API Tests`, () => {
                             data: {
                                 library: {
                                     assets: {
-                                        items: 'items'
+                                        items: 'items',
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
                                     }
                                 }
                             }
@@ -1369,7 +1440,12 @@ describe(`${Config.label} API Tests`, () => {
                         page: 20,
                         limit: 100
                     });
-                    expect(libraryAssets).toEqual({ assets: 'items' });
+                    expect(libraryAssets).toEqual({
+                        items: 'items',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1441,7 +1517,10 @@ describe(`${Config.label} API Tests`, () => {
                                 library: {
                                     browse: {
                                         folders: {
-                                            items: 'items'
+                                            items: 'items',
+                                            total: 'total',
+                                            page: 'page',
+                                            hasNextPage: 'hasNextPage'
                                         }
                                     }
                                 }
@@ -1451,7 +1530,12 @@ describe(`${Config.label} API Tests`, () => {
 
                 it('should return the correct response', async () => {
                     const libraryFolders = await api.listLibraryFolders({ libraryId: 'libraryId' });
-                    expect(libraryFolders).toEqual({ folders: 'items' });
+                    expect(libraryFolders).toEqual({
+                        items: 'items',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1467,7 +1551,10 @@ describe(`${Config.label} API Tests`, () => {
                                 library: {
                                     browse: {
                                         folders: {
-                                            items: 'items'
+                                            items: 'items',
+                                            total: 'total',
+                                            page: 'page',
+                                            hasNextPage: 'hasNextPage'
                                         }
                                     }
                                 }
@@ -1481,7 +1568,12 @@ describe(`${Config.label} API Tests`, () => {
                         page: 15,
                         limit: 25
                     });
-                    expect(libraryFolders).toEqual({ folders: 'items' });
+                    expect(libraryFolders).toEqual({
+                        items: 'items',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1576,8 +1668,10 @@ describe(`${Config.label} API Tests`, () => {
                                     id: "eyJpZGVudGlmaWVyIjoxLCJ0eXBlIjoiYnJhbmQifQ==",
                                     name: "Left Hook",
                                     search: {
-                                        total: 1,
-                                        edges: 'edges'
+                                        edges: 'edges',
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
                                     }
                                 }
                             }
@@ -1591,7 +1685,12 @@ describe(`${Config.label} API Tests`, () => {
                     };
 
                     const results = await api.searchInBrand(query);
-                    expect(results).toEqual({ assets: 'edges' });
+                    expect(results).toEqual({
+                        items: 'edges',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1608,8 +1707,10 @@ describe(`${Config.label} API Tests`, () => {
                                     id: "eyJpZGVudGlmaWVyIjoxLCJ0eXBlIjoiYnJhbmQifQ==",
                                     name: "Left Hook",
                                     search: {
-                                        total: 1,
-                                        edges: 'edges'
+                                        edges: 'edges',
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
                                     }
                                 }
                             }
@@ -1625,7 +1726,12 @@ describe(`${Config.label} API Tests`, () => {
                     };
 
                     const results = await api.searchInBrand(query);
-                    expect(results).toEqual({ assets: 'edges' });
+                    expect(results).toEqual({
+                        items: 'edges',
+                        total: 'total',
+                        page: 'page',
+                        hasNextPage: 'hasNextPage'
+                    });
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1866,7 +1972,10 @@ describe(`${Config.label} API Tests`, () => {
                                                 "width": 128,
                                                 "height": 128
                                             }
-                                        ]
+                                        ],
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
                                     }
                                 }
                             },
@@ -1883,8 +1992,11 @@ describe(`${Config.label} API Tests`, () => {
                     };
 
                     const results = await api.listSubFolderAssets(query);
-                    expect(results).toHaveProperty('assets');
-                    expect(results.assets).toHaveLength(2);
+                    expect(results).toHaveProperty('items');
+                    expect(results.items).toHaveLength(2);
+                    expect(results.total).toEqual('total');
+                    expect(results.page).toEqual('page');
+                    expect(results.hasNextPage).toEqual('hasNextPage');
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1916,7 +2028,10 @@ describe(`${Config.label} API Tests`, () => {
                                                 "width": 128,
                                                 "height": 128
                                             }
-                                        ]
+                                        ],
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
                                     }
                                 }
                             },
@@ -1935,8 +2050,11 @@ describe(`${Config.label} API Tests`, () => {
                     };
 
                     const results = await api.listSubFolderAssets(query);
-                    expect(results).toHaveProperty('assets');
-                    expect(results.assets).toHaveLength(2);
+                    expect(results).toHaveProperty('items');
+                    expect(results.items).toHaveLength(2);
+                    expect(results.total).toEqual('total');
+                    expect(results.page).toEqual('page');
+                    expect(results.hasNextPage).toEqual('hasNextPage');
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -1962,7 +2080,10 @@ describe(`${Config.label} API Tests`, () => {
                                                 "name": "FolderName2",
                                                 "__typename": "SubFolder"
                                             }
-                                        ]
+                                        ],
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
                                     }
                                 }
                             },
@@ -1979,8 +2100,11 @@ describe(`${Config.label} API Tests`, () => {
                     };
 
                     const results = await api.listSubFolderFolders(query);
-                    expect(results).toHaveProperty('folders');
-                    expect(results.folders).toHaveLength(2);
+                    expect(results).toHaveProperty('items');
+                    expect(results.items).toHaveLength(2);
+                    expect(results.total).toEqual('total');
+                    expect(results.page).toEqual('page');
+                    expect(results.hasNextPage).toEqual('hasNextPage');
                     expect(scope.isDone()).toBe(true);
                 });
             });
@@ -2006,7 +2130,10 @@ describe(`${Config.label} API Tests`, () => {
                                                 "name": "FolderName2",
                                                 "__typename": "SubFolder"
                                             }
-                                        ]
+                                        ],
+                                        total: 'total',
+                                        page: 'page',
+                                        hasNextPage: 'hasNextPage'
                                     }
                                 }
                             },
@@ -2025,8 +2152,11 @@ describe(`${Config.label} API Tests`, () => {
                     };
 
                     const results = await api.listSubFolderFolders(query);
-                    expect(results).toHaveProperty('folders');
-                    expect(results.folders).toHaveLength(2);
+                    expect(results).toHaveProperty('items');
+                    expect(results.items).toHaveLength(2);
+                    expect(results.total).toEqual('total');
+                    expect(results.page).toEqual('page');
+                    expect(results.hasNextPage).toEqual('hasNextPage');
                     expect(scope.isDone()).toBe(true);
                 });
             });


### PR DESCRIPTION
Implement pagination for the following:

* listProjects
* listLibraries
* listProjectAssets
* listProjectFolders
* listLibraryAssets
* listCollectionsAssets
* listLibraryFolders
* listSubFolderAssets
* listSubFolderFolders
* searchInBrand

Normalize responses returning the following for each of the above:

```
return {
            items,
            total,
            page,
            hasNextPage
        };
```