### PR TITLE
Return full response when fetching file [ci skip]

### DIFF
--- a/api-module-library/google-drive/api.js
+++ b/api-module-library/google-drive/api.js
@@ -96,6 +96,7 @@ class Api extends OAuth2Requester {
             query: {
                 alt: 'media',
             },
+            returnFullRes: true,
         };
         return this._get(options);
     }


### PR DESCRIPTION
Return full response when fetching for file from Drive. This is for having access to stream coming in `response.body` property.