### PR TITLE
Add link unfurling endpoint

### DIFF
--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -45,6 +45,7 @@ class Api extends OAuth2Requester {
             postEphemeral: '/chat.postEphemeral',
             updateMessage: '/chat.update',
             deleteMessage: '/chat.delete',
+            postUnfurl: '/chat.unfurl',
 
             // Files
             getFile: '/files.info', // Gets information about a file.
@@ -233,6 +234,15 @@ class Api extends OAuth2Requester {
     async postMessage(body) {
         const options = {
             url: this.baseUrl + this.URLs.postMessage,
+            body,
+        };
+        const response = await this._post(options);
+        return response;
+    }
+
+    async postUnfurl(body) {
+        const options = {
+            url: this.baseUrl + this.URLs.postUnfurl,
             body,
         };
         const response = await this._post(options);


### PR DESCRIPTION
I added the link unfurling endpoint to Slack integration.
I noted the Slack API module barely has tests created in api.test.js, so I added an issue to deal with that and create proper tests: LEF-650.

