### PR TITLE
HubSpot - add crud methods for Email Templates

### DIFF
--- a/api-module-library/hubspot/api.js
+++ b/api-module-library/hubspot/api.js
@@ -48,7 +48,10 @@ class Api extends OAuth2Requester {
             blogPosts: '/cms/v3/blogs/posts',
             landingPageById: (landingPageId) => `/cms/v3/pages/landing-pages/${landingPageId}`,
             sitePageById: (sitePageId) => `/cms/v3/pages/site-pages/${sitePageId}`,
-            blogPostById: (blogPostId) => `/cms/v3/blogs/posts/${blogPostId}`
+            blogPostById: (blogPostId) => `/cms/v3/blogs/posts/${blogPostId}`,
+            emailTemplates: '/content/api/v2/templates',
+            emailTemplateById: (templateId) => `/content/api/v2/templates/${templateId}`,
+            
         };
 
         this.authorizationUri = encodeURI(
@@ -820,6 +823,58 @@ class Api extends OAuth2Requester {
             }
         };
         return this._post(options);
+    }
+
+    // ***********************   Email Templates   **************************
+
+    async getEmailTemplates(query=''){
+        const options = {
+            url: `${this.baseUrl}${this.URLs.emailTemplates}`,
+        };
+        if (query !== '') {
+            options.url = `${options.url}?${query}`
+        }
+        return this._get(options);
+    }
+
+    async getEmailTemplate(id){
+        const options = {
+            url: `${this.baseUrl}${this.URLs.emailTemplateById(id)}`,
+        };
+        return this._get(options);
+    }
+
+    async updateEmailTemplate(objId, body) {
+        const options = {
+            url: `${this.baseUrl}${this.URLs.emailTemplateById(objId)}`,
+            body: body,
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+
+            }
+        };
+        return this._put(options);
+    }
+
+    async createEmailTemplate(body) {
+        const options = {
+            url: `${this.baseUrl}${this.URLs.emailTemplates}`,
+            body: body,
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+
+            }
+        };
+        return this._post(options);
+    }
+
+    async deleteEmailTemplate(id){
+        const options = {
+            url: `${this.baseUrl}${this.URLs.emailTemplateById(id)}`,
+        };
+        return this._delete(options);
     }
 
     // **************************   Other/All   **********************************

--- a/api-module-library/hubspot/tests/api.test.js
+++ b/api-module-library/hubspot/tests/api.test.js
@@ -412,4 +412,38 @@ describe(`${config.label} API tests`, () => {
             expect(response).toBeDefined();
         });
     });
+
+    describe('HS Email Templates', () => {
+        let allEmailTemplates;
+        it('should return the Email Templates', async () => {
+            allEmailTemplates = await api.getEmailTemplates();
+            expect(allEmailTemplates).toBeDefined();
+            expect(allEmailTemplates).toHaveProperty('objects')
+        });
+        it('get Email Template by Id' , async () => {
+            const templateToGet = allEmailTemplates.objects.slice(-1)[0];
+            const response = await api.getEmailTemplate(templateToGet.id);
+            expect(response).toBeDefined();
+        });
+        it('update a Email Template' , async () => {
+            const postToUpdate = allEmailTemplates.objects.slice(-1)[0];
+            const response = await api.updateEmailTemplate(
+                postToUpdate.id,
+                {label: `test email template ${Date.now()}`},
+                 );
+            expect(response).toBeDefined();
+        });
+        let createdId;
+        it('create an Email Template' , async () => {
+            const response = await api.createEmailTemplate(
+                allEmailTemplates.objects.slice(-1)[0]
+            );
+            expect(response).toBeDefined();
+            createdId = response.id;
+        });
+        it('Delete an Email Template' , async () => {
+            const response = await api.deleteEmailTemplate(createdId)
+            expect(response.status).toBe(204);
+        });
+    });
 });


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-hubspot@0.8.31-canary.216.26ae047.0
  # or 
  yarn add @friggframework/api-module-hubspot@0.8.31-canary.216.26ae047.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
