### PR TITLE
Feature/Add Sharepoint graphSearchQuery function

### DIFF
--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -1493,6 +1493,8 @@ describe(`${Config.label} API Tests`, () => {
                 let scope;
 
                 beforeEach(() => {
+
+                    console.log(buildQl())
                     scope = nock(baseUrl)
                         .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -1494,7 +1494,6 @@ describe(`${Config.label} API Tests`, () => {
 
                 beforeEach(() => {
 
-                    console.log(buildQl())
                     scope = nock(baseUrl)
                         .post('', (body ) => body.query.replace(/\s/g, '') === buildQl().replace(/\s/g, ''))
                         .reply(200, {

--- a/api-module-library/sharepoint/api.test.js
+++ b/api-module-library/sharepoint/api.test.js
@@ -374,6 +374,32 @@ describe(`${Config.label} API Tests`, () => {
                     expect(scope.isDone()).toBe(true);
                 });
             });
+
+            describe('Perform a graphSearchQuery', () => {
+                let scope;
+
+                beforeEach(() => {
+                    scope = nock(baseUrl)
+                        .post('/search/query')
+                        .reply(200, {
+                            results: 'results'
+                        });
+                });
+
+                it('should hit the correct endpoint', async () => {
+                    const query = {
+                        organizationId: 'driveId',
+                        query: 'query',
+                        filter: {
+                            fileTypes: ['jpg']
+                        }
+                    };
+
+                    const results = await api.graphSearchQuery(query);
+                    expect(results).toEqual({ results: 'results' });
+                    expect(scope.isDone()).toBe(true);
+                });
+            });
         });
 
         describe('#getFile', () => {


### PR DESCRIPTION
Add Sharepoint graphSearchQuery function
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@1.0.2-canary.217.dc55463.0
  npm install @friggframework/api-module-microsoft-sharepoint@0.0.8-canary.217.dc55463.0
  # or 
  yarn add @friggframework/api-module-frontify@1.0.2-canary.217.dc55463.0
  yarn add @friggframework/api-module-microsoft-sharepoint@0.0.8-canary.217.dc55463.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
