### PR TITLE
Slack lookup by externalId, remove the user requirement from Mongoose DB models

### DIFF
--- a/packages/integrations/model.js
+++ b/packages/integrations/model.js
@@ -12,7 +12,7 @@ const schema = new mongoose.Schema(
         user: {
             type: mongoose.Schema.Types.ObjectId,
             ref: 'User',
-            required: true,
+            required: false,
         },
         status: {
             type: String,

--- a/packages/module-plugin/credential.js
+++ b/packages/module-plugin/credential.js
@@ -6,7 +6,7 @@ const schema = new mongoose.Schema(
         user: {
             type: mongoose.Schema.Types.ObjectId,
             ref: 'User',
-            required: true,
+            required: false,
         },
         subType: { type: String },
         auth_is_valid: { type: Boolean },

--- a/packages/module-plugin/entity.js
+++ b/packages/module-plugin/entity.js
@@ -11,7 +11,7 @@ const schema = new mongoose.Schema(
         user: {
             type: mongoose.Schema.Types.ObjectId,
             ref: 'User',
-            required: true,
+            required: false,
         },
         name: { type: String },
         externalId: { type: String },

--- a/packages/module-plugin/manager.js
+++ b/packages/module-plugin/manager.js
@@ -9,7 +9,7 @@ class ModuleManager extends Delegate {
 
     constructor(params) {
         super(params);
-        this.userId = get(params, 'userId');
+        this.userId = get(params, 'userId', null); // Making this non-required
     }
 
     static getName() {


### PR DESCRIPTION
Goal is to make it optional for User-based lookup, and instead lean towards externalId based look-up for Credential and Entities