### PR TITLE
Add state and user_scope variables to Slack auth URI

### DIFF
--- a/api-module-library/slack/README.md
+++ b/api-module-library/slack/README.md
@@ -1,3 +1,11 @@
 # Frigg API Module Slack
 
 A quick description of Slack.
+
+Expected environment variables
+```
+SLACK_CLIENT_ID="Slack app client ID"
+SLACK_CLIENT_SECRET="Slack app client secret"
+SLACK_SCOPE="Slack bot scopes, comma separated"
+SLACK_USER_SCOPE="Slack user scopes, comma separated"
+```

--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -14,6 +14,7 @@ class Api extends OAuth2Requester {
         // this.client_id = get(params, 'client_id');
         // this.client_secret = get(params, 'client_secret');
         this.scope = process.env.SLACK_SCOPE;
+        this.user_scope = process.env.SLACK_USER_SCOPE || '';
         this.redirect_uri = get(
             params,
             'redirect_uri',
@@ -144,7 +145,7 @@ class Api extends OAuth2Requester {
 
     async getAuthUri() {
         const authUri = encodeURI(
-            `${this.URLs.authorize}?state=&client_id=${this.client_id}&scope=${this.scope}&redirect_uri=${this.redirect_uri}`
+            `${this.URLs.authorize}?state=${this.state}&client_id=${this.client_id}&scope=${this.scope}&user_scope=${this.user_scope}&redirect_uri=${this.redirect_uri}`
         );
         return authUri;
     }


### PR DESCRIPTION
- The state variable was missing in Slack URI.
- Added the user_scope variable as well.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-slack@0.2.1-canary.220.9e698c8.0
  # or 
  yarn add @friggframework/api-module-slack@0.2.1-canary.220.9e698c8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
