### PR TITLE
Add the team entity to Slack if it doesn't exists and return it in pr…

### DIFF
--- a/api-module-library/slack/api.js
+++ b/api-module-library/slack/api.js
@@ -21,7 +21,6 @@ class Api extends OAuth2Requester {
             `${process.env.REDIRECT_URI}/slack`
         );
         this.access_token = get(params, 'access_token', null);
-        this.team_access_token = get(params, 'access_token', null);
 
         this.URLs = {
             // Auth
@@ -82,7 +81,6 @@ class Api extends OAuth2Requester {
 
     async setTokens(params) {
         this.access_token = get(params, 'access_token');
-        this.team_access_token = get(params, 'access_token');
         this.refresh_token = get(params, 'refresh_token', null);
         const authedUser = get(params, 'authed_user', null);
         const accessExpiresIn = get(params, 'expires_in', null);

--- a/api-module-library/slack/manager.js
+++ b/api-module-library/slack/manager.js
@@ -82,7 +82,7 @@ class Manager extends ModuleManager {
         const externalId = isUserScopeAuthorized ?
             authInfo.authed_user.id : teamId;
 
-        await this.findOrCreateEntity({
+        await this.findOrCreateUserEntity({
             externalId: externalId,
             name: authInfo.team.name,
         });
@@ -139,7 +139,7 @@ class Manager extends ModuleManager {
         return [];
     }
 
-    async findOrCreateEntity(params) {
+    async findOrCreateUserEntity(params) {
         const externalId = get(params, 'externalId', null);
         const name = get(params, 'name', null);
 
@@ -195,7 +195,8 @@ class Manager extends ModuleManager {
 
     async updateOrCreateCredential() {
         const workspaceInfo = await this.api.authTest();
-        const externalId = workspaceInfo['bot_user_id'] ? get(workspaceInfo, 'team_id') : get(workspaceInfo, 'user_id');
+        const isTeamUser = workspaceInfo['bot_user_id'];
+        const externalId = isTeamUser ? get(workspaceInfo, 'team_id') : get(workspaceInfo, 'user_id');
         const updatedToken = {
             access_token: this.api.access_token,
             refresh_token: this.api.refresh_token,

--- a/api-module-library/slack/manager.js
+++ b/api-module-library/slack/manager.js
@@ -91,7 +91,7 @@ class Manager extends ModuleManager {
             type: Manager.getName(),
             credential_id: this.credential.id,
             entity_id: this.entity.id,
-            team_entity: null,
+            team_entity_id: null,
             auth_info: authInfo,
         };
 
@@ -101,7 +101,7 @@ class Manager extends ModuleManager {
                 teamId,
             });
 
-            returnObj.team_entity = teamEntity.id;
+            returnObj.team_entity_id = teamEntity.id;
         }
 
         return returnObj;

--- a/api-module-library/slack/manager.js
+++ b/api-module-library/slack/manager.js
@@ -92,6 +92,7 @@ class Manager extends ModuleManager {
             credential_id: this.credential.id,
             entity_id: this.entity.id,
             team_entity: null,
+            auth_info: authInfo,
         };
 
         if (isUserScopeAuthorized) {


### PR DESCRIPTION
Automatically creates and returns the team entity in Slack, in case user scopes exist in the auth flow. 
If there is no user scopes provided, it just creates the team entity.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-slack@0.2.2-canary.221.3ee830b.0
  # or 
  yarn add @friggframework/api-module-slack@0.2.2-canary.221.3ee830b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
