### PR TITLE
Fix to team entity creation - user should be null instead of 0

### DIFF
--- a/api-module-library/slack/manager.js
+++ b/api-module-library/slack/manager.js
@@ -125,7 +125,7 @@ class Manager extends ModuleManager {
             // create team entity
             const createObj = {
                 credential: credential.id,
-                user: 0,
+                user: null,
                 name: authInfo.team.name,
                 externalId: teamId,
             };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-slack@0.2.5-canary.223.b98e94a.0
  # or 
  yarn add @friggframework/api-module-slack@0.2.5-canary.223.b98e94a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
