### PR TITLE
Fix/Frontify refresh token url fixed

### DIFF
--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -42,6 +42,28 @@ class Api extends OAuth2Requester {
         return `${authorizationUri}?${querystring.stringify(query)}`;
     }
 
+    // Used because the Frontify API has a link to the refresh token that is different from the access token.
+    async refreshAccessToken(refreshTokenObject) {
+      this.access_token = undefined;
+      const params = new URLSearchParams();
+      params.append('grant_type', 'refresh_token');
+      params.append('client_id', this.client_id);
+      params.append('client_secret', this.client_secret);
+      params.append('refresh_token', refreshTokenObject.refresh_token);
+      params.append('redirect_uri', this.redirect_uri);
+
+      const options = {
+          body: params,
+          url: this.tokenRefresh,
+          headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+          },
+      };
+      const response = await this._post(options, false);
+      await this.setTokens(response);
+      return response;
+  }
+
     buildRequestOptions(query) {
         return {
             url: this.baseUrl,

--- a/api-module-library/frontify/api.js
+++ b/api-module-library/frontify/api.js
@@ -11,6 +11,7 @@ class Api extends OAuth2Requester {
         if (this.domain) {
             this.baseUrl = `https://${this.domain}/graphql`;
             this.tokenUri = `https://${this.domain}/api/oauth/accesstoken`;
+            this.tokenRefresh = `https://${this.domain}/api/oauth/refresh`;
         }
     }
 
@@ -18,7 +19,8 @@ class Api extends OAuth2Requester {
         this.domain = domain;
         this.baseUrl = `https://${this.domain}/graphql`;
         this.tokenUri = `https://${this.domain}/api/oauth/accesstoken`;
-    }
+        this.tokenRefresh = `https://${this.domain}/api/oauth/refresh`;
+      }
 
     getAuthUri() {
         const query = {

--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -22,6 +22,7 @@ describe(`${Config.label} API Tests`, () => {
                 expect(api.domain).toEqual('domain');
                 expect(api.baseUrl).toEqual('https://domain/graphql');
                 expect(api.tokenUri).toEqual('https://domain/api/oauth/accesstoken');
+                expect(api.tokenRefresh).toEqual('https://domain/api/oauth/refresh');
             });
         });
 
@@ -36,6 +37,7 @@ describe(`${Config.label} API Tests`, () => {
                 expect(api.domain).toBeNull();
                 expect(api.baseUrl).not.toBeDefined();
                 expect(api.tokenUri).not.toBeDefined();
+                expect(api.tokenRefresh).not.toBeDefined();
             });
         });
 
@@ -65,6 +67,7 @@ describe(`${Config.label} API Tests`, () => {
                 expect(api.domain).toEqual('my-domain');
                 expect(api.baseUrl).toEqual('https://my-domain/graphql');
                 expect(api.tokenUri).toEqual('https://my-domain/api/oauth/accesstoken');
+                expect(api.tokenRefresh).toEqual('https://my-domain/api/oauth/refresh');
             });
         });
     });
@@ -1889,7 +1892,7 @@ describe(`${Config.label} API Tests`, () => {
                           createAsset(input: {
                             fileId: "fileId",
                             title: "title",
-                            projectId: "projectId"
+                            parentId: "projectId"
                           }) {
                             job {
                               assetId

--- a/packages/module-plugin/requester/oauth-2.js
+++ b/packages/module-plugin/requester/oauth-2.js
@@ -111,7 +111,7 @@ class OAuth2Requester extends Requester {
 
         const options = {
             body: params,
-            url: this.tokenRefresh,
+            url: this.tokenUri,
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
             },

--- a/packages/module-plugin/requester/oauth-2.js
+++ b/packages/module-plugin/requester/oauth-2.js
@@ -111,7 +111,7 @@ class OAuth2Requester extends Requester {
 
         const options = {
             body: params,
-            url: this.tokenUri,
+            url: this.tokenRefresh,
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
             },


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@1.1.2-canary.226.6bf1ba9.0
  # or 
  yarn add @friggframework/api-module-frontify@1.1.2-canary.226.6bf1ba9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
