### PR TITLE
Feature/Add Frontify getRefreshAccessToken test

### DIFF
--- a/api-module-library/frontify/api.test.js
+++ b/api-module-library/frontify/api.test.js
@@ -72,6 +72,37 @@ describe(`${Config.label} API Tests`, () => {
         });
     });
 
+    describe('#getRefreshAccessToken', () => {
+        describe('Get refresh access token', () => {
+            let api;
+            let scope;
+            const url = 'https://my-domain';
+
+            beforeEach(() => {
+                api = new Api({
+                    domain: 'my-domain',
+                });
+
+                scope = nock(url)
+                    .post('/api/oauth/refresh')
+                    .reply(200, {
+                        access_token: 'access_token',
+                        refresh_token: 'refresh_token',
+                        expires_in: 'expires_in'
+                    });
+            });
+
+            it('should get refresh access token', async () => {
+                api.access_token = 'foobar';
+                const response = await api.refreshAccessToken({refresh_token: 'refresh_token'});
+                expect(response).toBeTruthy();
+                expect(api.access_token).not.toEqual('foobar');
+                expect(api.refresh_token).toEqual('refresh_token');
+                expect(api.tokenRefresh).toEqual(`${url}/api/oauth/refresh`);
+            });
+        });
+    });
+
     describe('#getAuthUri', () => {
         describe('Get with domain property present', () => {
             let api;


### PR DESCRIPTION
<img width="543" alt="image" src="https://github.com/friggframework/frigg/assets/40447063/982e31a2-6a5e-47f1-b58a-e2bd08ed88a5">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@1.1.3-canary.227.75df1ce.0
  # or 
  yarn add @friggframework/api-module-frontify@1.1.3-canary.227.75df1ce.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
