### PR TITLE
Microsoft Teams - skip conversation reference re-creation

### DIFF
--- a/api-module-library/microsoft-teams/api/api.js
+++ b/api-module-library/microsoft-teams/api/api.js
@@ -15,7 +15,7 @@ class Api {
         await this.botFrameworkApi.getTokenFromClientCredentials();
     }
 
-    async createConversationReferences(teamId=null){
+    async createConversationReferences(teamId=null, skipExisting=true){
         if (teamId) {
             this.graphApi.setTeamId(teamId);
         } else if (!this.graphApi.team_id) {
@@ -35,6 +35,9 @@ class Api {
                 channelId: teamChannel.id
             };
         await Promise.all(teamMembers.members.map(async (member) => {
+            if (skipExisting && this.botApi.conversationReferences[member.email]) {
+                return;
+            }
             await this.botApi.createConversationReference(initialRef, member);
         }));
         return this.botApi.conversationReferences;

--- a/api-module-library/microsoft-teams/package.json
+++ b/api-module-library/microsoft-teams/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@friggframework/api-module-microsoft-teams",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "prettier": "@friggframework/prettier-config",
     "description": "",
     "main": "index.js",

--- a/api-module-library/microsoft-teams/test/api.test.js
+++ b/api-module-library/microsoft-teams/test/api.test.js
@@ -30,6 +30,22 @@ describe('Test of cross API functionality', () => {
             expect(convRef[testEmail]).toBeDefined();
         });
 
+        it('Should not create the conversation references again', async () => {
+            api.botApi.createConversationReference = jest.fn().mockResolvedValueOnce({});
+           convRef = await api.createConversationReferences();
+            expect(convRef).toBeDefined();
+            expect(convRef[testEmail]).toBeDefined();
+            expect(api.botApi.createConversationReference).toHaveBeenCalledTimes(0);
+        })
+
+        it('Should only create the conversation references new members', async () => {
+            const ref = api.botApi.conversationReferences[testEmail];
+            delete api.botApi.conversationReferences[testEmail]
+            api.botApi.createConversationReference = jest.fn().mockResolvedValueOnce(ref);
+            await api.createConversationReferences();
+            expect(api.botApi.createConversationReference).toHaveBeenCalledTimes(1);
+            convRef[testEmail] = ref;
+        });
 
         it('Should send a proactive message from the bot', async () => {
             await api.botApi.sendProactive(testEmail, "hello from api.test.js!");
@@ -85,5 +101,7 @@ describe('Test of cross API functionality', () => {
             await api.botApi.sendProactive(testEmail, "hello from api.test.js again! woo!!");
 
         })
+
+
     });
 });


### PR DESCRIPTION
no longer re-create the conversation reference, by default, if a member already has one stored