### PR TITLE
Added variable BYPASS_ENCRYPTION_STAGE to encrypt module

### DIFF
--- a/packages/encrypt/README.md
+++ b/packages/encrypt/README.md
@@ -1,3 +1,13 @@
 # encrypt
 
 This package exports the `encrypt` mongoose plugin used in [Frigg](https://friggframework.org). You can find its documentation [on Frigg's website](https://docs.friggframework.org/packages/encrypt).
+
+## Configuration
+
+| Environment variable    | Description                                                                                                |
+|-------------------------|------------------------------------------------------------------------------------------------------------|
+| KMS_KEY_ARN             | The AWS KMS Key ARN, if using it to encryption/decryption.                                                 |
+| AES_KEY                 | AES key, used in conjunction with AES_KEY_ID. AES option is mutually exclusive with KMS_KEY_ARN.           |
+| AES_KEY_ID              | AES key ID, used in conjunction with AES_KEY.                                                              |
+| STAGE                   | The stage in which the application is running. It is usually defined in Serverless configuration, if used. |
+| BYPASS_ENCRYPTION_STAGE | Stages to bypass encryption/decryption, separated by comma.                                                |

--- a/packages/encrypt/encrypt.js
+++ b/packages/encrypt/encrypt.js
@@ -14,14 +14,20 @@ const findOneEvents = [
     'findOneAndReplace',
 ];
 
+const shouldBypassEncryption = (STAGE) => {
+    if (!process.env.BYPASS_ENCRYPTION_STAGE) {
+        return false;
+    }
+
+    const bypassStages = process.env.BYPASS_ENCRYPTION_STAGE.split(',').map((stage) => stage.trim());
+    return bypassStages.indexOf(STAGE) > -1;
+};
+
 // The Mongoose plug-in function
 function Encrypt(schema, options) {
     const { STAGE, KMS_KEY_ARN, AES_KEY_ID } = process.env;
-    const isEnabledForStage =
-        ['staging', 'QA', 'prod', 'encryption-test'].indexOf(STAGE) > -1;
 
-    // No-op if not enabled
-    if (!isEnabledForStage) {
+    if (shouldBypassEncryption(STAGE)) {
         return;
     }
 

--- a/packages/encrypt/encrypt.test.js
+++ b/packages/encrypt/encrypt.test.js
@@ -34,6 +34,7 @@ describe('Encrypt', () => {
             process.env = {
                 ...originalEnv,
                 STAGE: 'not-encryption-test',
+                BYPASS_ENCRYPTION_STAGE: 'not-encryption-test',
             };
 
             try {


### PR DESCRIPTION
This PR lets developers choose which stages they don't want db encryption. The STAGES were hardcoded, making it difficult if the user wanted to use a different environment and still have encryption enabled.