### PR TITLE
Working concept for having a sane default list of environments where we bypass field-level encryption

### DIFF
--- a/packages/encrypt/encrypt.js
+++ b/packages/encrypt/encrypt.js
@@ -15,11 +15,12 @@ const findOneEvents = [
 ];
 
 const shouldBypassEncryption = (STAGE) => {
-    if (!process.env.BYPASS_ENCRYPTION_STAGE) {
-        return false;
-    }
-
-    const bypassStages = process.env.BYPASS_ENCRYPTION_STAGE.split(',').map((stage) => stage.trim());
+    const bypassStageEnv = process.env.BYPASS_ENCRYPTION_STAGE;
+    // If the env is set to anything or an empty string, use the env. Otherwise, use the default array
+    const useEnv = !String(bypassStageEnv) || !!bypassStageEnv;
+    const bypassStages = useEnv
+        ? bypassStageEnv.split(',').map((stage) => stage.trim())
+        : ['dev', 'test', 'local', 'staging'];
     return bypassStages.indexOf(STAGE) > -1;
 };
 


### PR DESCRIPTION
@leofmds Thoughts on this approach?

I didn't get to run jest to tweak. Local error. Didn't feel like debugging.

Needed because now this defaults every env to encrypt, breaking folks inadvertently if they bump their packages (even any new api module update)