### PR TITLE
[Api Module] Fix: Google Calendar

### DIFF
--- a/api-module-library/google-calendar/definition.js
+++ b/api-module-library/google-calendar/definition.js
@@ -19,7 +19,7 @@ const Definition = {
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const entityDetails = await api.getTokenIdentity();
             return {
-                identifiers: { externalId: entityDetails.identifier, userId },
+                identifiers: { externalId: entityDetails.identifier, user: userId },
                 details: { name: entityDetails.name },
             }
         },

--- a/api-module-library/google-calendar/definition.js
+++ b/api-module-library/google-calendar/definition.js
@@ -8,7 +8,7 @@ const config = require('./defaultConfig.json')
 const Definition = {
     API: Api,
     getName: function () { return config.name },
-    name: config.name,//maybe not required
+    moduleName: config.name,//maybe not required
     Credential,
     Entity,
     requiredAuthMethods: {
@@ -16,15 +16,15 @@ const Definition = {
             const code = get(params.data, 'code');
             return api.getTokenFromCode(code);
         },
-        getEntityDetails: async function (api, callbackParams, tokenResponse) {
+        getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const entityDetails = await api.getTokenIdentity();
             return {
-                identifiers: { externalId: entityDetails.identifier },
+                identifiers: { externalId: entityDetails.identifier, userId },
                 details: { name: entityDetails.name },
             }
         },
         apiPropertiesToPersist: {
-            credential: ['access_token', 'refresh_token', 'userId'],
+            credential: ['access_token', 'refresh_token'],
             entity: [],
         },
         getCredentialDetails: async function (api) {

--- a/api-module-library/google-calendar/definition.js
+++ b/api-module-library/google-calendar/definition.js
@@ -1,37 +1,40 @@
 require('dotenv').config();
-const {Api} = require('./api');
+const { Api } = require('./api');
 const { Credential } = require('./models/credential');
 const { Entity } = require('./models/entity');
-const {get} = require("@friggframework/assertions");
+const { get } = require("@friggframework/assertions");
 const config = require('./defaultConfig.json')
 
 const Definition = {
     API: Api,
-    getName: function() {return config.name},
+    getName: function () { return config.name },
     name: config.name,//maybe not required
     Credential,
     Entity,
     requiredAuthMethods: {
-        getToken: async function(api, params){
+        getToken: async function (api, params) {
             const code = get(params.data, 'code');
             return api.getTokenFromCode(code);
         },
-        getEntityDetails: async function(api, callbackParams, tokenResponse) {
+        getEntityDetails: async function (api, callbackParams, tokenResponse) {
             const entityDetails = await api.getTokenIdentity();
             return {
                 identifiers: { externalId: entityDetails.identifier },
                 details: { name: entityDetails.name },
             }
         },
-        apiPropertiesToPersist: ['access_token', 'refresh_token', 'userId'],
-        getCredentialDetails: async function(api) {
+        apiPropertiesToPersist: {
+            credential: ['access_token', 'refresh_token', 'userId'],
+            entity: [],
+        },
+        getCredentialDetails: async function (api) {
             const userDetails = await api.getTokenIdentity();
             return {
-                identifiers: { externalId: userDetails.identifier},
+                identifiers: { externalId: userDetails.identifier },
                 details: {}
             };
         },
-        testAuthRequest: async function(api){
+        testAuthRequest: async function (api) {
             return await api.getUserDetails()
         },
     },

--- a/api-module-library/google-calendar/index.js
+++ b/api-module-library/google-calendar/index.js
@@ -3,6 +3,7 @@ const { Credential } = require('./models/credential');
 const { Entity } = require('./models/entity');
 const ModuleManager = require('./manager');
 const Config = require('./defaultConfig');
+const Definition = require('./definition');
 
 module.exports = {
     Api,
@@ -10,4 +11,5 @@ module.exports = {
     Entity,
     ModuleManager,
     Config,
+    Definition
 };


### PR DESCRIPTION
This PR is for fixing the Google Calendar API module.

We are exporting the Definition through `index.js`
and that would be the first change.

The second change was a bug i have encountered on the Auther that was giving me errors.

@sean showed me that the fix to this error would be:
```js
apiPropertiesToPersist: {
  credential: ['access_token','refresh_token'],
  entity: []
},
```

Because [Auther expects](https://github.com/friggframework/frigg/blob/813908d9b9c52c1f67d7f02a205f74cb31554dd4/packages/module-plugin/auther.js#L69) `definition.requiredAuthMethods.apiPropertiesToPersist.credential` to exist.

This is a change specifically for v1-alpha, not for Main at the given moment.