### PR TITLE
Fix the redirect_uri passed by the user in getInstance method

### DIFF
--- a/api-module-library/slack/manager.js
+++ b/api-module-library/slack/manager.js
@@ -30,7 +30,7 @@ class Manager extends ModuleManager {
         let instance = new this(params);
 
         const apiParams = { delegate: instance };
-        if (this.redirect_uri) apiParams.redirect_uri = this.redirect_uri;
+        if (instance.redirect_uri) apiParams.redirect_uri = instance.redirect_uri;
         if (params.entityId) {
             instance.entity = await Entity.findById(params.entityId);
             instance.credential = await Credential.findById(


### PR DESCRIPTION
The `redirect_uri` was being grabbed from `this` inside a static method, which doesn't work. Now it gets the redirect_uri from the created `instance`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-slack@0.2.8-canary.255.230c6c6.0
  # or 
  yarn add @friggframework/api-module-slack@0.2.8-canary.255.230c6c6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
