### PR TITLE
revert HEAD to a corrected v1-connectwise release

### DIFF
--- a/api-module-library/connectwise/package.json
+++ b/api-module-library/connectwise/package.json
@@ -12,7 +12,6 @@
     "license": "MIT",
     "devDependencies": {
         "@friggframework/devtools": "^1.1.0",
-        "@friggframework/eslint-config": "^1.0.8",
         "eslint": "^8.22.0",
         "jest": "^28.1.3",
         "prettier": "^2.7.1",


### PR DESCRIPTION
the goal of this is to undo the last two merges, and correctly release connectwise v1 before then replaying+merging the `devtools` changes