### PR TITLE
Remove user ID check from createIntegration

### DIFF
--- a/packages/integrations/manager.js
+++ b/packages/integrations/manager.js
@@ -180,12 +180,6 @@ class IntegrationManager extends Delegate {
             if (!entity) {
                 throw new Error(`Entity with ID ${id} does not exist.`);
             }
-
-            if (entity.user.toString() !== userId.toString()) {
-                throw new Error(
-                    'one or more the entities do not belong to the user'
-                );
-            }
         }
 
         // build integration


### PR DESCRIPTION
The Slack API module uses a many to 1 mapping of integrations to Slack entities when those integrations all connect to the same Slack workspace. However, this conflicts with the user ID check here which will throw an error if the user IDs don't match.