### PR TITLE
feat: Add updateFileMetadata function to google-drive api

### DIFF
--- a/api-module-library/google-drive/api.js
+++ b/api-module-library/google-drive/api.js
@@ -96,6 +96,15 @@ class Api extends OAuth2Requester {
         return this._post(options)
     }
 
+    async updateFileMetadata(fileId, query, body) {
+        const options = {
+            url: this.baseUrl + this.URLs.fileById(fileId),
+            query,
+            body,
+        };
+        return this._patch(options);
+    }
+
     async getFile(fileId, query) {
         const options = {
             url: this.baseUrl + this.URLs.fileById(fileId),


### PR DESCRIPTION
This PR adds `updateFileMetadata` function to facilitate updating files metadata
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-google-drive@0.5.0-canary.308.be65030.0
  # or 
  yarn add @friggframework/api-module-google-drive@0.5.0-canary.308.be65030.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
