### PR TITLE
Fixes for Microsoft Teams conversation references

### DIFF
--- a/api-module-library/microsoft-teams/api/bot.js
+++ b/api-module-library/microsoft-teams/api/bot.js
@@ -160,6 +160,10 @@ class Bot extends TeamsActivityHandler {
         await this.adapter.createConversation(initialRef, async (context) => {
             const ref = TurnContext.getConversationReference(context.activity);
             memberInfo = await this.adapter.getConversationMembers(context);
+            ref.user = {
+                ...memberInfo[0],
+                aadObjectId: memberInfo[0].objectId,
+            };
             this.conversationReferences[memberInfo[0].email] = ref;
         });
     }

--- a/api-module-library/microsoft-teams/api/bot.js
+++ b/api-module-library/microsoft-teams/api/bot.js
@@ -113,9 +113,11 @@ const invokeResponse = (card) => {
 };
 
 class Bot extends TeamsActivityHandler {
+    #conversationReferences;
+
     constructor(adapter, conversationReferences) {
         super();
-        this.conversationReferences = conversationReferences;
+        this.#conversationReferences = conversationReferences;
         this.adapter = adapter;
         this.onMembersAdded(async (context, next) => {
             const membersAdded = context.activity.membersAdded;
@@ -160,7 +162,7 @@ class Bot extends TeamsActivityHandler {
         await this.adapter.createConversation(initialRef, async (context) => {
             const ref = TurnContext.getConversationReference(context.activity);
             memberInfo = await this.adapter.getConversationMembers(context);
-            this.conversationReferences[memberInfo[0].email] = ref;
+            this.#conversationReferences[memberInfo[0].email] = ref;
         });
     }
 }

--- a/api-module-library/microsoft-teams/api/bot.js
+++ b/api-module-library/microsoft-teams/api/bot.js
@@ -113,11 +113,9 @@ const invokeResponse = (card) => {
 };
 
 class Bot extends TeamsActivityHandler {
-    #conversationReferences;
-
     constructor(adapter, conversationReferences) {
         super();
-        this.#conversationReferences = conversationReferences;
+        this.conversationReferences = conversationReferences;
         this.adapter = adapter;
         this.onMembersAdded(async (context, next) => {
             const membersAdded = context.activity.membersAdded;
@@ -162,7 +160,7 @@ class Bot extends TeamsActivityHandler {
         await this.adapter.createConversation(initialRef, async (context) => {
             const ref = TurnContext.getConversationReference(context.activity);
             memberInfo = await this.adapter.getConversationMembers(context);
-            this.#conversationReferences[memberInfo[0].email] = ref;
+            this.conversationReferences[memberInfo[0].email] = ref;
         });
     }
 }


### PR DESCRIPTION
- Filter out the bot from the conversation members, so we don't attempt to create a conversation with the bot. This was throwing an error.
- Use a getter and setter to make sure `botApi#conversationReferences` and `Bot#conversationReferences` reference the same object. Previously, these would get out of sync if you do something like `botApi.conversationReferences = {...}`.
- Apply lint formatting.
- Populate the conversation reference with extra user data.