### PR TITLE
Feature: For Hubspot API module make redirect uri and state overridable

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
 
     steps:
       - name: Check Out Code ⤵️

--- a/api-module-library/hubspot/api.js
+++ b/api-module-library/hubspot/api.js
@@ -54,15 +54,21 @@ class Api extends OAuth2Requester {
             
         };
 
-        this.authorizationUri = encodeURI(
-            `https://app.hubspot.com/oauth/authorize?client_id=${this.client_id}&redirect_uri=${this.redirect_uri}&scope=${this.scope}&state=${this.state}`
-        );
         this.tokenUri = 'https://api.hubapi.com/oauth/v1/token';
 
         this.access_token = get(params, 'access_token', null);
         this.refresh_token = get(params, 'refresh_token', null);
     }
-    async getAuthUri() {
+
+    async getAuthUri(params = { redirect_uri: null, state: null }) {
+        const redirectURI = params.redirect_uri || this.redirect_uri;
+        const state = params.state ? JSON.stringify(params.state) : this.state;
+        this.authorizationUri = [
+            `https://app.hubspot.com/oauth/authorize?client_id=${this.client_id}`,
+            `redirect_uri=${redirectURI}`,
+            `scope=${this.scope}`,
+            `state=${state}`
+        ].join('&');
         return this.authorizationUri;
     }
 

--- a/api-module-library/hubspot/manager.js
+++ b/api-module-library/hubspot/manager.js
@@ -59,9 +59,9 @@ class Manager extends ModuleManager {
         return validAuth;
     }
 
-    async getAuthorizationRequirements() {
+    async getAuthorizationRequirements(params = { redirect_uri: null, state: null }) {
         return {
-            url: await this.api.getAuthUri(),
+            url: await this.api.getAuthUri(params),
             type: 'oauth2',
         };
     }

--- a/api-module-library/hubspot/tests/manager.test.js
+++ b/api-module-library/hubspot/tests/manager.test.js
@@ -27,6 +27,12 @@ describe(`Should fully test the ${config.label} Manager`, () => {
         expect(requirements.type).to.equal('oauth2');
         authUrl = requirements.url;
     });
+
+    it('getAuthorizationRequirements() allows to override redirect_uri and state', async () => {
+        const requirements = await manager.getAuthorizationRequirements({ redirect_uri: 'http://example.com', state: { test: "123" } });
+        expect(requirements.url).to.equal(`https://app.hubspot.com/oauth/authorize?client_id=${process.env.HUBSPOT_CLIENT_ID}&redirect_uri=http://example.com&scope=${process.env.HUBSPOT_SCOPE}&state={\"test\":\"123\"}`);
+    });
+
     describe('processAuthorizationCallback()', () => {
         it('should return auth details', async () => {
             const response = await Authenticator.oauth2(authUrl);

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "contributors:generate": "all-contributors generate"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=7"
+    "node": "^18.17.0",
+    "npm": "10.8.2"
   },
   "author": "seanspeaks <sean.matthews@lefthook.co>",
   "license": "MIT",


### PR DESCRIPTION
This PR implements an optional `params` parameter to the getAuthorizationRequirements method that is an object containing redirect_uri and state properties. This will be useful when someone wants to pass a custom redirect_uri or state object to the Oauth flow.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-hubspot@0.11.3-canary.320.5b231d6.0
  # or 
  yarn add @friggframework/api-module-hubspot@0.11.3-canary.320.5b231d6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
