### PR TITLE
feat: allow redirect_uri to be passed as parameter for getInstance

### DIFF
--- a/api-module-library/hubspot/manager.js
+++ b/api-module-library/hubspot/manager.js
@@ -31,7 +31,7 @@ class Manager extends ModuleManager {
             client_id: process.env.HUBSPOT_CLIENT_ID,
             client_secret: process.env.HUBSPOT_CLIENT_SECRET,
             scope: process.env.HUBSPOT_SCOPE,
-            redirect_uri: `${process.env.REDIRECT_URI}/hubspot`,
+            redirect_uri: params.redirect_uri ?? `${process.env.REDIRECT_URI}/hubspot`,
             delegate: instance,
         };
 


### PR DESCRIPTION
This PR allows the redirect_uri to be passed as parameter for the getInstance method in order to override the default redirect_uri format.