### PR TITLE
Fix bug during local running

### DIFF
--- a/packages/core/module-plugin/module-factory.js
+++ b/packages/core/module-plugin/module-factory.js
@@ -1,12 +1,10 @@
-const { Entity } = require("./entity");
+const { Entity } = require('./entity');
 const { Auther } = require('./auther');
 
 class ModuleFactory {
     constructor(...params) {
         this.moduleDefinitions = params;
-        this.moduleTypes = this.moduleDefinitions.map(
-            (def) => def.moduleName
-        );
+        this.moduleTypes = this.moduleDefinitions.map((def) => def.moduleName);
     }
 
     async getEntitiesForUser(userId) {
@@ -14,7 +12,7 @@ class ModuleFactory {
         for (const moduleDefinition of this.moduleDefinitions) {
             const moduleInstance = await Auther.getInstance({
                 userId,
-                definition: moduleDefinition
+                definition: moduleDefinition,
             });
             const list = await moduleInstance.getEntitiesForUserId(userId);
             results.push(...list);
@@ -27,33 +25,36 @@ class ModuleFactory {
     }
 
     getModuleDefinitionFromTypeName(typeName) {
-        return
+        return;
     }
-
 
     async getModuleInstanceFromEntityId(entityId, userId) {
         const entity = await Entity.findById(entityId);
         const moduleDefinition = this.moduleDefinitions.find(
-            (def) => entity['__t'] === Auther.getEntityModelFromDefinition(def).modelName
-        )
+            (def) =>
+                entity.toJSON()['__t'] ===
+                Auther.getEntityModelFromDefinition(def).modelName
+        );
         if (!moduleDefinition) {
-            throw new Error('Module definition not found for entity type: ' + entity['__t']);
+            throw new Error(
+                'Module definition not found for entity type: ' + entity['__t']
+            );
         }
         return await Auther.getInstance({
             userId,
             entityId,
-            definition: moduleDefinition
+            definition: moduleDefinition,
         });
     }
 
-     async getInstanceFromTypeName(typeName, userId) {
-        const moduleDefinition =this.moduleDefinitions.find(
+    async getInstanceFromTypeName(typeName, userId) {
+        const moduleDefinition = this.moduleDefinitions.find(
             (def) => def.getName() === typeName
         );
-         return await Auther.getInstance({
-             userId,
-             definition: moduleDefinition
-         });
+        return await Auther.getInstance({
+            userId,
+            definition: moduleDefinition,
+        });
     }
 }
 


### PR DESCRIPTION
When running an app locally, the first time an integration record is retrieved by ID and the module-factory is run, the app errors out.

Specifically, `getModuleInstanceFromEntityId` fails to find the moduleDefinition, only on the first invocation.

After debugging with logs and inspection, it looks like mongoose (current version?) fails to initialize the descriminator decorator on the mongoose object being evaluated (`entity['__t']` comes up `undefined`). Subsequent requests succeed. This makes me believe there's something to do with initializing the mongoDB connection or mongoose collections. 

One patch fix here is to force the mongoose object to finish initializing by calling toJSON.

Works locally for me, unclear how to write the test to prove it out.