### PR TITLE
Fix Microsoft Graph API token refresh

### DIFF
--- a/api-module-library/microsoft-teams/api/graph.js
+++ b/api-module-library/microsoft-teams/api/graph.js
@@ -75,6 +75,28 @@ class graphApi extends OAuth2Requester {
         }
     }
 
+    async refreshAccessToken(refreshTokenObject) {
+        this.access_token = undefined;
+        const params = new URLSearchParams();
+        params.append('grant_type', 'refresh_token');
+        params.append('client_id', this.client_id);
+        params.append('client_secret', this.client_secret);
+        params.append('refresh_token', refreshTokenObject.refresh_token);
+        params.append('redirect_uri', this.redirect_uri);
+        params.append('scope', this.scope);
+
+        const options = {
+            body: params,
+            url: this.tokenUri,
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+        };
+        const response = await this._post(options, false);
+        await this.setTokens(response);
+        return response;
+    }
+
     setTenantId(tenantId) {
         this.tenant_id = tenantId;
         this.generateUrls();


### PR DESCRIPTION
The default token refresh behavior was not working correctly for Microsoft's Graph API. Since the default refresh call does not include a `scope` param, the returned token had no permissions and resulted in 403 errors. This PR overrides `refreshAccessToken` in `graph.js` to include the `scope` param.

This also fixes another bug where the refreshed token was not getting saved to Mongo. `findAndUpsertCredential` expected the `tenant_id` to be defined on the instance, but it was currently not defined. So I added a line in `getInstance` that sets the `tenant_id` after fetching the entity.