### PR TITLE
Lots going on here. Updating the Integraton Base class, which may need a different name? Basically, this loads up the class with helper methods and functions that are used by the rest of Frigg core to be able to take advantage of new updates and concepts in Frigg v2. - Removes the legacy "notify" concept with the "delegate" pattern. - Replaces with "send", which is similar in concept to a state machine send that XState uses. But ultimately it's sending an event to the integration instance, with data, which ultimately invokes the handler found at the "on" event register. - Adds an event handler registration method and flow, whereby standard/default/lifecycle events are added to the register - Adds user action concepts/loaders - Adds a few other helper functions intended to be used in various implementation moments across the framework - Centralizes the "Definition" concept so that there's a static definition and a dynamic constructor-based loading of instance variables and event handlers

### DIFF
--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -1,41 +1,122 @@
 const { IntegrationMapping } = require('./integration-mapping');
+const { Options } = require('./options');
+const constantsToBeMigrated = {
+    defaultEvents: {
+        ON_CREATE: 'ON_CREATE',
+        ON_UPDATE: 'ON_UPDATE',
+        ON_DELETE: 'ON_DELETE',
+        GET_CONFIG_OPTIONS: 'GET_CONFIG_OPTIONS',
+        REFRESH_CONFIG_OPTIONS: 'REFRESH_CONFIG_OPTIONS',
+        GET_USER_ACTIONS: 'GET_USER_ACTIONS',
+        GET_USER_ACTION_OPTIONS: 'GET_USER_ACTION_OPTIONS',
+        REFRESH_USER_ACTION_OPTIONS: 'REFRESH_USER_ACTION_OPTIONS',
+        // etc...
+    },
+    types: {
+        LIFE_CYCLE_EVENT: 'LIFE_CYCLE_EVENT',
+        USER_ACTION: 'USER_ACTION',
+    },
+};
 
 class IntegrationBase {
+    static getOptionDetails() {
+        const options = new Options({
+            module: Object.values(this.Definition.modules)[0], // This is a placeholder until we revamp the frontend
+            ...this.Definition,
+        });
+        return options.get();
+    }
     /**
-     * CHILDREN SHOULD SPECIFY A CONFIG
+     * CHILDREN SHOULD SPECIFY A DEFINITION FOR THE INTEGRATION
      */
-    static Config = {
+    static Definition = {
         name: 'Integration Name',
         version: '0.0.0', // Integration Version, used for migration and storage purposes, as well as display
         supportedVersions: [], // Eventually usable for deprecation and future test version purposes
 
-        // an array of events that are process(able) by this Integration
-        events: [],
+        modules: {},
+        display: {
+            name: 'Integration Name',
+            logo: '',
+            description: '',
+            // etc...
+        },
     };
 
     static getName() {
-        return this.Config.name;
+        return this.Definition.name;
     }
 
     static getCurrentVersion() {
-        return this.Config.version;
+        return this.Definition.version;
+    }
+    loadModules() {
+        // Load all the modules defined in Definition.modules
+        const moduleNames = Object.keys(this.constructor.Definition.modules);
+        for (const moduleName of moduleNames) {
+            const { definition } =
+                this.constructor.Definition.modules[moduleName];
+            if (typeof definition.API === 'function') {
+                this[moduleName] = { api: new definition.API() };
+            } else {
+                throw new Error(
+                    `Module ${moduleName} must be a function that extends IntegrationModule`
+                );
+            }
+        }
+    }
+    registerEventHandlers() {
+        this.on = {
+            ...this.defaultEvents,
+            ...this.events,
+        };
     }
 
     constructor(params) {
-        this.delegateTypes = [];
-        this.userActions = [];
+        this.defaultEvents = {
+            [constantsToBeMigrated.defaultEvents.ON_CREATE]: {
+                type: constantsToBeMigrated.types.LIFE_CYCLE_EVENT,
+                handler: this.onCreate,
+            },
+            [constantsToBeMigrated.defaultEvents.ON_UPDATE]: {
+                type: constantsToBeMigrated.types.LIFE_CYCLE_EVENT,
+                handler: this.onUpdate,
+            },
+            [constantsToBeMigrated.defaultEvents.ON_DELETE]: {
+                type: constantsToBeMigrated.types.LIFE_CYCLE_EVENT,
+                handler: this.onDelete,
+            },
+            [constantsToBeMigrated.defaultEvents.GET_CONFIG_OPTIONS]: {
+                type: constantsToBeMigrated.types.LIFE_CYCLE_EVENT,
+                handler: this.getConfigOptions,
+            },
+            [constantsToBeMigrated.defaultEvents.REFRESH_CONFIG_OPTIONS]: {
+                type: constantsToBeMigrated.types.LIFE_CYCLE_EVENT,
+                handler: this.refreshConfigOptions,
+            },
+            [constantsToBeMigrated.defaultEvents.GET_USER_ACTIONS]: {
+                type: constantsToBeMigrated.types.LIFE_CYCLE_EVENT,
+                handler: this.loadUserActions,
+            },
+            [constantsToBeMigrated.defaultEvents.GET_USER_ACTION_OPTIONS]: {
+                type: constantsToBeMigrated.types.LIFE_CYCLE_EVENT,
+                handler: this.getActionOptions,
+            },
+            [constantsToBeMigrated.defaultEvents.REFRESH_USER_ACTION_OPTIONS]: {
+                type: constantsToBeMigrated.types.LIFE_CYCLE_EVENT,
+                handler: this.refreshActionOptions,
+            },
+        };
+        this.loadModules();
     }
 
-    //psuedo delegate for backwards compatability
-    async receiveNotification(notifier, delegateString, object = null) {}
-
-    async notify(delegateString, object = null) {
-        if (!this.delegateTypes.includes(delegateString)) {
+    async send(event, object) {
+        if (!this.on[event]) {
             throw new Error(
-                `delegateString:${delegateString} is not defined in delegateTypes`
+                `Event ${event} is not defined in the Integration event object`
             );
         }
-        return this.receiveNotification(this, delegateString, object);
+        return this.on[event].handler.call(this, object);
     }
 
     async validateConfig() {
@@ -69,28 +150,20 @@ class IntegrationBase {
     async testAuth() {
         let didAuthPass = true;
 
-        try {
-            await this.primary.testAuth();
-        } catch {
-            didAuthPass = false;
-            this.record.messages.errors.push({
-                title: 'Authentication Error',
-                message: `There was an error with your ${this.primary.constructor.getName()} Entity.
+        for (const module of Object.keys(IntegrationBase.Definition.modules)) {
+            try {
+                await this[module].testAuth();
+            } catch {
+                didAuthPass = false;
+                this.record.messages.errors.push({
+                    title: 'Authentication Error',
+                    message: `There was an error with your ${this[
+                        module
+                    ].constructor.getName()} Entity.
                 Please reconnect/re-authenticate, or reach out to Support for assistance.`,
-                timestamp: Date.now(),
-            });
-        }
-
-        try {
-            await this.target.testAuth();
-        } catch {
-            didAuthPass = false;
-            this.record.messages.errors.push({
-                title: 'Authentication Error',
-                message: `There was an error with your ${this.target.constructor.getName()} Entity.
-            Please reconnect/re-authenticate, or reach out to Support for assistance.`,
-                timestamp: Date.now(),
-            });
+                    timestamp: Date.now(),
+                });
+            }
         }
 
         if (!didAuthPass) {
@@ -113,15 +186,6 @@ class IntegrationBase {
             sourceId,
             mapping
         );
-    }
-
-    async getAndSetUserActions() {
-        this.userActions = await this.getUserActions();
-        if (this.record?.config) {
-            this.record.config.userActions = this.userActions;
-            await this.record.save();
-        }
-        return this.userActions;
     }
 
     /**
@@ -153,11 +217,34 @@ class IntegrationBase {
         return options;
     }
 
-    async getUserActions() {
-        return [];
+    async loadDynamicUserActions() {
+        // Child class should override this method to load dynamic user actions.
+        // Dynamic user actions should return in the same form a valid event object
+
+        return {};
+    }
+    async loadUserActions({ actionType } = {}) {
+        console.log('loadUserActions called with actionType:', actionType);
+        const userActions = {};
+        for (const [key, event] of Object.entries(this.events)) {
+            if (event.type === constantsToBeMigrated.types.USER_ACTION) {
+                if (!actionType || event.userActionType === actionType) {
+                    userActions[key] = event;
+                }
+            }
+        }
+        const dynamicUserActions = await this.loadDynamicUserActions();
+        const filteredDynamicActions = actionType
+            ? Object.fromEntries(
+                  Object.entries(dynamicUserActions).filter(
+                      ([_, event]) => event.userActionType === actionType
+                  )
+              )
+            : dynamicUserActions;
+        return { ...userActions, ...filteredDynamicActions };
     }
 
-    async getActionOptions() {
+    async getActionOptions(actionId, data) {
         const options = {
             jsonSchema: {},
             uiSchema: {},


### PR DESCRIPTION
- Removes the legacy "notify" concept with the "delegate" pattern.
- Replaces with "send", which is similar in concept to a state machine send that XState uses. But ultimately it's sending an event to the integration instance, with data, which ultimately invokes the handler found at the "on" event register.
- Adds an event handler registration method and flow, whereby standard/default/lifecycle events are added to the register
- Adds user action concepts/loaders
- Adds a few other helper functions intended to be used in various implementation moments across the framework
- Centralizes the "Definition" concept so that there's a static definition and a dynamic constructor-based loading of instance variables and event handlers

All of these should likely be combined with another few commits. And tested with the v1.3 prototyping repo.