### PR TITLE
Update the integration-factory to take advantage of/utilize the new methods for the integration-base.

### DIFF
--- a/packages/core/integrations/integration-model.js
+++ b/packages/core/integrations/integration-model.js
@@ -9,6 +9,10 @@ const schema = new mongoose.Schema(
                 required: true,
             },
         ],
+        entityReference: {
+            type: mongoose.Schema.Types.Map,
+            of: String,
+        },
         user: {
             type: mongoose.Schema.Types.ObjectId,
             ref: 'User',


### PR DESCRIPTION
# Add entityReference to Integration Model and Update Integration Factory

Add the entityReference field to the Integration Model and update the Integration Factory to support name-based module references. This enhancement allows developers to import the same API module multiple times with different intended purposes, such as slack-admin and slack-user.

Key changes:
- Add `entityReference` field to the Integration Model schema
- Update `getInstanceFromIntegrationId` method in Integration Factory to handle entityReference
- Implement `getModuleTypesAndKeys` method to map module types to keys
- Improve error handling for duplicate module types
- Update module loading logic to support both entityReference and default behavior

This update provides more flexibility in integration configurations and should be paired with other integration-related updates for full functionality.