### PR TITLE
Update integration-router to use the new .send method and default lifecycle events.

### DIFF
--- a/packages/core/integrations/options.js
+++ b/packages/core/integrations/options.js
@@ -1,6 +1,5 @@
 const { RequiredPropertyError } = require('../errors');
 const { get, getAndVerifyType } = require('../assertions');
-const { ModuleManager } = require('../module-plugin');
 
 class Options {
     constructor(params) {
@@ -18,7 +17,7 @@ class Options {
         }
 
         this.display = {};
-        this.display.name = get(params.display, 'name');
+        this.display.name = get(params.display, 'label');
         this.display.description = get(params.display, 'description');
         this.display.detailsUrl = get(params.display, 'detailsUrl');
         this.display.icon = get(params.display, 'icon');
@@ -26,7 +25,7 @@ class Options {
 
     get() {
         return {
-            type: this.module.getName(),
+            type: this.module.definition.getName(),
 
             // Flag for if the User can configure any settings
             hasUserConfig: this.hasUserConfig,


### PR DESCRIPTION
Update the "options" class to read from the updated integration and module Definition fields properly.

The main changes include:
- Updating `this.display.name` to read from `params.display.label` instead of `params.display.name`
- Changing `this.module.getName()` to `this.module.definition.getName()`

Formatting automatically applied via prettier/eslint fix for the integration-router.js and auther.js files.

The integration-router.js file has been updated to use the new `send` method for various integration actions, replacing direct method calls like `onCreate`, `onUpdate`, `onDelete`, etc.