### PR TITLE
Add Programmatic Serverless

### DIFF
--- a/packages/devtools/index.js
+++ b/packages/devtools/index.js
@@ -1,5 +1,7 @@
 const test = require('./test');
+const { createFriggInfrastructure } = require('./infrastructure');
 
 module.exports = {
-    ...test
-}
+    createFriggInfrastructure,
+    ...test,
+};

--- a/packages/devtools/infrastructure/app-handler-helpers.js
+++ b/packages/devtools/infrastructure/app-handler-helpers.js
@@ -1,0 +1,57 @@
+const { createHandler, flushDebugLog } = require('@friggframework/core');
+const express = require('express');
+const bodyParser = require('body-parser');
+const cors = require('cors');
+const Boom = require('@hapi/boom');
+const loadUserManager = require('./routers/middleware/loadUser');
+const serverlessHttp = require('serverless-http');
+
+const createApp = (applyMiddleware) => {
+    const app = express();
+
+    app.use(bodyParser.json({ limit: '10mb' }));
+    app.use(bodyParser.urlencoded({ extended: true }));
+    app.use(
+        cors({
+            origin: '*',
+            credentials: true,
+        })
+    );
+
+    app.use(loadUserManager);
+
+    if (applyMiddleware) applyMiddleware(app);
+
+    // Handle sending error response and logging server errors to console
+    app.use((err, req, res, next) => {
+        const boomError = err.isBoom ? err : Boom.boomify(err);
+        const {
+            output: { statusCode = 500 },
+        } = boomError;
+
+        if (statusCode >= 500) {
+            flushDebugLog(boomError);
+            res.status(statusCode).json({ error: 'Internal Server Error' });
+        } else {
+            res.status(statusCode).json({ error: err.message });
+        }
+    });
+
+    return app;
+};
+
+function createAppHandler(eventName, router, shouldUseDatabase = true) {
+    const app = createApp((app) => {
+        app.use(router);
+    });
+    return createHandler({
+        eventName,
+        method: serverlessHttp(app),
+        shouldUseDatabase,
+    });
+}
+
+module.exports = {
+    createApp,
+    createAppHandler,
+};

--- a/packages/devtools/infrastructure/backend-utils.js
+++ b/packages/devtools/infrastructure/backend-utils.js
@@ -1,0 +1,90 @@
+const { createFriggBackend, Worker } = require('@friggframework/core');
+const {
+    findNearestBackendPackageJson,
+} = require('../frigg-cli/utils/backend-path');
+const path = require('path');
+const fs = require('fs-extra');
+
+const backendPath = findNearestBackendPackageJson();
+if (!backendPath) {
+    throw new Error('Could not find backend package.json');
+}
+
+const backendDir = path.dirname(backendPath);
+const backendFilePath = path.join(backendDir, 'index.js');
+if (!fs.existsSync(backendFilePath)) {
+    throw new Error('Could not find index.js');
+}
+
+const backendJsFile = require(backendFilePath);
+const { Router } = require('express');
+const appDefinition = backendJsFile.Definition;
+
+const backend = createFriggBackend(appDefinition);
+const loadRouterFromObject = (IntegrationClass, routerObject) => {
+    const router = Router();
+    const { path, method, event } = routerObject;
+    console.log(
+        `Registering ${method} ${path} for ${IntegrationClass.Definition.name}`
+    );
+    router[method.toLowerCase()](path, async (req, res, next) => {
+        try {
+            const integration = new IntegrationClass({});
+            await integration.loadModules();
+            await integration.registerEventHandlers();
+            const result = await integration.send(event, req.body);
+            res.json(result);
+        } catch (error) {
+            next(error);
+        }
+    });
+
+    return router;
+};
+const createQueueWorker = (integrationClass) => {
+    class QueueWorker extends Worker {
+        constructor(params) {
+            super(params);
+        }
+        async _run(params, context) {
+            try {
+                let instance;
+                if (!params.integrationId) {
+                    instance = new integrationClass({});
+                    await instance.loadModules();
+                    // await instance.loadUserActions();
+                    await instance.registerEventHandlers();
+                    console.log(
+                        `${params.event} for ${integrationClass.Definition.name} integration with no integrationId`
+                    );
+                } else {
+                    instance =
+                        await integrationClass.getInstanceFromIntegrationId({
+                            integrationId: params.integrationId,
+                        });
+                    console.log(
+                        `${params.event} for ${instance.integration.config.type} of integrationId: ${params.integrationId}`
+                    );
+                }
+                const res = await instance.send(params.event, {
+                    data: params.data,
+                    context,
+                });
+                return res;
+            } catch (error) {
+                console.error(
+                    `Error in ${params.event} for ${integrationClass.Definition.name}:`,
+                    error
+                );
+                throw error;
+            }
+        }
+    }
+    return QueueWorker;
+};
+
+module.exports = {
+    ...backend,
+    loadRouterFromObject,
+    createQueueWorker,
+};

--- a/packages/devtools/infrastructure/create-frigg-infrastructure.js
+++ b/packages/devtools/infrastructure/create-frigg-infrastructure.js
@@ -1,0 +1,38 @@
+const path = require('path');
+const fs = require('fs-extra');
+const { composeServerlessDefinition } = require('./serverless-template');
+
+const {
+    findNearestBackendPackageJson,
+} = require('../frigg-cli/utils/backend-path');
+
+function createFriggInfrastructure() {
+    const backendPath = findNearestBackendPackageJson();
+    if (!backendPath) {
+        throw new Error('Could not find backend package.json');
+    }
+
+    const backendDir = path.dirname(backendPath);
+    const backendFilePath = path.join(backendDir, 'index.js');
+    if (!fs.existsSync(backendFilePath)) {
+        throw new Error('Could not find index.js');
+    }
+
+    const backend = require(backendFilePath);
+    const appDefinition = backend.Definition;
+
+    // const serverlessTemplate = require(path.resolve(
+    //     __dirname,
+    //     './serverless-template.js'
+    // ));
+    const definition = composeServerlessDefinition(
+        appDefinition,
+        backend.IntegrationFactory
+    );
+
+    return {
+        ...definition,
+    };
+}
+
+module.exports = { createFriggInfrastructure };

--- a/packages/devtools/infrastructure/index.js
+++ b/packages/devtools/infrastructure/index.js
@@ -1,0 +1,4 @@
+const { createFriggInfrastructure } = require('./create-frigg-infrastructure');
+module.exports = {
+    createFriggInfrastructure,
+};

--- a/packages/devtools/infrastructure/routers/auth.js
+++ b/packages/devtools/infrastructure/routers/auth.js
@@ -1,0 +1,26 @@
+const { createIntegrationRouter } = require('@friggframework/core');
+const { createAppHandler } = require('./../app-handler-helpers');
+const { requireLoggedInUser } = require('./middleware/requireLoggedInUser');
+const {
+    moduleFactory,
+    integrationFactory,
+    IntegrationHelper,
+} = require('./../backend-utils');
+
+const router = createIntegrationRouter({
+    factory: { moduleFactory, integrationFactory, IntegrationHelper },
+    requireLoggedInUser,
+    getUserId: (req) => req.user.getUserId(),
+});
+
+router.route('/redirect/:appId').get((req, res) => {
+    res.redirect(
+        `${process.env.FRONTEND_URI}/redirect/${
+            req.params.appId
+        }?${new URLSearchParams(req.query)}`
+    );
+});
+
+const handler = createAppHandler('HTTP Event: Auth', router);
+
+module.exports = { handler, router };

--- a/packages/devtools/infrastructure/routers/integration-defined-routers.js
+++ b/packages/devtools/infrastructure/routers/integration-defined-routers.js
@@ -1,0 +1,37 @@
+const { createIntegrationRouter } = require('@friggframework/core');
+const { createAppHandler } = require('./../app-handler-helpers');
+const { requireLoggedInUser } = require('./middleware/requireLoggedInUser');
+const {
+    moduleFactory,
+    integrationFactory,
+    IntegrationHelper,
+    loadRouterFromObject,
+} = require('./../backend-utils');
+const { Router } = require('express');
+
+const handlers = {};
+integrationFactory.integrationClasses.forEach((IntegrationClass) => {
+    const router = Router();
+    const basePath = `/api/${IntegrationClass.Definition.name}-integration`;
+    IntegrationClass.Definition.routes.forEach((routeDef) => {
+        if (typeof routeDef === 'function') {
+            router.use(basePath, routeDef(IntegrationClass));
+        } else if (typeof routeDef === 'object') {
+            router.use(
+                basePath,
+                loadRouterFromObject(IntegrationClass, routeDef)
+            );
+        } else if (routeDef instanceof express.Router) {
+            router.use(basePath, routeDef);
+        }
+    });
+
+    handlers[`${IntegrationClass.Definition.name}`] = {
+        handler: createAppHandler(
+            `HTTP Event: ${IntegrationClass.Definition.name}`,
+            router
+        ),
+    };
+});
+
+module.exports = { handlers };

--- a/packages/devtools/infrastructure/routers/middleware/loadUser.js
+++ b/packages/devtools/infrastructure/routers/middleware/loadUser.js
@@ -1,0 +1,15 @@
+const catchAsyncError = require('express-async-handler');
+const { User } = require('../../backend-utils');
+
+module.exports = catchAsyncError(async (req, res, next) => {
+    const authorizationHeader = req.headers.authorization;
+
+    if (authorizationHeader) {
+        // Removes "Bearer " and trims
+        const token = authorizationHeader.split(' ')[1].trim();
+        // Load user for later middleware/routes to use
+        req.user = await User.newUser({ token });
+    }
+
+    return next();
+});

--- a/packages/devtools/infrastructure/routers/middleware/requireLoggedInUser.js
+++ b/packages/devtools/infrastructure/routers/middleware/requireLoggedInUser.js
@@ -1,0 +1,12 @@
+const Boom = require('@hapi/boom');
+
+// CheckLoggedIn Middleware
+const requireLoggedInUser = (req, res, next) => {
+    if (!req.user || !req.user.isLoggedIn()) {
+        throw Boom.unauthorized('Invalid Token');
+    }
+
+    next();
+};
+
+module.exports = { requireLoggedInUser };

--- a/packages/devtools/infrastructure/routers/user.js
+++ b/packages/devtools/infrastructure/routers/user.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const { createAppHandler } = require('../app-handler-helpers');
+const { checkRequiredParams } = require('@friggframework/core');
+const { User } = require('../backend-utils');
+const catchAsyncError = require('express-async-handler');
+
+const router = express();
+
+// define the login endpoint
+router.route('/user/login').post(
+    catchAsyncError(async (req, res) => {
+        const { username, password } = checkRequiredParams(req.body, [
+            'username',
+            'password',
+        ]);
+        const user = await User.loginUser({ username, password });
+        const token = await user.createUserToken(120);
+        res.status(201);
+        res.json({ token });
+    })
+);
+
+router.route('/user/create').post(
+    catchAsyncError(async (req, res) => {
+        const { username, password } = checkRequiredParams(req.body, [
+            'username',
+            'password',
+        ]);
+        const user = await User.createIndividualUser({
+            username,
+            password,
+        });
+        const token = await user.createUserToken(120);
+        res.status(201);
+        res.json({ token });
+    })
+);
+
+const handler = createAppHandler('HTTP Event: User', router);
+
+module.exports = { handler, router };

--- a/packages/devtools/infrastructure/routers/websocket.js
+++ b/packages/devtools/infrastructure/routers/websocket.js
@@ -1,0 +1,55 @@
+const { createHandler } = require('@friggframework/core');
+const { WebsocketConnection } = require('@friggframework/core');
+
+const handleWebSocketConnection = async (event, context) => {
+    // Handle different WebSocket events
+    switch (event.requestContext.eventType) {
+        case 'CONNECT':
+            // Handle new connection
+            try {
+                const connectionId = event.requestContext.connectionId;
+                await WebsocketConnection.create({ connectionId });
+                console.log(`Stored new connection: ${connectionId}`);
+                return { statusCode: 200, body: 'Connected.' };
+            } catch (error) {
+                console.error('Error storing connection:', error);
+                return { statusCode: 500, body: 'Error connecting.' };
+            }
+
+        case 'DISCONNECT':
+            // Handle disconnection
+            try {
+                const connectionId = event.requestContext.connectionId;
+                await WebsocketConnection.deleteOne({ connectionId });
+                console.log(`Removed connection: ${connectionId}`);
+                return { statusCode: 200, body: 'Disconnected.' };
+            } catch (error) {
+                console.error('Error removing connection:', error);
+                return { statusCode: 500, body: 'Error disconnecting.' };
+            }
+
+        case 'MESSAGE':
+            // Handle incoming message
+            const message = JSON.parse(event.body);
+            console.log('Received message:', message);
+
+            // Process the message and send a response
+            const responseMessage = { message: 'Message received' };
+            return {
+                statusCode: 200,
+                body: JSON.stringify(responseMessage),
+            };
+
+        default:
+            return { statusCode: 400, body: 'Unhandled event type.' };
+    }
+};
+
+const handler = createHandler({
+    eventName: 'WebSocket Event',
+    method: handleWebSocketConnection,
+    shouldUseDatabase: true, // Set to true as we're using the database
+    isUserFacingResponse: true, // This is a server-to-server response
+});
+
+module.exports = { handler };

--- a/packages/devtools/infrastructure/serverless-template.js
+++ b/packages/devtools/infrastructure/serverless-template.js
@@ -1,0 +1,291 @@
+const path = require('path');
+const fs = require('fs');
+
+const composeServerlessDefinition = (AppDefinition, IntegrationFactory) => {
+    const definition = {
+        frameworkVersion: '>=3.17.0',
+        service: AppDefinition.name || 'create-frigg-app',
+        package: {
+            individually: true,
+        },
+        useDotenv: true,
+        provider: {
+            name: AppDefinition.provider || 'aws',
+            runtime: 'nodejs20.x',
+            timeout: 30,
+            region: 'us-east-1',
+            stage: '${opt:stage}',
+            environment: {
+                STAGE: '${opt:stage}',
+                AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1,
+            },
+            iamRoleStatements: [
+                {
+                    Effect: 'Allow',
+                    Action: ['sns:Publish'],
+                    Resource: {
+                        Ref: 'InternalErrorBridgeTopic',
+                    },
+                },
+            ],
+        },
+        plugins: [
+            'serverless-dotenv-plugin',
+            'serverless-offline-sqs',
+            'serverless-offline',
+            '@friggframework/serverless-plugin',
+        ],
+        custom: {
+            'serverless-offline': {
+                httpPort: 3001,
+                lambdaPort: 4001,
+                websocketPort: 3002,
+            },
+            'serverless-offline-sqs': {
+                autoCreate: false,
+                apiVersion: '2012-11-05',
+                endpoint: 'http://localhost:4566',
+                region: 'us-east-1',
+                accessKeyId: 'root',
+                secretAccessKey: 'root',
+                skipCacheInvalidation: false,
+            },
+            webpack: {
+                webpackConfig: 'webpack.config.js',
+                includeModules: {
+                    forceExclude: ['aws-sdk'],
+                },
+                packager: 'npm',
+                excludeFiles: ['src/**/*.test.js', 'test/'],
+            },
+        },
+        functions: {
+            defaultWebsocket: {
+                handler:
+                    '/../node_modules/@friggframework/devtools/infrastructure/routers/websocket.handler',
+                events: [
+                    {
+                        websocket: {
+                            route: '$connect',
+                        },
+                    },
+                    {
+                        websocket: {
+                            route: '$default',
+                        },
+                    },
+                    {
+                        websocket: {
+                            route: '$disconnect',
+                        },
+                    },
+                ],
+            },
+            auth: {
+                handler:
+                    '/../node_modules/@friggframework/devtools/infrastructure/routers/auth.handler',
+                events: [
+                    {
+                        http: {
+                            path: '/api/integrations',
+                            method: 'ANY',
+                            cors: true,
+                        },
+                    },
+                    {
+                        http: {
+                            path: '/api/integrations/{proxy+}',
+                            method: 'ANY',
+                            cors: true,
+                        },
+                    },
+                    {
+                        http: {
+                            path: '/api/authorize',
+                            method: 'ANY',
+                            cors: true,
+                        },
+                    },
+                ],
+            },
+            user: {
+                handler:
+                    '/../node_modules/@friggframework/devtools/infrastructure/routers/user.handler',
+                events: [
+                    {
+                        http: {
+                            path: '/user/{proxy+}',
+                            method: 'ANY',
+                            cors: true,
+                        },
+                    },
+                ],
+            },
+        },
+        resources: {
+            Resources: {
+                InternalErrorQueue: {
+                    Type: 'AWS::SQS::Queue',
+                    Properties: {
+                        QueueName:
+                            'internal-error-queue-${self:provider.stage}',
+                        MessageRetentionPeriod: 300,
+                    },
+                },
+                InternalErrorBridgeTopic: {
+                    Type: 'AWS::SNS::Topic',
+                    Properties: {
+                        Subscription: [
+                            {
+                                Protocol: 'sqs',
+                                Endpoint: {
+                                    'Fn::GetAtt': ['InternalErrorQueue', 'Arn'],
+                                },
+                            },
+                        ],
+                    },
+                },
+                InternalErrorBridgePolicy: {
+                    Type: 'AWS::SQS::QueuePolicy',
+                    Properties: {
+                        Queues: [{ Ref: 'InternalErrorQueue' }],
+                        PolicyDocument: {
+                            Version: '2012-10-17',
+                            Statement: [
+                                {
+                                    Sid: 'Allow Dead Letter SNS to publish to SQS',
+                                    Effect: 'Allow',
+                                    Principal: {
+                                        Service: 'sns.amazonaws.com',
+                                    },
+                                    Resource: {
+                                        'Fn::GetAtt': [
+                                            'InternalErrorQueue',
+                                            'Arn',
+                                        ],
+                                    },
+                                    Action: [
+                                        'SQS:SendMessage',
+                                        'SQS:SendMessageBatch',
+                                    ],
+                                    Condition: {
+                                        ArnEquals: {
+                                            'aws:SourceArn': {
+                                                Ref: 'InternalErrorBridgeTopic',
+                                            },
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                },
+                ApiGatewayAlarm5xx: {
+                    Type: 'AWS::CloudWatch::Alarm',
+                    Properties: {
+                        AlarmDescription: 'API Gateway 5xx Errors',
+                        Namespace: 'AWS/ApiGateway',
+                        MetricName: '5XXError',
+                        Statistic: 'Sum',
+                        Threshold: 0,
+                        ComparisonOperator: 'GreaterThanThreshold',
+                        EvaluationPeriods: 1,
+                        Period: 60,
+                        AlarmActions: [{ Ref: 'InternalErrorBridgeTopic' }],
+                        Dimensions: [
+                            {
+                                Name: 'ApiName',
+                                Value: {
+                                    'Fn::Join': [
+                                        '-',
+                                        [
+                                            '${self:provider.stage}',
+                                            '${self:service}',
+                                        ],
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    };
+
+    // Add integration-specific functions and resources
+    AppDefinition.integrations.forEach((integration) => {
+        const integrationName = integration.Definition.name;
+
+        // Add function for the integration
+        definition.functions[integrationName] = {
+            handler: `/../node_modules/@friggframework/devtools/infrastructure/routers/integration-defined-routers.handlers.${integrationName}.handler`,
+            // events: integration.Definition.routes.map((route) => ({
+            //     http: {
+            //         path: `/api/${integrationName}-integration${route.path}`,
+            //         method: route.method || 'ANY',
+            //         cors: true,
+            //     },
+            // })),
+            events: [
+                {
+                    http: {
+                        path: `/api/${integrationName}-integration/{proxy*}`,
+                        method: 'ANY',
+                        cors: true,
+                    },
+                },
+            ],
+        };
+
+        // Add SQS Queue for the integration
+        const queueReference = `${
+            integrationName.charAt(0).toUpperCase() + integrationName.slice(1)
+        }Queue`;
+        const queueName = `\${self:service}--\${self:provider.stage}-${queueReference}`;
+        definition.resources.Resources[queueReference] = {
+            Type: 'AWS::SQS::Queue',
+            Properties: {
+                QueueName: `\${self:custom.${queueReference}}`,
+                MessageRetentionPeriod: 60,
+                RedrivePolicy: {
+                    maxReceiveCount: 1,
+                    deadLetterTargetArn: {
+                        'Fn::GetAtt': ['InternalErrorQueue', 'Arn'],
+                    },
+                },
+            },
+        };
+
+        // Add Queue Worker for the integration
+        const queueWorkerName = `${integrationName}QueueWorker`;
+        definition.functions[queueWorkerName] = {
+            handler: `/../node_modules/@friggframework/devtools/infrastructure/workers/integration-defined-workers.handlers.${integrationName}.queueWorker`,
+            reservedConcurrency: 5,
+            events: [
+                {
+                    sqs: {
+                        arn: {
+                            'Fn::GetAtt': [queueReference, 'Arn'],
+                        },
+                        batchSize: 1,
+                    },
+                },
+            ],
+            timeout: 600,
+        };
+
+        // Add Queue URL for the integration to the ENVironment variables
+        definition.provider.environment = {
+            ...definition.provider.environment,
+            [integrationName.toUpperCase() + '_QUEUE_URL']: {
+                Ref: queueReference,
+            },
+        };
+
+        definition.custom[queueReference] = queueName;
+    });
+
+    return definition;
+};
+
+module.exports = { composeServerlessDefinition };

--- a/packages/devtools/infrastructure/workers/integration-defined-workers.js
+++ b/packages/devtools/infrastructure/workers/integration-defined-workers.js
@@ -1,0 +1,24 @@
+const { createHandler } = require('@friggframework/core');
+const { integrationFactory, createQueueWorker } = require('./../backend-utils');
+
+const handlers = {};
+integrationFactory.integrationClasses.forEach((IntegrationClass) => {
+    const defaultQueueWorker = createQueueWorker(IntegrationClass);
+
+    handlers[`${IntegrationClass.Definition.name}`] = {
+        queueWorker: createHandler({
+            eventName: `Queue Worker for ${IntegrationClass.Definition.name}`,
+            isUserFacingResponse: false,
+            method: async (event, context) => {
+                const worker = new defaultQueueWorker();
+                await worker.run(event, context);
+                return {
+                    message: 'Successfully processed the Generic Queue Worker',
+                    input: event,
+                };
+            },
+        }),
+    };
+});
+
+module.exports = { handlers };

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -8,8 +8,12 @@
     "@babel/traverse": "^7.25.3",
     "@friggframework/core": "^2.0.0-next.0",
     "@friggframework/test": "^2.0.0-next.0",
+    "@hapi/boom": "^7.4.11",
+    "@inquirer/prompts": "^5.3.8",
     "axios": "^1.7.2",
+    "body-parser": "^1.20.2",
     "commander": "^12.1.0",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "eslint": "^8.22.0",
     "eslint-config-prettier": "^8.5.0",
@@ -17,12 +21,19 @@
     "eslint-plugin-markdown": "^3.0.0",
     "eslint-plugin-no-only-tests": "^3.0.0",
     "eslint-plugin-yaml": "^0.5.0",
+    "express": "^4.19.2",
+    "express-async-handler": "^1.2.0",
     "fs-extra": "^11.2.0",
-    "inquirer": "^10.1.6"
+    "lodash": "^4.17.21",
+    "serverless-http": "^2.7.0"
   },
   "devDependencies": {
     "@friggframework/eslint-config": "^2.0.0-next.0",
-    "@friggframework/prettier-config": "^2.0.0-next.0"
+    "@friggframework/prettier-config": "^2.0.0-next.0",
+    "serverless-dotenv-plugin": "^6.0.0",
+    "serverless-offline": "^13.8.0",
+    "serverless-offline-sqs": "^8.0.0",
+    "serverless-webpack": "^5.14.1"
   },
   "scripts": {
     "lint:fix": "prettier --write --loglevel error . && eslint . --fix",


### PR DESCRIPTION
# Infrastructure Creation and Serverless Configuration

This update introduces a `createFriggInfrastructure` function that significantly enhances the application's infrastructure setup:

1. Generates default routers for integrations, authentication, user management, and entities.
2. Programmatically creates the serverless.yml definition based on configured integrations.
3. Automatically adds a new router, queue, and queue worker for each integration.
4. Implements a websocket handler for enhanced real-time capabilities.
5. Lays the groundwork for future iterations and improvements.

## TODO:

- [ ] Determine compatibility with locally defined serverless.yml and consider supporting this option.
- [ ] Resolve Webpack issues related to scope/directory references to address build size concerns.
- [ ] Implement additional override options in the serverless.yml definition based on the Frigg App definition.
- [ ] Move Frigg App definition handling to the root level to support concurrent frontend and backend execution.
- [ ] Develop comprehensive test suite.
- [ ] Verify build and deploy functionality, especially with `sls offline`.
- [ ] Review and adjust defaults for various configurations (KMS Key, Secrets Manager, domain management, VPC settings).
- [ ] Identify and address additional TODOs through testing and `frigg start` command usage.
- [ ] Consider adding options to the `frigg-start` command.
- [ ] Evaluate and implement TypeScript support.