### PR TITLE
Add the new Frigg Serverless Plugin

### DIFF
--- a/packages/serverless-plugin/index.js
+++ b/packages/serverless-plugin/index.js
@@ -1,0 +1,131 @@
+const { spawn } = require("child_process");
+
+class FriggServerlessPlugin {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+    this.provider = serverless.getProvider("aws");
+    this.hooks = {
+      initialize: () => this.init(),
+      "after:package:package": () => this.afterPackage(),
+      "before:deploy:deploy": () => this.beforeDeploy(),
+    };
+  }
+  async asyncInit() {
+    this.serverless.cli.log("Initializing Frigg Serverless Plugin...");
+    console.log("Hello from Frigg Serverless Plugin!");
+    if (this.serverless.processedInput.commands.includes("offline")) {
+      console.log("Running in offline mode. Making queues!");
+      const queues = Object.keys(this.serverless.service.custom)
+        .filter((key) => key.endsWith("Queue"))
+        .map((key) => {
+          return {
+            key,
+            name: this.serverless.service.custom[key],
+          };
+        });
+      console.log("Queues to be created:", queues);
+
+      const AWS = require("aws-sdk");
+
+      const endpointUrl = "localhost:4566"; // Assuming localstack is running on port 4
+      const region = "us-east-1";
+
+      // Configure AWS SDK
+      AWS.config.update({
+        region: region,
+        endpoint: endpointUrl,
+      });
+
+      const sqs = new AWS.SQS();
+// Find the environment variables that we need to override and create an easy map
+      const environmentMap = {};
+      const environment = this.serverless.service.provider.environment;
+
+      for (const [key, value] of Object.entries(environment)) {
+        if (typeof value === "object" && value.Ref) {
+          environmentMap[value.Ref] = key;
+        }
+      }
+
+      const queueCreationPromises = queues.map((queue) => {
+        return new Promise((resolve, reject) => {
+          const params = {
+            QueueName: queue.name,
+          };
+
+          sqs.createQueue(params, (err, data) => {
+            if (err) {
+              console.error(
+                `Error creating queue ${queue.name}: ${err.message}`
+              );
+              reject(err);
+            } else {
+              const queueUrl = data.QueueUrl;
+              console.log(
+                `Queue ${queue.name} created successfully. URL: ${queueUrl}`
+              );
+
+              const environmentKey = environmentMap[queue.key];
+              this.serverless.extendConfiguration(
+                ["provider", "environment", environmentKey],
+                queueUrl
+              );
+              console.log(`Set ${environmentKey} to ${queueUrl}`);
+              resolve(queueUrl);
+            }
+          });
+        });
+      });
+
+      await Promise.all(queueCreationPromises);
+    } else {
+      console.log("Running in online mode, doing nothing");
+    }
+  }
+  init() {}
+  afterPackage() {
+    console.log("After package hook called");
+    // // const queues = Object.keys(infrastructure.custom)
+    // //     .filter((key) => key.endsWith('Queue'))
+    // //     .map((key) => infrastructure.custom[key]);
+    // // console.log('Queues to be created:', queues);
+    // //
+    // // const endpointUrl = 'http://localhost:4566'; // Assuming localstack is running on port 4
+    // // const region = 'us-east-1';
+    // // const command = 'aws';
+    // // queues.forEach((queue) => {
+    // //     const args = [
+    // //         '--endpoint-url',
+    // //         endpointUrl,
+    // //         'sqs',
+    // //         'create-queue',
+    // //         '--queue-name',
+    // //         queue,
+    // //         '--region',
+    // //         region,
+    // //         '--output',
+    // //         'table',
+    // //     ];
+    // //
+    // //     const childProcess = spawn(command, args, {
+    // //         cwd: backendPath,
+    // //         stdio: 'inherit',
+    // //     });
+    // //     childProcess.on('error', (error) => {
+    // //         console.error(`Error executing command: ${error.message}`);
+    // //     });
+    // //
+    // //     childProcess.on('close', (code) => {
+    // //         if (code !== 0) {
+    // //             console.log(`Child process exited with code ${code}`);
+    // //         }
+    // //     });
+    // });
+  }
+  beforeDeploy() {
+    console.log("Before deploy hook called");
+  }
+}
+
+module.exports = FriggServerlessPlugin;

--- a/packages/serverless-plugin/package.json
+++ b/packages/serverless-plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@friggframework/serverless-plugin",
+  "version": "0.0.1",
+  "description": "Plugin to help dynamically load frigg resources",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "author": "Left Hook, Inc.",
+  "license": "MIT"
+}


### PR DESCRIPTION
Adds the new Frigg Serverless Plugin (which, may be obsolete once we migrate off serverless?) that creates the queues in the localstack SQS instead of requiring the user to run a bash script/command.

This plugin initializes during the serverless offline command, creating SQS queues in localstack based on the custom configuration. It also updates the environment variables with the newly created queue URLs.

Also sets the stage to do a lot more, now that I/we know how to write plugins (pretty easy actually).

TODO:
[] Webpack fix?
[] Start localstack? Check to see if it's running?
[] Allow a flag to determine what to run (THIS ONE IS CRITICAL FOR WORKING WITH PROD)