### PR TITLE
Updating the frigg cli for deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30624,7 +30624,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.7",
         "postcss": "^8.4.41",
-        "tailwindcss": "^3.4.7",
+        "tailwindcss": "^3.4.10",
         "vite": "^5.3.4"
       }
     },

--- a/packages/devtools/frigg-cli/build-command/index.js
+++ b/packages/devtools/frigg-cli/build-command/index.js
@@ -1,0 +1,27 @@
+const { spawn } = require('child_process');
+const path = require('path');
+
+function buildCommand(...args) {
+    console.log('Building the serverless application...');
+    const backendPath = path.resolve(process.cwd());
+    const infrastructurePath = 'infrastructure.js';
+    const command = 'serverless';
+    const serverlessArgs = ['package', '--config', infrastructurePath, ...args.filter(arg => arg !== 'build')];
+
+    const childProcess = spawn(command, serverlessArgs, {
+        cwd: backendPath,
+        stdio: 'inherit',
+    });
+
+    childProcess.on('error', (error) => {
+        console.error(`Error executing command: ${error.message}`);
+    });
+
+    childProcess.on('close', (code) => {
+        if (code !== 0) {
+            console.log(`Child process exited with code ${code}`);
+        }
+    });
+} 
+
+module.exports = { buildCommand };

--- a/packages/devtools/frigg-cli/deploy-command/index.js
+++ b/packages/devtools/frigg-cli/deploy-command/index.js
@@ -1,0 +1,27 @@
+const { spawn } = require('child_process');
+const path = require('path');
+
+function deployCommand(...args) {
+    console.log('Deploying the serverless application...');
+    const backendPath = path.resolve(process.cwd());
+    const infrastructurePath = 'infrastructure.js';
+    const command = 'serverless';
+    const serverlessArgs = ['deploy', '--config', infrastructurePath, ...args.filter(arg => arg !== 'deploy')];
+
+    const childProcess = spawn(command, serverlessArgs, {
+        cwd: backendPath,
+        stdio: 'inherit',
+    });
+
+    childProcess.on('error', (error) => {
+        console.error(`Error executing command: ${error.message}`);
+    });
+
+    childProcess.on('close', (code) => {
+        if (code !== 0) {
+            console.log(`Child process exited with code ${code}`);
+        }
+    });
+}
+
+module.exports = { deployCommand };

--- a/packages/devtools/frigg-cli/index.js
+++ b/packages/devtools/frigg-cli/index.js
@@ -3,6 +3,8 @@
 const { Command } = require('commander');
 const { installCommand } = require('./install-command');
 const { startCommand } = require('./start-command'); // Assuming you have a startCommand module
+const { buildCommand } = require('./build-command');
+const { deployCommand } = require('./deploy-command');
 
 const program = new Command();
 program
@@ -15,6 +17,16 @@ program
     .description('Run the backend and optional frontend')
     .action(startCommand);
 
+program
+    .command('build')
+    .description('Build the serverless application')
+    .action(buildCommand);
+
+program
+    .command('deploy')
+    .description('Deploy the serverless application')
+    .action(deployCommand);
+
 program.parse(process.argv);
 
-module.exports = { installCommand, startCommand };
+module.exports = { installCommand, startCommand, buildCommand, deployCommand };

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -33,7 +33,8 @@
     "serverless-dotenv-plugin": "^6.0.0",
     "serverless-offline": "^13.8.0",
     "serverless-offline-sqs": "^8.0.0",
-    "serverless-webpack": "^5.14.1"
+    "serverless-webpack": "^5.14.1",
+    "serverless": "3.39.0"
   },
   "scripts": {
     "lint:fix": "prettier --write --loglevel error . && eslint . --fix",


### PR DESCRIPTION
### TL;DR
Added build and deploy commands to the Frigg CLI tool and included serverless as a dependency.

### What changed?
- Created new build command that packages serverless applications
- Added deploy command for serverless deployment
- Integrated both commands into the main CLI program
- Added serverless v3.39.0 as a dependency
- Updated tailwindcss from 3.4.7 to 3.4.10

### How to test?
1. Run `frigg build` to package your serverless application
2. Run `frigg deploy` to deploy your serverless application
3. Verify both commands execute successfully with your infrastructure.js configuration
4. Check that the deployment process completes without errors

### Why make this change?
To streamline the development workflow by providing direct CLI commands for building and deploying serverless applications, eliminating the need to run serverless commands manually.