### PR TITLE
Address Biome linting concerns, and more importantly, update the {proxy+} greedy path to be properly written instead of the *. Not sure who did that. Probably me, but let's blame the AI.

### DIFF
--- a/packages/devtools/infrastructure/serverless-template.js
+++ b/packages/devtools/infrastructure/serverless-template.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 
-const composeServerlessDefinition = (AppDefinition, IntegrationFactory) => {
+const composeServerlessDefinition = (AppDefinition) => {
     const definition = {
         frameworkVersion: '>=3.17.0',
         service: AppDefinition.name || 'create-frigg-app',
@@ -213,7 +213,7 @@ const composeServerlessDefinition = (AppDefinition, IntegrationFactory) => {
     };
 
     // Add integration-specific functions and resources
-    AppDefinition.integrations.forEach((integration) => {
+    for (const integration of AppDefinition.integrations) {
         const integrationName = integration.Definition.name;
 
         // Add function for the integration
@@ -229,7 +229,7 @@ const composeServerlessDefinition = (AppDefinition, IntegrationFactory) => {
             events: [
                 {
                     http: {
-                        path: `/api/${integrationName}-integration/{proxy*}`,
+                        path: `/api/${integrationName}-integration/{proxy+}`,
                         method: 'ANY',
                         cors: true,
                     },
@@ -277,13 +277,13 @@ const composeServerlessDefinition = (AppDefinition, IntegrationFactory) => {
         // Add Queue URL for the integration to the ENVironment variables
         definition.provider.environment = {
             ...definition.provider.environment,
-            [integrationName.toUpperCase() + '_QUEUE_URL']: {
+            [`${integrationName.toUpperCase()}_QUEUE_URL`]: {
                 Ref: queueReference,
             },
         };
 
         definition.custom[queueReference] = queueName;
-    });
+    }
 
     return definition;
 };


### PR DESCRIPTION
### TL;DR
Updated API gateway path parameter and integration queue URL handling in serverless template

### What changed?
- Modified API gateway path parameter from `{proxy*}` to `{proxy+}` for _actual_ AWS compatibility
- Replaced string concatenation with template literals for queue URL environment variables
- Converted `.forEach` loop to `for...of` loop for better readability
- Removed unused `IntegrationFactory` parameter from `composeServerlessDefinition` function

### How to test?
1. Deploy a serverless application using this template
2. Verify API gateway endpoints are accessible with nested paths
3. Confirm integration queue URLs are correctly set in environment variables
4. Check that all integrations are properly configured with their respective queues

### Why make this change?
The `{proxy*}` syntax was causing issues with API Gateway path mappings. Using `{proxy+}` is the AWS-recommended approach for handling nested paths. Additionally, the code improvements make the template more maintainable and follow modern JavaScript practices.