### PR TITLE
Default visibility timeout is 30 seconds but the queue worker lambda timeout limit is set to 10 minuets, and that's a nono according to the powers that be (for good reason).

### DIFF
--- a/packages/devtools/infrastructure/serverless-template.js
+++ b/packages/devtools/infrastructure/serverless-template.js
@@ -247,6 +247,7 @@ const composeServerlessDefinition = (AppDefinition) => {
             Properties: {
                 QueueName: `\${self:custom.${queueReference}}`,
                 MessageRetentionPeriod: 60,
+                VisibilityTimeout: 1800,  // 30 minutes
                 RedrivePolicy: {
                     maxReceiveCount: 1,
                     deadLetterTargetArn: {


### PR DESCRIPTION
### TL;DR
Added a 30-minute visibility timeout to SQS queue configuration

### What changed?
Added a `VisibilityTimeout` property set to 1800 seconds (30 minutes) in the SQS queue configuration within the serverless template

### How to test?
1. Deploy the updated serverless template
2. Send a message to the SQS queue
3. Verify that the message remains invisible for 30 minutes after being received by a consumer

### Why make this change?
Setting an explicit visibility timeout prevents messages from being processed multiple times if the consumer takes longer than the default 30-second timeout to process the message. This is particularly important for long-running tasks that require more processing time.

(Or so saith the AI. My commit message gives you my real feelings about the issue... okay, this is all accurate but reads like an AI and that's boring)