### PR TITLE
Updated so that devtools depends on core, and no dependency on devtools from core.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30449,6 +30449,7 @@
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.20.2",
         "common-tags": "^1.8.2",
+        "cors": "^2.8.5",
         "express": "^4.19.2",
         "express-async-handler": "^1.2.0",
         "lodash": "4.17.21",

--- a/packages/core/handlers/backend-utils.js
+++ b/packages/core/handlers/backend-utils.js
@@ -1,7 +1,5 @@
 const { createFriggBackend, Worker } = require('@friggframework/core');
-const {
-    findNearestBackendPackageJson,
-} = require('../../devtools/frigg-cli/utils/backend-path');
+const { findNearestBackendPackageJson } = require('@friggframework/core/utils');
 const path = require('node:path');
 const fs = require('fs-extra');
 

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -59,6 +59,7 @@ const {
     ModuleFactory,
     Auther,
 } = require('./module-plugin/index');
+const utils = require('./utils');
 
 // const {Sync } = require('./syncs/model');
 
@@ -137,4 +138,7 @@ module.exports = {
 
     // queues
     QueuerUtil,
+
+    // utils
+    ...utils,
 };

--- a/packages/core/utils/backend-path.js
+++ b/packages/core/utils/backend-path.js
@@ -23,4 +23,4 @@ function validateBackendPath(backendPath) {
 module.exports = {
     findNearestBackendPackageJson,
     validateBackendPath,
-};
+}; 

--- a/packages/core/utils/index.js
+++ b/packages/core/utils/index.js
@@ -1,0 +1,6 @@
+const { findNearestBackendPackageJson, validateBackendPath } = require('./backend-path');
+
+module.exports = {
+    findNearestBackendPackageJson,
+    validateBackendPath,
+};

--- a/packages/devtools/frigg-cli/index.test.js
+++ b/packages/devtools/frigg-cli/index.test.js
@@ -1,10 +1,7 @@
 const { Command } = require('commander');
 const { installCommand } = require('./index');
 const { validatePackageExists } = require('./install-command/validate-package');
-const {
-    findNearestBackendPackageJson,
-    validateBackendPath,
-} = require('./utils/backend-path');
+const { findNearestBackendPackageJson, validateBackendPath } = require('@friggframework/core');
 const { installPackage } = require('./install-command/install-package');
 const { createIntegrationFile } = require('./install-command/integration-file');
 const { updateBackendJsFile } = require('./install-command/backend-js');

--- a/packages/devtools/frigg-cli/install-command/index.js
+++ b/packages/devtools/frigg-cli/install-command/index.js
@@ -4,15 +4,12 @@ const { resolve } = require('node:path');
 const { updateBackendJsFile } = require('./backend-js');
 const { logInfo, logError } = require('./logger');
 const { commitChanges } = require('./commit-changes');
-const {
-    findNearestBackendPackageJson,
-    validateBackendPath,
-} = require('../utils/backend-path');
 const { handleEnvVariables } = require('./environment-variables');
 const {
     validatePackageExists,
     searchAndSelectPackage,
 } = require('./validate-package');
+const { findNearestBackendPackageJson, validateBackendPath } = require('@friggframework/core');
 
 const installCommand = async (apiModuleName) => {
     try {

--- a/packages/devtools/infrastructure/create-frigg-infrastructure.js
+++ b/packages/devtools/infrastructure/create-frigg-infrastructure.js
@@ -2,9 +2,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const { composeServerlessDefinition } = require('./serverless-template');
 
-const {
-    findNearestBackendPackageJson,
-} = require('../frigg-cli/utils/backend-path');
+const { findNearestBackendPackageJson } = require('@friggframework/core');
 
 function createFriggInfrastructure() {
     const backendPath = findNearestBackendPackageJson();


### PR DESCRIPTION
### TL;DR
Moved backend path utilities from frigg-cli to core package and exposed them through the core package's public API.

### What changed?
- Relocated `backend-path.js` from `packages/devtools/frigg-cli/utils` to `packages/core/utils`
- Created a new `utils/index.js` in core package to export the utilities
- Updated all imports to reference the utilities from `@friggframework/core` instead of the CLI package
- Added `cors` dependency to package-lock.json

### How to test?
1. Import `findNearestBackendPackageJson` and `validateBackendPath` from `@friggframework/core`
2. Verify the functions work as expected in their new location
3. Ensure existing CLI functionality continues to work with the updated imports

### Why make this change?
These utility functions are used across multiple packages and are more appropriately housed in the core package. This change improves code organization and makes these utilities more accessible to other packages that depend on the core package.