### PR TITLE
Simple fix for now, may have unintented side effects depending on where Frigg Start is run from. But let's go with simple.

### DIFF
--- a/packages/core/utils/backend-path.js
+++ b/packages/core/utils/backend-path.js
@@ -1,9 +1,21 @@
 const fs = require('fs-extra');
-const path = require('path');
+const path = require('node:path');
 const PACKAGE_JSON = 'package.json';
 
 function findNearestBackendPackageJson() {
     let currentDir = process.cwd();
+    
+    // First check if we're in production by looking for package.json in the current directory
+    const rootPackageJson = path.join(currentDir, PACKAGE_JSON);
+    if (fs.existsSync(rootPackageJson)) {
+        // In production environment, check for index.js in the same directory
+        const indexJs = path.join(currentDir, 'index.js');
+        if (fs.existsSync(indexJs)) {
+            return rootPackageJson;
+        }
+    }
+
+    // If not found at root or not in production, look for it in the backend directory
     while (currentDir !== path.parse(currentDir).root) {
         const packageJsonPath = path.join(currentDir, 'backend', PACKAGE_JSON);
         if (fs.existsSync(packageJsonPath)) {


### PR DESCRIPTION
### TL;DR
Enhanced package.json detection to support both production and development environments.

### What changed?
Added a new check to detect if we're in a production environment by looking for both `package.json` and `index.js` in the current directory before falling back to the existing backend directory search logic.

### How to test?
1. Test in development environment:
   - Run the application from a directory containing a `backend` folder
   - Verify package.json is found in the backend directory

2. Test in production environment:
   - Create a directory with both `package.json` and `index.js`
   - Run the application from this directory
   - Verify package.json is found in the current directory

### Why make this change?
To improve the package detection logic by supporting both production deployments (where files are in the root directory) and development environments (where files are in the backend directory), making the application more flexible across different deployment scenarios.