### PR TITLE
Just adding lodash.get for now, some obvious cleanup for later.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21398,7 +21398,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true,
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "license": "MIT"
     },
     "node_modules/lodash.ismatch": {
@@ -30456,6 +30456,7 @@
         "form-data": "^4.0.0",
         "fs-extra": "^11.2.0",
         "lodash": "4.17.21",
+        "lodash.get": "^4.4.2",
         "mongoose": "6.11.6",
         "node-fetch": "^2.6.7",
         "serverless-http": "^2.7.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
     "form-data": "^4.0.0",
     "fs-extra": "^11.2.0",
     "lodash": "4.17.21",
+    "lodash.get": "^4.4.2",
     "mongoose": "6.11.6",
     "node-fetch": "^2.6.7",
     "serverless-http": "^2.7.0",


### PR DESCRIPTION
### TL;DR
Added `lodash.get` as a direct dependency to the core package.

### What changed?
- Added `lodash.get` version ^4.4.2 as a dependency in the core package
- Removed the dev-only flag from `lodash.get` in package-lock.json
- Note: The package is marked as deprecated in favor of optional chaining

### How to test?
1. Run `npm install` to update dependencies
2. Verify that code using `lodash.get` functions correctly
3. Check that the build process completes without errors

### Why make this change?
The core package directly uses `lodash.get` functionality but it was only listed as a dev dependency. This change properly declares the dependency relationship, ensuring the package is available in production environments.