### PR TITLE
Missing dotenv from a prior release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30451,6 +30451,7 @@
         "body-parser": "^1.20.2",
         "common-tags": "^1.8.2",
         "cors": "^2.8.5",
+        "dotenv": "^16.4.7",
         "express": "^4.19.2",
         "express-async-handler": "^1.2.0",
         "form-data": "^4.0.0",
@@ -30477,6 +30478,18 @@
         "prettier": "^2.7.1",
         "sinon": "^16.1.1",
         "typescript": "^5.0.2"
+      }
+    },
+    "packages/core/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "packages/core/node_modules/uuid": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
     "body-parser": "^1.20.2",
     "common-tags": "^1.8.2",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
     "express": "^4.19.2",
     "express-async-handler": "^1.2.0",
     "form-data": "^4.0.0",


### PR DESCRIPTION
### TL;DR
Added dotenv package to core dependencies

### What changed?
Added dotenv v16.4.7 as a dependency in the core package to enable environment variable management

### How to test?
1. Run `npm install` in the core package directory
2. Verify dotenv is listed in node_modules
3. Create a test .env file and ensure it can be loaded using `require('dotenv').config()`

### Why make this change?
To provide proper environment variable management capabilities, allowing for better configuration handling and security by keeping sensitive information out of the codebase