### PR TITLE
Removing credential: true from cors options as it contradicts the origin: '*' option

### DIFF
--- a/packages/core/handlers/app-handler-helpers.js
+++ b/packages/core/handlers/app-handler-helpers.js
@@ -14,7 +14,6 @@ const createApp = (applyMiddleware) => {
     app.use(
         cors({
             origin: '*',
-            credentials: true,
         })
     );
 


### PR DESCRIPTION
### TL;DR
Removed CORS credentials support from the application middleware

### What changed?
Removed the `credentials: true` option from the CORS configuration, which previously allowed the sharing of cookies and HTTP authentication across origins

### How to test?
1. Start the application
2. Make a cross-origin request to any endpoint
3. Verify that CORS requests work without credentials
4. Confirm that cookies and authentication headers are not shared across origins

### Why make this change?
Removing CORS credentials enhances security by preventing the sharing of sensitive authentication information across different domains. This is a more secure default configuration when credential sharing isn't explicitly required.