### PR TITLE
Turns out it wasn't the credentials, it was allowedHeaders. Making this generic/all.

### DIFF
--- a/packages/core/handlers/app-handler-helpers.js
+++ b/packages/core/handlers/app-handler-helpers.js
@@ -14,6 +14,9 @@ const createApp = (applyMiddleware) => {
     app.use(
         cors({
             origin: '*',
+            allowedHeaders: '*',
+            methods: '*',
+            credentials: true,
         })
     );
 


### PR DESCRIPTION
### TL;DR
Added additional CORS configuration options to allow for more flexible cross-origin requests.

### What changed?
Extended the CORS middleware configuration to include:
- `allowedHeaders: '*'` to accept all header types
- `methods: '*'` to allow all HTTP methods
- `credentials: true` to support credentials in cross-origin requests

### How to test?
1. Make cross-origin requests to the API with custom headers
2. Test requests with different HTTP methods
3. Verify that authenticated requests work across origins
4. Confirm that CORS preflight requests return appropriate headers

### Why make this change?
To provide more permissive CORS settings that enable broader API access from different origins and support more complex cross-origin requests, including those with custom headers and credentials.