### PR TITLE
Working on tweaks to get serverless offlinea nd serverless package working seamlessly no matter hte environment

### DIFF
--- a/packages/core/module-plugin/requester/requester.js
+++ b/packages/core/module-plugin/requester/requester.js
@@ -108,6 +108,7 @@ class Requester extends Delegate {
     }
 
     async _post(options, stringify = true) {
+        console.log('options', options);
         const fetchOptions = {
             method: 'POST',
             credentials: 'include',

--- a/packages/devtools/frigg-cli/index.js
+++ b/packages/devtools/frigg-cli/index.js
@@ -16,6 +16,7 @@ program
     .command('start')
     .description('Run the backend and optional frontend')
     .option('-s, --stage <stage>', 'deployment stage', 'dev')
+    .option('-v, --verbose', 'enable verbose output')
     .action(startCommand);
 
 program
@@ -29,6 +30,7 @@ program
     .command('deploy')
     .description('Deploy the serverless application')
     .option('-s, --stage <stage>', 'deployment stage', 'dev')
+    .option('-v, --verbose', 'enable verbose output')
     .action(deployCommand);
 
 program.parse(process.argv);

--- a/packages/devtools/frigg-cli/start-command/index.js
+++ b/packages/devtools/frigg-cli/start-command/index.js
@@ -1,7 +1,11 @@
-const { spawn } = require('child_process');
-const path = require('path');
+const { spawn } = require('node:child_process');
+const path = require('node:path');
 
 function startCommand(options) {
+    if (options.verbose) {
+        console.log('Verbose mode enabled');
+        console.log('Options:', options);
+    }
     console.log('Starting backend and optional frontend...');
     // Suppress AWS SDK warning message about maintenance mode
     process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = 1;
@@ -16,6 +20,16 @@ function startCommand(options) {
         '--stage',
         options.stage
     ];
+
+    // Add verbose flag to serverless if verbose option is enabled
+    if (options.verbose) {
+        args.push('--verbose');
+    }
+
+    if (options.verbose) {
+        console.log(`Executing command: ${command} ${args.join(' ')}`);
+        console.log(`Working directory: ${backendPath}`);
+    }
 
     const childProcess = spawn(command, args, {
         cwd: backendPath,


### PR DESCRIPTION
### TL;DR
Added verbose logging options to CLI commands and improved node_modules path resolution for serverless offline mode.

### What changed?
- Added `-v, --verbose` flag to `start` and `deploy` CLI commands
- Enhanced logging in the start command to show command execution details when verbose mode is enabled
- Implemented robust node_modules path detection using multiple fallback methods
- Added handler path modification logic for serverless offline mode
- Added debug logging for POST request options in the requester module

### How to test?
1. Run CLI commands with the new verbose flag:
   ```bash
   frigg start -v
   frigg deploy -v
   ```
2. Test serverless offline mode to verify correct node_modules resolution:
   ```bash
   frigg start -s dev -v
   ```
3. Verify POST requests are properly logged in the console

### Why make this change?
Improves debugging capabilities by providing more detailed logging options and fixes potential issues with node_modules resolution during local development. This makes it easier to troubleshoot deployment and startup issues, particularly when running in serverless offline mode.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.388.f6a3f63.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.388.f6a3f63.0
  npm install @friggframework/devtools@2.0.0--canary.388.f6a3f63.0
  npm install @friggframework/eslint-config@2.0.0--canary.388.f6a3f63.0
  npm install @friggframework/prettier-config@2.0.0--canary.388.f6a3f63.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.388.f6a3f63.0
  npm install @friggframework/test@2.0.0--canary.388.f6a3f63.0
  npm install @friggframework/ui@2.0.0--canary.388.f6a3f63.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.388.f6a3f63.0
  yarn add @friggframework/devtools@2.0.0--canary.388.f6a3f63.0
  yarn add @friggframework/eslint-config@2.0.0--canary.388.f6a3f63.0
  yarn add @friggframework/prettier-config@2.0.0--canary.388.f6a3f63.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.388.f6a3f63.0
  yarn add @friggframework/test@2.0.0--canary.388.f6a3f63.0
  yarn add @friggframework/ui@2.0.0--canary.388.f6a3f63.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.21`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/core`, `@friggframework/devtools`
    - Working on tweaks to get serverless offlinea nd serverless package working seamlessly no matter hte environment [#388](https://github.com/friggframework/frigg/pull/388) ([@seanspeaks](https://github.com/seanspeaks))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - Turns out it wasn't the credentials, it was allowedHeaders. Making this generic/all. [#387](https://github.com/friggframework/frigg/pull/387) ([@seanspeaks](https://github.com/seanspeaks))
  
  #### Authors: 1
  
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
