### PR TITLE
Loading integration instance by ID is only available on the integration factory. Passing that through and using that for the queue worker.

### DIFF
--- a/packages/core/handlers/backend-utils.js
+++ b/packages/core/handlers/backend-utils.js
@@ -39,7 +39,7 @@ const loadRouterFromObject = (IntegrationClass, routerObject) => {
 
     return router;
 };
-const createQueueWorker = (integrationClass) => {
+const createQueueWorker = (integrationClass, integrationFactory) => {
     class QueueWorker extends Worker {
         async _run(params, context) {
             try {
@@ -54,11 +54,11 @@ const createQueueWorker = (integrationClass) => {
                     );
                 } else {
                     instance =
-                        await integrationClass.getInstanceFromIntegrationId({
+                        await integrationFactory.getInstanceFromIntegrationId({
                             integrationId: params.integrationId,
                         });
                     console.log(
-                        `${params.event} for ${instance.integration.config.type} of integrationId: ${params.integrationId}`
+                        `${params.event} for ${instance.record.config.type} of integrationId: ${params.integrationId}`
                     );
                 }
                 const res = await instance.send(params.event, {

--- a/packages/core/handlers/workers/integration-defined-workers.js
+++ b/packages/core/handlers/workers/integration-defined-workers.js
@@ -3,7 +3,7 @@ const { integrationFactory, createQueueWorker } = require('../backend-utils');
 
 const handlers = {};
 integrationFactory.integrationClasses.forEach((IntegrationClass) => {
-    const defaultQueueWorker = createQueueWorker(IntegrationClass);
+    const defaultQueueWorker = createQueueWorker(IntegrationClass, integrationFactory);
 
     handlers[`${IntegrationClass.Definition.name}`] = {
         queueWorker: createHandler({


### PR DESCRIPTION
### TL;DR

Updated the `createQueueWorker` function to use the integration factory for retrieving integration instances.

### What changed?

- Modified the `createQueueWorker` function to accept an additional `integrationFactory` parameter
- Changed the instance retrieval logic to use `integrationFactory.getInstanceFromIntegrationId` instead of calling the method directly on the integration class
- Updated the log message to reference `instance.record.config.type` instead of `instance.integration.config.type`
- Updated the call to `createQueueWorker` in `integration-defined-workers.js` to pass the integration factory as a parameter

### How to test?

1. Verify that queue workers are created correctly for all integrations
2. Test that integration instances are properly retrieved using the integration factory
3. Confirm that log messages display the correct integration type

### Why make this change?

This change improves the architecture by using the integration factory consistently for retrieving integration instances, which provides better encapsulation and follows the factory pattern more closely. It also fixes a potential issue with accessing the integration configuration through the correct property path.