### PR TITLE
Added dynamic queue writing permissioning, thanks Claude

### DIFF
--- a/packages/devtools/infrastructure/serverless-template.js
+++ b/packages/devtools/infrastructure/serverless-template.js
@@ -129,6 +129,28 @@ const composeServerlessDefinition = (AppDefinition) => {
                         Ref: 'InternalErrorBridgeTopic',
                     },
                 },
+                {
+                    Effect: 'Allow',
+                    Action: [
+                        'sqs:SendMessage',
+                        'sqs:SendMessageBatch',
+                        'sqs:GetQueueUrl',
+                        'sqs:GetQueueAttributes'
+                    ],
+                    Resource: [
+                        {
+                            'Fn::GetAtt': ['InternalErrorQueue', 'Arn']
+                        },
+                        {
+                            'Fn::Join': [
+                                ':',
+                                [
+                                    'arn:aws:sqs:${self:provider.region}:*:${self:service}--${self:provider.stage}-*Queue'
+                                ]
+                            ]
+                        }
+                    ],
+                }
             ],
         },
         plugins: [


### PR DESCRIPTION
### TL;DR

Added SQS permissions to the serverless template to allow sending messages to error queues.

### What changed?

Added IAM permissions in the serverless template that allow Lambda functions to:
- Send messages to SQS queues (`sqs:SendMessage`, `sqs:SendMessageBatch`)
- Get queue URLs and attributes (`sqs:GetQueueUrl`, `sqs:GetQueueAttributes`)
- Access both the specific `InternalErrorQueue` and any queue matching the pattern `${self:service}--${self:provider.stage}-*Queue`

### How to test?

1. Deploy the service with these updated permissions
2. Verify that Lambda functions can successfully send messages to SQS queues
3. Check CloudWatch logs to ensure there are no permission-related errors when interacting with SQS

### Why make this change?

These permissions are necessary for Lambda functions to properly communicate with SQS queues for error handling. Without these permissions, Lambda functions would be unable to send error messages to the queues, potentially causing silent failures or incomplete error reporting.