### PR TITLE
refactor: simplify health endpoint documentation by removing redundant details on sensitive information exposure

### DIFF
--- a/packages/core/handlers/routers/HEALTHCHECK.md
+++ b/packages/core/handlers/routers/HEALTHCHECK.md
@@ -229,7 +229,7 @@ await mongoose.connection.db.admin().ping({ maxTimeMS: 2000 });
 
 - Basic health endpoint requires no authentication for monitoring compatibility
 - Detailed endpoints require `x-api-key` header authentication
-- Health endpoints do not expose sensitive information (DB types, versions, memory usage)
+- Health endpoints do not expose sensitive information
 - Database connection strings and credentials are never included in responses
 - External API checks use read-only endpoints
 - Rate limiting should be configured at the API Gateway level


### PR DESCRIPTION
Simplify healthcheck documentation.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.404.e9d4980.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.404.e9d4980.0
  npm install @friggframework/devtools@2.0.0--canary.404.e9d4980.0
  npm install @friggframework/eslint-config@2.0.0--canary.404.e9d4980.0
  npm install @friggframework/prettier-config@2.0.0--canary.404.e9d4980.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.404.e9d4980.0
  npm install @friggframework/test@2.0.0--canary.404.e9d4980.0
  npm install @friggframework/ui@2.0.0--canary.404.e9d4980.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.404.e9d4980.0
  yarn add @friggframework/devtools@2.0.0--canary.404.e9d4980.0
  yarn add @friggframework/eslint-config@2.0.0--canary.404.e9d4980.0
  yarn add @friggframework/prettier-config@2.0.0--canary.404.e9d4980.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.404.e9d4980.0
  yarn add @friggframework/test@2.0.0--canary.404.e9d4980.0
  yarn add @friggframework/ui@2.0.0--canary.404.e9d4980.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.26`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/core`
    - feat: improve health check endpoint [#403](https://github.com/friggframework/frigg/pull/403) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/core`, `@friggframework/devtools`
    - feat: add comprehensive healthcheck endpoints for Frigg service [#401](https://github.com/friggframework/frigg/pull/401) ([@seanspeaks](https://github.com/seanspeaks))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - Feat: implement support for VPC in Frigg Framework [#393](https://github.com/friggframework/frigg/pull/393) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/core`
    - refactor: simplify health endpoint documentation by removing redundant details on sensitive information exposure [#404](https://github.com/friggframework/frigg/pull/404) ([@d-klotz](https://github.com/d-klotz))
  
  #### ⚠️ Pushed to `next`
  
  - Update .gitignore ([@seanspeaks](https://github.com/seanspeaks))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
