### PR TITLE
fix: add publishConfig.access to all packages for npm publishing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,5 +52,8 @@
     "url": "https://github.com/friggframework/frigg/issues"
   },
   "homepage": "https://github.com/friggframework/frigg#readme",
-  "description": ""
+  "description": "",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -3,6 +3,19 @@
   "version": "2.0.0-next.0",
   "description": "Canonical JSON Schema definitions for Frigg Framework",
   "main": "index.js",
+  "author": "",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/friggframework/frigg.git"
+  },
+  "bugs": {
+    "url": "https://github.com/friggframework/frigg/issues"
+  },
+  "homepage": "https://github.com/friggframework/frigg#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "jest",
     "validate": "node scripts/validate-schemas.js",


### PR DESCRIPTION
## Summary
- Fixes the npm publishing error (E402) that was preventing the release workflow from completing
- Adds `publishConfig.access: "public"` to `@friggframework/schemas` and `@friggframework/core` packages
- Ensures all packages are explicitly marked as public for npm publishing

## Problem
The GitHub Actions release workflow was failing with:
```
lerna ERR! E402 You must sign up for private packages
```

This occurred because `@friggframework/schemas` was missing the `publishConfig.access: "public"` setting, causing npm to treat it as a private package (which requires a paid npm account).

## Solution
Added `publishConfig.access: "public"` to all packages that were missing it:
- ✅ @friggframework/schemas - Added publishConfig and standard metadata
- ✅ @friggframework/core - Added publishConfig

All 8 packages now have the correct public access configuration.

## Test plan
- [x] Verified all packages have `publishConfig.access: "public"` 
- [ ] Next release workflow should complete successfully without E402 error

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.30`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/devtools`, `@friggframework/schemas`
    - feat: integrate create-frigg-app functionality with vpc-kms-ssm features [#402](https://github.com/friggframework/frigg/pull/402) ([@seanspeaks](https://github.com/seanspeaks))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - feat: add AWS discovery and SSM support to serverless template [#398](https://github.com/friggframework/frigg/pull/398) ([@seanspeaks](https://github.com/seanspeaks) [@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/core`, `@friggframework/schemas`
    - fix: add publishConfig.access to all packages for npm publishing [#407](https://github.com/friggframework/frigg/pull/407) ([@seanspeaks](https://github.com/seanspeaks))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
