### PR TITLE
fix: add @friggframework/schemas dependency to devtools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31937,6 +31937,7 @@
         "@babel/eslint-parser": "^7.18.9",
         "@babel/parser": "^7.25.3",
         "@babel/traverse": "^7.25.3",
+        "@friggframework/schemas": "^2.0.0-next.0",
         "@friggframework/test": "^2.0.0-next.0",
         "@hapi/boom": "^10.0.1",
         "@inquirer/prompts": "^5.3.8",
@@ -32227,6 +32228,7 @@
     "packages/schemas": {
       "name": "@friggframework/schemas",
       "version": "2.0.0-next.0",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1"

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -9,6 +9,7 @@
     "@babel/eslint-parser": "^7.18.9",
     "@babel/parser": "^7.25.3",
     "@babel/traverse": "^7.25.3",
+    "@friggframework/schemas": "^2.0.0-next.0",
     "@friggframework/test": "^2.0.0-next.0",
     "@hapi/boom": "^10.0.1",
     "@inquirer/prompts": "^5.3.8",


### PR DESCRIPTION
## Summary
- Fixes MODULE_NOT_FOUND error when running `npx frigg deploy` in production
- Adds missing @friggframework/schemas dependency to devtools package.json
- Ensures proper monorepo dependency management

## Problem
The devtools package was importing @friggframework/schemas in `backend-first-handler.js` but the dependency was not declared in package.json. This caused deployment failures in production environments.

## Solution
Added @friggframework/schemas ^2.0.0-next.0 to the dependencies list to match other workspace package versions.

## Test Plan
- [x] npm install runs successfully
- [x] Package lock file updated
- [ ] Production deployment should now work without MODULE_NOT_FOUND error

🤖 Generated with [Claude Code](https://claude.ai/code)