### PR TITLE
fix: add API Gateway v2 permissions for HttpApi creation

### DIFF
--- a/packages/devtools/infrastructure/iam-generator.js
+++ b/packages/devtools/infrastructure/iam-generator.js
@@ -431,6 +431,8 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
             Resource: [
                 'arn:aws:apigateway:*::/restapis',
                 'arn:aws:apigateway:*::/restapis/*',
+                'arn:aws:apigateway:*::/apis',
+                'arn:aws:apigateway:*::/apis/*',
                 'arn:aws:apigateway:*::/domainnames',
                 'arn:aws:apigateway:*::/domainnames/*'
             ]

--- a/packages/devtools/infrastructure/iam-policy-basic.json
+++ b/packages/devtools/infrastructure/iam-policy-basic.json
@@ -204,6 +204,8 @@
       "Resource": [
         "arn:aws:apigateway:*::/restapis",
         "arn:aws:apigateway:*::/restapis/*",
+        "arn:aws:apigateway:*::/apis",
+        "arn:aws:apigateway:*::/apis/*",
         "arn:aws:apigateway:*::/domainnames",
         "arn:aws:apigateway:*::/domainnames/*"
       ]

--- a/packages/devtools/infrastructure/iam-policy-full.json
+++ b/packages/devtools/infrastructure/iam-policy-full.json
@@ -204,6 +204,8 @@
       "Resource": [
         "arn:aws:apigateway:*::/restapis",
         "arn:aws:apigateway:*::/restapis/*",
+        "arn:aws:apigateway:*::/apis",
+        "arn:aws:apigateway:*::/apis/*",
         "arn:aws:apigateway:*::/domainnames",
         "arn:aws:apigateway:*::/domainnames/*"
       ]


### PR DESCRIPTION
## Summary
- Fixes deployment AccessDeniedException when creating HttpApi resources
- Adds missing API Gateway v2 resource permissions to IAM policies
- Updates both static JSON files and dynamic IAM generator

## Problem
Deployment was failing with:
```
CREATE_FAILED: HttpApi (AWS::ApiGatewayV2::Api)
User is not authorized to perform: apigateway:POST on resource: arn:aws:apigateway:***::/apis
```

The IAM policies only had permissions for REST APIs (`/restapis/*`) but not for HTTP APIs (`/apis/*`) which are used by serverless framework's HttpApi resources.

## Solution
Added the missing resource patterns to all IAM policy files:
- `packages/devtools/infrastructure/iam-policy-basic.json`
- `packages/devtools/infrastructure/iam-policy-full.json`  
- `packages/devtools/infrastructure/iam-generator.js`

New permissions added:
- `arn:aws:apigateway:*::/apis`
- `arn:aws:apigateway:*::/apis/*`

## Test Plan
- [x] All IAM policy files updated consistently
- [x] Dynamic IAM generator includes new permissions
- [ ] Deployment should now succeed without AccessDeniedException
- [ ] HttpApi resources should be created successfully

🤖 Generated with [Claude Code](https://claude.ai/code)