### PR TITLE
feat: include broader permissions to iam

### DIFF
--- a/packages/devtools/frigg-cli/deploy-command/index.js
+++ b/packages/devtools/frigg-cli/deploy-command/index.js
@@ -17,6 +17,8 @@ async function deployCommand(options) {
         options.stage,
     ];
 
+    console.log('>>> Env vars: ', JSON.stringify(process.env));
+
     const childProcess = spawn(command, serverlessArgs, {
         cwd: backendPath,
         stdio: 'inherit',

--- a/packages/devtools/frigg-cli/deploy-command/index.js
+++ b/packages/devtools/frigg-cli/deploy-command/index.js
@@ -5,7 +5,7 @@ async function deployCommand(options) {
     console.log('Deploying the serverless application...');
 
     // AWS discovery is now handled directly in serverless-template.js
-    console.log('🚀 Deploying serverless application...');
+    console.log('🔥 Deploying serverless application...');
     const backendPath = path.resolve(process.cwd());
     const infrastructurePath = 'infrastructure.js';
     const command = 'serverless';

--- a/packages/devtools/frigg-cli/deploy-command/index.js
+++ b/packages/devtools/frigg-cli/deploy-command/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 async function deployCommand(options) {
     console.log('Deploying the serverless application...');
-    
+
     // AWS discovery is now handled directly in serverless-template.js
     console.log('🚀 Deploying serverless application...');
     const backendPath = path.resolve(process.cwd());
@@ -14,12 +14,13 @@ async function deployCommand(options) {
         '--config',
         infrastructurePath,
         '--stage',
-        options.stage
+        options.stage,
     ];
 
     const childProcess = spawn(command, serverlessArgs, {
         cwd: backendPath,
         stdio: 'inherit',
+        env: { ...process.env },
     });
 
     childProcess.on('error', (error) => {

--- a/packages/devtools/infrastructure/AWS-IAM-CREDENTIAL-NEEDS.md
+++ b/packages/devtools/infrastructure/AWS-IAM-CREDENTIAL-NEEDS.md
@@ -17,38 +17,39 @@ These permissions are required when `aws-discovery.js` runs during the build to 
 
 ```json
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSDiscoveryPermissions",
-      "Effect": "Allow",
-      "Action": [
-        "sts:GetCallerIdentity",
-        "ec2:DescribeVpcs",
-        "ec2:DescribeSubnets", 
-        "ec2:DescribeSecurityGroups",
-        "ec2:DescribeRouteTables",
-        "ec2:DescribeNatGateways",
-        "ec2:DescribeAddresses",
-        "kms:ListKeys",
-        "kms:DescribeKey"
-      ],
-      "Resource": "*"
-    }
-  ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AWSDiscoveryPermissions",
+            "Effect": "Allow",
+            "Action": [
+                "sts:GetCallerIdentity",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeRouteTables",
+                "ec2:DescribeNatGateways",
+                "ec2:DescribeAddresses",
+                "kms:ListKeys",
+                "kms:DescribeKey"
+            ],
+            "Resource": "*"
+        }
+    ]
 }
 ```
 
 ### What Each Permission Does:
-- **`sts:GetCallerIdentity`** - Gets your AWS account ID for KMS key ARN construction
-- **`ec2:DescribeVpcs`** - Finds your default VPC or first available VPC
-- **`ec2:DescribeSubnets`** - Identifies private subnets within your VPC
-- **`ec2:DescribeSecurityGroups`** - Locates default security group or Frigg-specific security group
-- **`ec2:DescribeRouteTables`** - Determines which subnets are private (no direct internet gateway route)
-- **`ec2:DescribeNatGateways`** - Finds existing NAT Gateways to reuse (prevents duplicate resource creation)
-- **`ec2:DescribeAddresses`** - Finds available Elastic IPs to reuse (prevents allocation conflicts)
-- **`kms:ListKeys`** - Lists available KMS keys in your account
-- **`kms:DescribeKey`** - Gets details about KMS keys to find customer-managed keys
+
+-   **`sts:GetCallerIdentity`** - Gets your AWS account ID for KMS key ARN construction
+-   **`ec2:DescribeVpcs`** - Finds your default VPC or first available VPC
+-   **`ec2:DescribeSubnets`** - Identifies private subnets within your VPC
+-   **`ec2:DescribeSecurityGroups`** - Locates default security group or Frigg-specific security group
+-   **`ec2:DescribeRouteTables`** - Determines which subnets are private (no direct internet gateway route)
+-   **`ec2:DescribeNatGateways`** - Finds existing NAT Gateways to reuse (prevents duplicate resource creation)
+-   **`ec2:DescribeAddresses`** - Finds available Elastic IPs to reuse (prevents allocation conflicts)
+-   **`kms:ListKeys`** - Lists available KMS keys in your account
+-   **`kms:DescribeKey`** - Gets details about KMS keys to find customer-managed keys
 
 ## Core Deployment Permissions
 
@@ -56,214 +57,236 @@ Required for basic Frigg application deployment:
 
 ```json
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "CloudFormationFriggStacks",
-      "Effect": "Allow",
-      "Action": [
-        "cloudformation:CreateStack",
-        "cloudformation:UpdateStack",
-        "cloudformation:DeleteStack",
-        "cloudformation:DescribeStacks",
-        "cloudformation:DescribeStackEvents",
-        "cloudformation:DescribeStackResources",
-        "cloudformation:DescribeStackResource",
-        "cloudformation:ListStackResources",
-        "cloudformation:GetTemplate",
-        "cloudformation:ValidateTemplate",
-        "cloudformation:DescribeChangeSet",
-        "cloudformation:CreateChangeSet",
-        "cloudformation:DeleteChangeSet",
-        "cloudformation:ExecuteChangeSet"
-      ],
-      "Resource": [
-        "arn:aws:cloudformation:*:*:stack/*frigg*/*"
-      ]
-    },
-    {
-      "Sid": "S3DeploymentBucket",
-      "Effect": "Allow", 
-      "Action": [
-        "s3:CreateBucket",
-        "s3:PutObject",
-        "s3:GetObject",
-        "s3:DeleteObject",
-        "s3:PutBucketPolicy",
-        "s3:PutBucketVersioning",
-        "s3:PutBucketPublicAccessBlock",
-        "s3:GetBucketLocation",
-        "s3:ListBucket",
-        "s3:PutBucketTagging",
-        "s3:GetBucketTagging"
-      ],
-      "Resource": [
-        "arn:aws:s3:::*serverless*",
-        "arn:aws:s3:::*serverless*/*"
-      ]
-    },
-    {
-      "Sid": "LambdaFriggFunctions",
-      "Effect": "Allow",
-      "Action": [
-        "lambda:CreateFunction",
-        "lambda:UpdateFunctionCode",
-        "lambda:UpdateFunctionConfiguration",
-        "lambda:DeleteFunction",
-        "lambda:GetFunction",
-        "lambda:ListFunctions",
-        "lambda:PublishVersion",
-        "lambda:CreateAlias",
-        "lambda:UpdateAlias",
-        "lambda:DeleteAlias",
-        "lambda:GetAlias",
-        "lambda:AddPermission",
-        "lambda:RemovePermission",
-        "lambda:GetPolicy",
-        "lambda:PutProvisionedConcurrencyConfig",
-        "lambda:DeleteProvisionedConcurrencyConfig",
-        "lambda:PutConcurrency",
-        "lambda:DeleteConcurrency",
-        "lambda:TagResource",
-        "lambda:UntagResource",
-        "lambda:ListVersionsByFunction"
-      ],
-      "Resource": [
-        "arn:aws:lambda:*:*:function:*frigg*"
-      ]
-    },
-    {
-      "Sid": "FriggLambdaEventSourceMapping",
-      "Effect": "Allow",
-      "Action": [
-        "lambda:CreateEventSourceMapping",
-        "lambda:DeleteEventSourceMapping",
-        "lambda:GetEventSourceMapping",
-        "lambda:UpdateEventSourceMapping",
-        "lambda:ListEventSourceMappings"
-      ],
-      "Resource": [
-        "arn:aws:lambda:*:*:event-source-mapping:*"
-      ]
-    },
-    {
-      "Sid": "IAMRolesForFriggLambda",
-      "Effect": "Allow",
-      "Action": [
-        "iam:CreateRole",
-        "iam:DeleteRole", 
-        "iam:GetRole",
-        "iam:PassRole",
-        "iam:PutRolePolicy",
-        "iam:DeleteRolePolicy",
-        "iam:GetRolePolicy",
-        "iam:AttachRolePolicy",
-        "iam:DetachRolePolicy",
-        "iam:TagRole",
-        "iam:UntagRole"
-      ],
-      "Resource": [
-        "arn:aws:iam::*:role/*frigg*",
-        "arn:aws:iam::*:role/*frigg*LambdaRole*"
-      ]
-    },
-    {
-      "Sid": "IAMPolicyVersionPermissions",
-      "Effect": "Allow",
-      "Action": [
-        "iam:ListPolicyVersions"
-      ],
-      "Resource": [
-        "arn:aws:iam::*:policy/*"
-      ]
-    },
-    {
-      "Sid": "FriggMessagingServices",
-      "Effect": "Allow",
-      "Action": [
-        "sqs:CreateQueue",
-        "sqs:DeleteQueue",
-        "sqs:GetQueueAttributes",
-        "sqs:SetQueueAttributes",
-        "sqs:GetQueueUrl",
-        "sqs:TagQueue",
-        "sqs:UntagQueue"
-      ],
-      "Resource": [
-        "arn:aws:sqs:*:*:*frigg*",
-        "arn:aws:sqs:*:*:internal-error-queue-*"
-      ]
-    },
-    {
-      "Sid": "FriggSNSTopics",
-      "Effect": "Allow",
-      "Action": [
-        "sns:CreateTopic",
-        "sns:DeleteTopic", 
-        "sns:GetTopicAttributes",
-        "sns:SetTopicAttributes",
-        "sns:Subscribe",
-        "sns:Unsubscribe",
-        "sns:TagResource",
-        "sns:UntagResource"
-      ],
-      "Resource": [
-        "arn:aws:sns:*:*:*frigg*"
-      ]
-    },
-    {
-      "Sid": "FriggMonitoringAndLogs",
-      "Effect": "Allow",
-      "Action": [
-        "cloudwatch:PutMetricAlarm",
-        "cloudwatch:DeleteAlarms",
-        "cloudwatch:DescribeAlarms",
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:DeleteLogGroup",
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams",
-        "logs:FilterLogEvents",
-        "logs:PutLogEvents",
-        "logs:PutRetentionPolicy"
-      ],
-      "Resource": [
-        "arn:aws:logs:*:*:log-group:/aws/lambda/*frigg*",
-        "arn:aws:logs:*:*:log-group:/aws/lambda/*frigg*:*",
-        "arn:aws:cloudwatch:*:*:alarm:*frigg*"
-      ]
-    },
-    {
-      "Sid": "FriggAPIGateway",
-      "Effect": "Allow", 
-      "Action": [
-        "apigateway:POST",
-        "apigateway:PUT",
-        "apigateway:DELETE",
-        "apigateway:GET",
-        "apigateway:PATCH"
-      ],
-      "Resource": [
-        "arn:aws:apigateway:*::/restapis",
-        "arn:aws:apigateway:*::/restapis/*",
-        "arn:aws:apigateway:*::/domainnames",
-        "arn:aws:apigateway:*::/domainnames/*"
-      ]
-    }
-  ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "CloudFormationFriggStacks",
+            "Effect": "Allow",
+            "Action": [
+                "cloudformation:CreateStack",
+                "cloudformation:UpdateStack",
+                "cloudformation:DeleteStack",
+                "cloudformation:DescribeStacks",
+                "cloudformation:DescribeStackEvents",
+                "cloudformation:DescribeStackResources",
+                "cloudformation:DescribeStackResource",
+                "cloudformation:ListStackResources",
+                "cloudformation:GetTemplate",
+                "cloudformation:ValidateTemplate",
+                "cloudformation:DescribeChangeSet",
+                "cloudformation:CreateChangeSet",
+                "cloudformation:DeleteChangeSet",
+                "cloudformation:ExecuteChangeSet"
+            ],
+            "Resource": ["arn:aws:cloudformation:*:*:stack/*frigg*/*"]
+        },
+        {
+            "Sid": "S3DeploymentBucket",
+            "Effect": "Allow",
+            "Action": [
+                "s3:CreateBucket",
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:DeleteObject",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketVersioning",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:GetBucketLocation",
+                "s3:ListBucket",
+                "s3:PutBucketTagging",
+                "s3:GetBucketTagging"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*serverless*",
+                "arn:aws:s3:::*serverless*/*"
+            ]
+        },
+        {
+            "Sid": "LambdaFriggFunctions",
+            "Effect": "Allow",
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:UpdateFunctionCode",
+                "lambda:UpdateFunctionConfiguration",
+                "lambda:DeleteFunction",
+                "lambda:GetFunction",
+                "lambda:ListFunctions",
+                "lambda:PublishVersion",
+                "lambda:CreateAlias",
+                "lambda:UpdateAlias",
+                "lambda:DeleteAlias",
+                "lambda:GetAlias",
+                "lambda:AddPermission",
+                "lambda:RemovePermission",
+                "lambda:GetPolicy",
+                "lambda:PutProvisionedConcurrencyConfig",
+                "lambda:DeleteProvisionedConcurrencyConfig",
+                "lambda:PutConcurrency",
+                "lambda:DeleteConcurrency",
+                "lambda:TagResource",
+                "lambda:UntagResource",
+                "lambda:ListVersionsByFunction"
+            ],
+            "Resource": ["arn:aws:lambda:*:*:function:*frigg*"]
+        },
+        {
+            "Sid": "FriggLambdaEventSourceMapping",
+            "Effect": "Allow",
+            "Action": [
+                "lambda:CreateEventSourceMapping",
+                "lambda:DeleteEventSourceMapping",
+                "lambda:GetEventSourceMapping",
+                "lambda:UpdateEventSourceMapping",
+                "lambda:ListEventSourceMappings"
+            ],
+            "Resource": ["arn:aws:lambda:*:*:event-source-mapping:*"]
+        },
+        {
+            "Sid": "IAMRolesForFriggLambda",
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:GetRole",
+                "iam:PassRole",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy",
+                "iam:GetRolePolicy",
+                "iam:AttachRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:TagRole",
+                "iam:UntagRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::*:role/*frigg*",
+                "arn:aws:iam::*:role/*frigg*LambdaRole*"
+            ]
+        },
+        {
+            "Sid": "IAMPolicyVersionPermissions",
+            "Effect": "Allow",
+            "Action": ["iam:ListPolicyVersions"],
+            "Resource": ["arn:aws:iam::*:policy/*"]
+        },
+        {
+            "Sid": "FriggMessagingServices",
+            "Effect": "Allow",
+            "Action": [
+                "sqs:CreateQueue",
+                "sqs:DeleteQueue",
+                "sqs:GetQueueAttributes",
+                "sqs:SetQueueAttributes",
+                "sqs:GetQueueUrl",
+                "sqs:TagQueue",
+                "sqs:UntagQueue"
+            ],
+            "Resource": [
+                "arn:aws:sqs:*:*:*frigg*",
+                "arn:aws:sqs:*:*:internal-error-queue-*"
+            ]
+        },
+        {
+            "Sid": "FriggSNSTopics",
+            "Effect": "Allow",
+            "Action": [
+                "sns:CreateTopic",
+                "sns:DeleteTopic",
+                "sns:GetTopicAttributes",
+                "sns:SetTopicAttributes",
+                "sns:Subscribe",
+                "sns:Unsubscribe",
+                "sns:TagResource",
+                "sns:UntagResource"
+            ],
+            "Resource": ["arn:aws:sns:*:*:*frigg*"]
+        },
+        {
+            "Sid": "FriggMonitoringAndLogs",
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:PutMetricAlarm",
+                "cloudwatch:DeleteAlarms",
+                "cloudwatch:DescribeAlarms",
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:DeleteLogGroup",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "logs:FilterLogEvents",
+                "logs:PutLogEvents",
+                "logs:PutRetentionPolicy"
+            ],
+            "Resource": [
+                "arn:aws:logs:*:*:log-group:/aws/lambda/*frigg*",
+                "arn:aws:logs:*:*:log-group:/aws/lambda/*frigg*:*",
+                "arn:aws:cloudwatch:*:*:alarm:*frigg*"
+            ]
+        },
+        {
+            "Sid": "FriggAPIGateway",
+            "Effect": "Allow",
+            "Action": [
+                "apigateway:POST",
+                "apigateway:PUT",
+                "apigateway:DELETE",
+                "apigateway:GET",
+                "apigateway:PATCH"
+            ],
+            "Resource": [
+                "arn:aws:apigateway:*::/restapis",
+                "arn:aws:apigateway:*::/restapis/*",
+                "arn:aws:apigateway:*::/domainnames",
+                "arn:aws:apigateway:*::/domainnames/*"
+            ]
+        },
+        {
+            "Sid": "FriggAPIGatewayV2",
+            "Effect": "Allow",
+            "Action": [
+                "apigateway:GET",
+                "apigateway:DELETE",
+                "apigateway:PATCH",
+                "apigateway:POST",
+                "apigateway:PUT"
+            ],
+            "Resource": [
+                "arn:aws:apigateway:*::/apis",
+                "arn:aws:apigateway:*::/apis/*",
+                "arn:aws:apigateway:*::/apis/*/stages",
+                "arn:aws:apigateway:*::/apis/*/stages/*",
+                "arn:aws:apigateway:*::/apis/*/mappings",
+                "arn:aws:apigateway:*::/apis/*/mappings/*"
+            ]
+        }
+    ]
 }
 ```
 
+**API Gateway Permissions Security Note:**
+
+The API Gateway permissions are intentionally split into two separate policies:
+
+-   **FriggAPIGateway**: Covers API Gateway v1 (REST APIs) with specific CRUD operations
+-   **FriggAPIGatewayV2**: Covers API Gateway v2 (HTTP APIs) with the same specific operations
+
+This approach follows the principle of least privilege by:
+
+-   ✅ **Avoiding wildcards**: Using specific actions instead of `apigateway:*`
+-   ✅ **Resource scoping**: Limiting to Frigg-specific API Gateway resources
+-   ✅ **Version separation**: Maintaining clear separation between v1 and v2 APIs
+-   ✅ **Audit-friendly**: Each permission can be individually tracked and monitored
+
 **What the Lambda permissions enable:**
-- **Function Management**: Create, update, delete, and configure Lambda functions
-- **Version & Alias Management**: Publish new versions and manage aliases for deployments
-- **Permission Management**: Add/remove function permissions for API Gateway and other services
-- **Concurrency Management**: Configure provisioned and reserved concurrency
-- **EventSourceMapping Management**: Connect Lambda functions to event sources like SQS, SNS, Kinesis, and DynamoDB streams. These permissions are crucial for:
-  - Creating mappings between SQS queues and Lambda functions
-  - Managing event-driven architectures
-  - Handling queue-based processing (e.g., HubSpot integration queues)
-  - Cleaning up event source mappings during stack deletion
+
+-   **Function Management**: Create, update, delete, and configure Lambda functions
+-   **Version & Alias Management**: Publish new versions and manage aliases for deployments
+-   **Permission Management**: Add/remove function permissions for API Gateway and other services
+-   **Concurrency Management**: Configure provisioned and reserved concurrency
+-   **EventSourceMapping Management**: Connect Lambda functions to event sources like SQS, SNS, Kinesis, and DynamoDB streams. These permissions are crucial for:
+    -   Creating mappings between SQS queues and Lambda functions
+    -   Managing event-driven architectures
+    -   Handling queue-based processing (e.g., HubSpot integration queues)
+    -   Cleaning up event source mappings during stack deletion
 
 ## Feature-Specific Permissions
 
@@ -273,58 +296,61 @@ Additional permissions needed when your app definition includes `vpc: { enable: 
 
 ```json
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "FriggVPCEndpointManagement",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateVpcEndpoint",
-        "ec2:DeleteVpcEndpoint", 
-        "ec2:DescribeVpcEndpoints",
-        "ec2:ModifyVpcEndpoint",
-        "ec2:CreateNatGateway",
-        "ec2:DeleteNatGateway",
-        "ec2:DescribeNatGateways",
-        "ec2:AllocateAddress",
-        "ec2:ReleaseAddress",
-        "ec2:DescribeAddresses",
-        "ec2:CreateRouteTable",
-        "ec2:DeleteRouteTable",
-        "ec2:DescribeRouteTables",
-        "ec2:CreateRoute",
-        "ec2:DeleteRoute",
-        "ec2:AssociateRouteTable",
-        "ec2:DisassociateRouteTable",
-        "ec2:CreateSecurityGroup",
-        "ec2:DeleteSecurityGroup",
-        "ec2:AuthorizeSecurityGroupEgress",
-        "ec2:AuthorizeSecurityGroupIngress",
-        "ec2:RevokeSecurityGroupEgress",
-        "ec2:RevokeSecurityGroupIngress"
-      ],
-      "Resource": "*",
-      "Condition": {
-        "StringLike": {
-          "ec2:CreateAction": [
-            "CreateVpcEndpoint",
-            "CreateNatGateway", 
-            "CreateRouteTable",
-            "CreateRoute",
-            "CreateSecurityGroup"
-          ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "FriggVPCEndpointManagement",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateVpcEndpoint",
+                "ec2:DeleteVpcEndpoint",
+                "ec2:DescribeVpcEndpoints",
+                "ec2:ModifyVpcEndpoint",
+                "ec2:CreateNatGateway",
+                "ec2:DeleteNatGateway",
+                "ec2:DescribeNatGateways",
+                "ec2:AllocateAddress",
+                "ec2:ReleaseAddress",
+                "ec2:DescribeAddresses",
+                "ec2:CreateRouteTable",
+                "ec2:DeleteRouteTable",
+                "ec2:DescribeRouteTables",
+                "ec2:CreateRoute",
+                "ec2:DeleteRoute",
+                "ec2:AssociateRouteTable",
+                "ec2:DisassociateRouteTable",
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupEgress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSubnet",
+                "ec2:DetachInternetGateway"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "ec2:CreateAction": [
+                        "CreateVpcEndpoint",
+                        "CreateNatGateway",
+                        "CreateRouteTable",
+                        "CreateRoute",
+                        "CreateSecurityGroup"
+                    ]
+                }
+            }
         }
-      }
-    }
-  ]
+    ]
 }
 ```
 
 **What this enables:**
-- Creates NAT Gateway for Lambda internet access to external APIs (Salesforce, HubSpot, etc.)
-- Creates VPC endpoints for AWS services (S3, DynamoDB, KMS, SSM) to reduce NAT Gateway costs
-- Creates route tables and subnet associations for proper Lambda networking
-- Automatically configures your Lambda functions to run in your default VPC with full internet access
+
+-   Creates NAT Gateway for Lambda internet access to external APIs (Salesforce, HubSpot, etc.)
+-   Creates VPC endpoints for AWS services (S3, DynamoDB, KMS, SSM) to reduce NAT Gateway costs
+-   Creates route tables and subnet associations for proper Lambda networking
+-   Automatically configures your Lambda functions to run in your default VPC with full internet access
 
 ### KMS Support
 
@@ -332,35 +358,31 @@ Additional permissions needed when your app definition includes `encryption: { u
 
 ```json
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "FriggKMSEncryptionRuntime",
-      "Effect": "Allow",
-      "Action": [
-        "kms:GenerateDataKey",
-        "kms:Decrypt"
-      ],
-      "Resource": [
-        "arn:aws:kms:*:*:key/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "kms:ViaService": [
-            "lambda.*.amazonaws.com",
-            "s3.*.amazonaws.com"
-          ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "FriggKMSEncryptionRuntime",
+            "Effect": "Allow",
+            "Action": ["kms:GenerateDataKey", "kms:Decrypt"],
+            "Resource": ["arn:aws:kms:*:*:key/*"],
+            "Condition": {
+                "StringEquals": {
+                    "kms:ViaService": [
+                        "lambda.*.amazonaws.com",
+                        "s3.*.amazonaws.com"
+                    ]
+                }
+            }
         }
-      }
-    }
-  ]
+    ]
 }
 ```
 
 **What this enables:**
-- Lambda functions can encrypt and decrypt data using your default KMS key
-- Automatic discovery and configuration of customer-managed KMS keys
-- Fallback to AWS-managed keys if no customer keys are available
+
+-   Lambda functions can encrypt and decrypt data using your default KMS key
+-   Automatic discovery and configuration of customer-managed KMS keys
+-   Fallback to AWS-managed keys if no customer keys are available
 
 ### SSM Parameter Store Support
 
@@ -368,29 +390,30 @@ Additional permissions needed when your app definition includes `ssm: { enable: 
 
 ```json
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "FriggSSMParameterAccess",
-      "Effect": "Allow", 
-      "Action": [
-        "ssm:GetParameter",
-        "ssm:GetParameters",
-        "ssm:GetParametersByPath"
-      ],
-      "Resource": [
-        "arn:aws:ssm:*:*:parameter/*frigg*",
-        "arn:aws:ssm:*:*:parameter/*frigg*/*"
-      ]
-    }
-  ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "FriggSSMParameterAccess",
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParameter",
+                "ssm:GetParameters",
+                "ssm:GetParametersByPath"
+            ],
+            "Resource": [
+                "arn:aws:ssm:*:*:parameter/*frigg*",
+                "arn:aws:ssm:*:*:parameter/*frigg*/*"
+            ]
+        }
+    ]
 }
 ```
 
 **What this enables:**
-- Lambda functions can retrieve configuration from SSM Parameter Store
-- Automatic configuration of AWS Parameters and Secrets Lambda Extension layer
-- Secure environment variable management through SSM
+
+-   Lambda functions can retrieve configuration from SSM Parameter Store
+-   Automatic configuration of AWS Parameters and Secrets Lambda Extension layer
+-   Secure environment variable management through SSM
 
 ## Complete Policy Template
 
@@ -398,63 +421,65 @@ For convenience, here's a single IAM policy that includes all permissions needed
 
 ```json
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "FriggCorePermissions",
-      "Effect": "Allow",
-      "Action": [
-        "sts:GetCallerIdentity",
-        "cloudformation:*",
-        "lambda:*", 
-        "apigateway:*",
-        "logs:*",
-        "sqs:*",
-        "sns:*",
-        "cloudwatch:*",
-        "ec2:Describe*",
-        "ec2:CreateVpcEndpoint",
-        "ec2:DeleteVpcEndpoint",
-        "ec2:ModifyVpcEndpoint",
-        "kms:ListKeys",
-        "kms:DescribeKey", 
-        "kms:GenerateDataKey",
-        "kms:Decrypt",
-        "ssm:GetParameter*"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "S3DeploymentBuckets",
-      "Effect": "Allow",
-      "Action": [
-        "s3:*"
-      ],
-      "Resource": [
-        "arn:aws:s3:::*serverless*",
-        "arn:aws:s3:::*serverless*/*"
-      ]
-    },
-    {
-      "Sid": "IAMRoleManagement",
-      "Effect": "Allow",
-      "Action": [
-        "iam:CreateRole",
-        "iam:DeleteRole",
-        "iam:GetRole", 
-        "iam:PassRole",
-        "iam:PutRolePolicy",
-        "iam:DeleteRolePolicy",
-        "iam:GetRolePolicy",
-        "iam:AttachRolePolicy",
-        "iam:DetachRolePolicy",
-        "iam:TagRole",
-        "iam:UntagRole",
-        "iam:ListPolicyVersions"
-      ],
-      "Resource": "arn:aws:iam::*:role/*"
-    }
-  ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "FriggCorePermissions",
+            "Effect": "Allow",
+            "Action": [
+                "sts:GetCallerIdentity",
+                "cloudformation:*",
+                "lambda:*",
+                "apigateway:GET",
+                "apigateway:POST",
+                "apigateway:PUT",
+                "apigateway:DELETE",
+                "apigateway:PATCH",
+                "logs:*",
+                "sqs:*",
+                "sns:*",
+                "cloudwatch:*",
+                "ec2:Describe*",
+                "ec2:CreateVpcEndpoint",
+                "ec2:DeleteVpcEndpoint",
+                "ec2:ModifyVpcEndpoint",
+                "kms:ListKeys",
+                "kms:DescribeKey",
+                "kms:GenerateDataKey",
+                "kms:Decrypt",
+                "ssm:GetParameter*"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "S3DeploymentBuckets",
+            "Effect": "Allow",
+            "Action": ["s3:*"],
+            "Resource": [
+                "arn:aws:s3:::*serverless*",
+                "arn:aws:s3:::*serverless*/*"
+            ]
+        },
+        {
+            "Sid": "IAMRoleManagement",
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:GetRole",
+                "iam:PassRole",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy",
+                "iam:GetRolePolicy",
+                "iam:AttachRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:TagRole",
+                "iam:UntagRole",
+                "iam:ListPolicyVersions"
+            ],
+            "Resource": "arn:aws:iam::*:role/*"
+        }
+    ]
 }
 ```
 
@@ -465,11 +490,13 @@ For convenience, here's a single IAM policy that includes all permissions needed
 This policy has been updated to follow the principle of least privilege by scoping permissions to Frigg-specific resources:
 
 **Before (Overly Broad):**
+
 ```json
 "Resource": "*"  // ❌ Too permissive
 ```
 
 **After (Frigg-Specific):**
+
 ```json
 "Resource": [
   "arn:aws:lambda:*:*:function:*frigg*"      // ✅ Only functions containing "frigg"
@@ -491,15 +518,17 @@ This policy has been updated to follow the principle of least privilege by scopi
 For these permissions to work properly, ensure your Frigg applications follow the naming convention of including "frigg" in resource names:
 
 ✅ **Good Examples:**
-- `my-frigg-app-dev` (CloudFormation stack)
-- `integration-frigg-service-auth` (Lambda function)
-- `customer-frigg-platform-prod-auth` (Lambda function)
-- `/my-frigg-app/prod/database-url` (SSM parameter)
-- `internal-error-queue-dev` (SQS queue - special pattern for error queues)
+
+-   `my-frigg-app-dev` (CloudFormation stack)
+-   `integration-frigg-service-auth` (Lambda function)
+-   `customer-frigg-platform-prod-auth` (Lambda function)
+-   `/my-frigg-app/prod/database-url` (SSM parameter)
+-   `internal-error-queue-dev` (SQS queue - special pattern for error queues)
 
 ❌ **Won't Match:**
-- `my-integration-app-dev` (no "frigg" in name)
-- `customer-platform-prod` (no "frigg" in name)
+
+-   `my-integration-app-dev` (no "frigg" in name)
+-   `customer-platform-prod` (no "frigg" in name)
 
 **Note:** The `internal-error-queue-*` pattern is specifically allowed for error handling queues.
 
@@ -519,10 +548,10 @@ You can further restrict permissions by:
 
 ```json
 {
-  "Resource": [
-    "arn:aws:cloudformation:us-east-1:YOUR-ACCOUNT-ID:stack/your-app-*/*",
-    "arn:aws:lambda:us-east-1:YOUR-ACCOUNT-ID:function:your-app-*"
-  ]
+    "Resource": [
+        "arn:aws:cloudformation:us-east-1:YOUR-ACCOUNT-ID:stack/your-app-*/*",
+        "arn:aws:lambda:us-east-1:YOUR-ACCOUNT-ID:function:your-app-*"
+    ]
 }
 ```
 
@@ -530,15 +559,15 @@ You can further restrict permissions by:
 
 The discovery process sets these environment variables during build:
 
-- `AWS_DISCOVERY_VPC_ID` - Your default VPC ID
-- `AWS_DISCOVERY_SECURITY_GROUP_ID` - Default security group ID
-- `AWS_DISCOVERY_SUBNET_ID_1` - First private subnet ID (for Lambda functions)
-- `AWS_DISCOVERY_SUBNET_ID_2` - Second private subnet ID (for Lambda functions, or same as first if only one exists)
-- `AWS_DISCOVERY_PUBLIC_SUBNET_ID` - Public subnet ID (for NAT Gateway placement)
-- `AWS_DISCOVERY_ROUTE_TABLE_ID` - Private route table ID for VPC endpoints
-- `AWS_DISCOVERY_KMS_KEY_ID` - Default KMS key ARN
-- `AWS_DISCOVERY_NAT_GATEWAY_ID` - Existing NAT Gateway ID (if found)
-- `AWS_DISCOVERY_ELASTIC_IP_ALLOCATION_ID` - Existing Elastic IP allocation ID (if found)
+-   `AWS_DISCOVERY_VPC_ID` - Your default VPC ID
+-   `AWS_DISCOVERY_SECURITY_GROUP_ID` - Default security group ID
+-   `AWS_DISCOVERY_SUBNET_ID_1` - First private subnet ID (for Lambda functions)
+-   `AWS_DISCOVERY_SUBNET_ID_2` - Second private subnet ID (for Lambda functions, or same as first if only one exists)
+-   `AWS_DISCOVERY_PUBLIC_SUBNET_ID` - Public subnet ID (for NAT Gateway placement)
+-   `AWS_DISCOVERY_ROUTE_TABLE_ID` - Private route table ID for VPC endpoints
+-   `AWS_DISCOVERY_KMS_KEY_ID` - Default KMS key ARN
+-   `AWS_DISCOVERY_NAT_GATEWAY_ID` - Existing NAT Gateway ID (if found)
+-   `AWS_DISCOVERY_ELASTIC_IP_ALLOCATION_ID` - Existing Elastic IP allocation ID (if found)
 
 ## Troubleshooting
 
@@ -557,17 +586,19 @@ The discovery process sets these environment variables during build:
 ### Fallback Behavior
 
 If AWS discovery fails during build, the framework will:
-- Log a warning message
-- Set fallback environment variables
-- Continue with deployment using safe default values
-- Not fail the build process
+
+-   Log a warning message
+-   Set fallback environment variables
+-   Continue with deployment using safe default values
+-   Not fail the build process
 
 ### Regional Considerations
 
 Ensure your IAM policy includes permissions for the AWS region where you're deploying:
-- Discovery permissions work across all regions (use `*` in resource ARNs)
-- Deployment permissions should match your target region
-- Some services like IAM are global, others are region-specific
+
+-   Discovery permissions work across all regions (use `*` in resource ARNs)
+-   Deployment permissions should match your target region
+-   Some services like IAM are global, others are region-specific
 
 ## Using with CI/CD
 
@@ -584,13 +615,13 @@ Example GitHub Actions configuration:
 - name: Configure AWS credentials
   uses: aws-actions/configure-aws-credentials@v1
   with:
-    aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    aws-region: us-east-1
+      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws-region: us-east-1
 
 - name: Deploy Frigg App
   run: |
-    frigg deploy
+      frigg deploy
 ```
 
 This policy ensures your Frigg application can successfully discover AWS resources during build time and deploy all necessary infrastructure components during deployment.

--- a/packages/devtools/infrastructure/GENERATE-IAM-DOCS.md
+++ b/packages/devtools/infrastructure/GENERATE-IAM-DOCS.md
@@ -14,10 +14,10 @@ npx frigg generate-iam [options]
 
 ### Options
 
-- `-o, --output <path>` - Output directory (default: `backend/infrastructure`)
-- `-u, --user <name>` - Deployment user name (default: `frigg-deployment-user`)
-- `-s, --stack-name <name>` - CloudFormation stack name (default: `frigg-deployment-iam`)
-- `-v, --verbose` - Enable verbose output
+-   `-o, --output <path>` - Output directory (default: `backend/infrastructure`)
+-   `-u, --user <name>` - Deployment user name (default: `frigg-deployment-user`)
+-   `-s, --stack-name <name>` - CloudFormation stack name (default: `frigg-deployment-iam`)
+-   `-v, --verbose` - Enable verbose output
 
 ### Examples
 
@@ -40,33 +40,38 @@ npx frigg generate-iam --verbose
 The command analyzes your `backend/index.js` AppDefinition and generates IAM policies based on:
 
 ### Always Included (Core Features)
-- **CloudFormation** - Stack management permissions
-- **Lambda** - Function deployment and management
-- **IAM** - Role creation and management for Lambda functions
-- **S3** - Deployment bucket access
-- **SQS/SNS** - Messaging services
-- **CloudWatch/Logs** - Monitoring and logging
-- **API Gateway** - REST API management
+
+-   **CloudFormation** - Stack management permissions
+-   **Lambda** - Function deployment and management
+-   **IAM** - Role creation and management for Lambda functions
+-   **S3** - Deployment bucket access
+-   **SQS/SNS** - Messaging services
+-   **CloudWatch/Logs** - Monitoring and logging
+-   **API Gateway** - REST API management
 
 ### Conditionally Included (Based on AppDefinition)
 
 #### VPC Support (`vpc.enable: true`)
-- VPC endpoint creation and management
-- NAT Gateway creation and management
-- Route table and security group management
-- Elastic IP allocation
+
+-   VPC endpoint creation and management
+-   NAT Gateway creation and management
+-   Route table and security group management
+-   Elastic IP allocation
 
 #### KMS Encryption (`encryption.useDefaultKMSForFieldLevelEncryption: true`)
-- KMS key usage for Lambda and S3
-- Data encryption and decryption permissions
+
+-   KMS key usage for Lambda and S3
+-   Data encryption and decryption permissions
 
 #### SSM Parameter Store (`ssm.enable: true`)
-- Parameter retrieval permissions
-- Scoped to parameters containing "frigg" in the path
+
+-   Parameter retrieval permissions
+-   Scoped to parameters containing "frigg" in the path
 
 #### WebSocket Support (`websockets.enable: true`)
-- Currently included in core permissions
-- API Gateway WebSocket management
+
+-   Currently included in core permissions
+-   API Gateway WebSocket management
 
 ## Sample AppDefinition Analysis
 
@@ -77,26 +82,27 @@ const appDefinition = {
     name: 'my-integration-app',
     integrations: [AsanaIntegration, SlackIntegration],
     vpc: {
-        enable: true
+        enable: true,
     },
     encryption: {
-        useDefaultKMSForFieldLevelEncryption: true
+        useDefaultKMSForFieldLevelEncryption: true,
     },
     ssm: {
-        enable: false
+        enable: false,
     },
     websockets: {
-        enable: true
-    }
+        enable: true,
+    },
 };
 ```
 
 The command will generate:
-- ✅ Core deployment permissions
-- ✅ VPC management permissions
-- ✅ KMS encryption permissions  
-- ❌ SSM Parameter Store permissions (disabled)
-- ✅ WebSocket permissions (via core)
+
+-   ✅ Core deployment permissions
+-   ✅ VPC management permissions
+-   ✅ KMS encryption permissions
+-   ❌ SSM Parameter Store permissions (disabled)
+-   ✅ WebSocket permissions (via core)
 
 ## Generated File Structure
 
@@ -110,26 +116,32 @@ backend/infrastructure/
 ## Security Benefits
 
 ### Principle of Least Privilege
-- Only includes permissions your app actually uses
-- Scoped resource patterns (e.g., only resources containing "frigg")
-- No unnecessary cloud service permissions
+
+-   Only includes permissions your app actually uses
+-   Scoped resource patterns (e.g., only resources containing "frigg")
+-   No unnecessary cloud service permissions
 
 ### Resource Scoping
+
 All permissions are scoped to resources following naming patterns:
-- `*frigg*` - General Frigg resources
-- `*serverless*` - Deployment buckets
-- `internal-error-queue-*` - Error handling queues
+
+-   `*frigg*` - General Frigg resources
+-   `*serverless*` - Deployment buckets
+-   `internal-error-queue-*` - Error handling queues
 
 ### Conditional Policies
+
 Feature-specific policies are only created when:
-- The feature is enabled in your AppDefinition
-- CloudFormation conditions control policy attachment
+
+-   The feature is enabled in your AppDefinition
+-   CloudFormation conditions control policy attachment
 
 ## Deployment Workflow
 
 After generating the template:
 
 ### 1. Deploy the Stack
+
 ```bash
 aws cloudformation deploy \
   --template-file backend/infrastructure/frigg-deployment-iam.yaml \
@@ -139,6 +151,7 @@ aws cloudformation deploy \
 ```
 
 ### 2. Retrieve Access Key
+
 ```bash
 aws cloudformation describe-stacks \
   --stack-name frigg-deployment-iam \
@@ -147,6 +160,7 @@ aws cloudformation describe-stacks \
 ```
 
 ### 3. Get Secret Access Key
+
 ```bash
 aws secretsmanager get-secret-value \
   --secret-id frigg-deployment-credentials \
@@ -155,15 +169,18 @@ aws secretsmanager get-secret-value \
 ```
 
 ### 4. Configure CI/CD
+
 Add the credentials to your deployment environment:
-- GitHub Actions: Repository secrets
-- GitLab CI: Environment variables
-- Jenkins: Credentials manager
-- Local: AWS credentials file
+
+-   GitHub Actions: Repository secrets
+-   GitLab CI: Environment variables
+-   Jenkins: Credentials manager
+-   Local: AWS credentials file
 
 ## Troubleshooting
 
 ### Command Not Found
+
 ```bash
 # Install dependencies
 npm install
@@ -173,37 +190,42 @@ ls backend/index.js
 ```
 
 ### No AppDefinition Found
-- Ensure `backend/index.js` exports a `Definition` object
-- Check that the Definition follows the correct structure
+
+-   Ensure `backend/index.js` exports a `Definition` object
+-   Check that the Definition follows the correct structure
 
 ### Permission Errors During Deployment
-- Ensure your AWS CLI is configured with admin permissions
-- Add `--capabilities CAPABILITY_NAMED_IAM` to deployment commands
+
+-   Ensure your AWS CLI is configured with admin permissions
+-   Add `--capabilities CAPABILITY_NAMED_IAM` to deployment commands
 
 ### Generated Policy Too Restrictive
-- Check that your resources follow naming conventions (contain "frigg")
-- Enable additional features in your AppDefinition if needed
-- Review the generated template for resource patterns
+
+-   Check that your resources follow naming conventions (contain "frigg")
+-   Enable additional features in your AppDefinition if needed
+-   Review the generated template for resource patterns
 
 ## Comparison with Generic Template
 
-| Aspect | Generic Template | Generated Template |
-|--------|-----------------|-------------------|
-| Size | ~15KB | ~8-12KB (varies) |
-| Permissions | All features | Only enabled features |
-| Security | Broad access | Scoped access |
-| Maintenance | Manual updates | Auto-generated |
-| Deployment Risk | Over-privileged | Least privilege |
+| Aspect          | Generic Template | Generated Template    |
+| --------------- | ---------------- | --------------------- |
+| Size            | ~15KB            | ~8-12KB (varies)      |
+| Permissions     | All features     | Only enabled features |
+| Security        | Broad access     | Scoped access         |
+| Maintenance     | Manual updates   | Auto-generated        |
+| Deployment Risk | Over-privileged  | Least privilege       |
 
 ## Integration with Development Workflow
 
 ### Local Development
+
 1. Update AppDefinition
 2. Run `npx frigg generate-iam`
 3. Deploy updated IAM stack
 4. Test deployment with new permissions
 
 ### CI/CD Pipeline
+
 ```yaml
 # GitHub Actions example
 - name: Generate IAM Template
@@ -211,16 +233,17 @@ ls backend/index.js
 
 - name: Deploy IAM Stack
   run: |
-    aws cloudformation deploy \
-      --template-file backend/infrastructure/frigg-deployment-iam.yaml \
-      --stack-name ${{ env.STACK_NAME }} \
-      --capabilities CAPABILITY_NAMED_IAM
+      aws cloudformation deploy \
+        --template-file backend/infrastructure/frigg-deployment-iam.yaml \
+        --stack-name ${{ env.STACK_NAME }} \
+        --capabilities CAPABILITY_NAMED_IAM
 ```
 
 ### Version Control
-- Commit generated templates to version control
-- Review changes in pull requests
-- Track permission changes over time
+
+-   Commit generated templates to version control
+-   Review changes in pull requests
+-   Track permission changes over time
 
 ## Best Practices
 
@@ -233,17 +256,19 @@ ls backend/index.js
 ## Advanced Usage
 
 ### Custom Parameter Values
+
 ```bash
 # Enable all features regardless of AppDefinition
 npx frigg generate-iam --verbose
 
 # Then manually edit the generated template to set:
 # EnableVPCSupport: true
-# EnableKMSSupport: true  
+# EnableKMSSupport: true
 # EnableSSMSupport: true
 ```
 
 ### Multiple Environments
+
 ```bash
 # Generate for different environments
 npx frigg generate-iam --stack-name my-app-dev-iam --output ./aws/dev

--- a/packages/devtools/infrastructure/frigg-deployment-iam-stack.yaml
+++ b/packages/devtools/infrastructure/frigg-deployment-iam-stack.yaml
@@ -257,6 +257,26 @@ Resources:
               - 'arn:aws:apigateway:*::/restapis/*'
               - 'arn:aws:apigateway:*::/domainnames'
               - 'arn:aws:apigateway:*::/domainnames/*'
+          
+          # API Gateway v2 permissions
+          - Sid: 'FriggAPIGatewayV2'
+            Effect: Allow
+            Action:
+              - 'apigateway:GET'
+              - 'apigateway:DELETE'
+              - 'apigateway:PATCH'
+              - 'apigateway:POST'
+              - 'apigateway:PUT'
+            Resource:
+              - 'arn:aws:apigateway:*::/apis'
+              - 'arn:aws:apigateway:*::/apis/*'
+              - 'arn:aws:apigateway:*::/apis/*/stages'
+              - 'arn:aws:apigateway:*::/apis/*/stages/*'
+              - 'arn:aws:apigateway:*::/apis/*/mappings'
+              - 'arn:aws:apigateway:*::/apis/*/mappings/*'
+              - 'arn:aws:apigateway:*::/domainnames'
+              - 'arn:aws:apigateway:*::/domainnames/*'
+              - 'arn:aws:apigateway:*::/domainnames/*/apimappings'
 
   # VPC-specific permissions
   FriggVPCPolicy:
@@ -297,6 +317,8 @@ Resources:
               - 'ec2:CreateTags'
               - 'ec2:DeleteTags'
               - 'ec2:DescribeTags'
+              - 'ec2:DetachInternetGateway'
+              - 'ec2:DeleteSubnet'
             Resource: '*'
 
   # KMS permissions

--- a/packages/devtools/infrastructure/iam-generator.js
+++ b/packages/devtools/infrastructure/iam-generator.js
@@ -1,4 +1,3 @@
-const fs = require('fs-extra');
 const path = require('path');
 
 /**
@@ -11,11 +10,8 @@ const path = require('path');
  * @returns {string} CloudFormation YAML template
  */
 function generateIAMCloudFormation(appDefinition, options = {}) {
-    const {
-        deploymentUserName = 'frigg-deployment-user',
-        stackName = 'frigg-deployment-iam',
-        mode = 'auto'
-    } = options;
+    const { deploymentUserName = 'frigg-deployment-user', mode = 'auto' } =
+        options;
 
     // Determine which features are enabled based on mode
     let features;
@@ -24,62 +20,77 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
             vpc: false,
             kms: false,
             ssm: false,
-            websockets: appDefinition.websockets?.enable === true
+            websockets: appDefinition.websockets?.enable === true,
         };
     } else if (mode === 'full') {
         features = {
             vpc: true,
             kms: true,
             ssm: true,
-            websockets: appDefinition.websockets?.enable === true
+            websockets: appDefinition.websockets?.enable === true,
         };
-    } else { // mode === 'auto'
+    } else {
+        // mode === 'auto'
         features = {
             vpc: appDefinition.vpc?.enable === true,
-            kms: appDefinition.encryption?.useDefaultKMSForFieldLevelEncryption === true,
+            kms:
+                appDefinition.encryption
+                    ?.useDefaultKMSForFieldLevelEncryption === true,
             ssm: appDefinition.ssm?.enable === true,
-            websockets: appDefinition.websockets?.enable === true
+            websockets: appDefinition.websockets?.enable === true,
         };
     }
 
     // Build the CloudFormation template
     const template = {
         AWSTemplateFormatVersion: '2010-09-09',
-        Description: `IAM roles and policies for ${appDefinition.name || 'Frigg'} application deployment pipeline`,
-        
+        Description: `IAM roles and policies for ${
+            appDefinition.name || 'Frigg'
+        } application deployment pipeline`,
+
         Parameters: {
             DeploymentUserName: {
                 Type: 'String',
                 Default: deploymentUserName,
-                Description: 'Name for the IAM user that will deploy Frigg applications'
+                Description:
+                    'Name for the IAM user that will deploy Frigg applications',
             },
             EnableVPCSupport: {
                 Type: 'String',
                 Default: features.vpc ? 'true' : 'false',
                 AllowedValues: ['true', 'false'],
-                Description: 'Enable VPC-related permissions for Frigg applications'
+                Description:
+                    'Enable VPC-related permissions for Frigg applications',
             },
             EnableKMSSupport: {
                 Type: 'String',
                 Default: features.kms ? 'true' : 'false',
                 AllowedValues: ['true', 'false'],
-                Description: 'Enable KMS encryption permissions for Frigg applications'
+                Description:
+                    'Enable KMS encryption permissions for Frigg applications',
             },
             EnableSSMSupport: {
                 Type: 'String',
                 Default: features.ssm ? 'true' : 'false',
                 AllowedValues: ['true', 'false'],
-                Description: 'Enable SSM Parameter Store permissions for Frigg applications'
-            }
+                Description:
+                    'Enable SSM Parameter Store permissions for Frigg applications',
+            },
         },
 
         Conditions: {
-            CreateVPCPermissions: { 'Fn::Equals': [{ Ref: 'EnableVPCSupport' }, 'true'] },
-            CreateKMSPermissions: { 'Fn::Equals': [{ Ref: 'EnableKMSSupport' }, 'true'] },
-            CreateSSMPermissions: { 'Fn::Equals': [{ Ref: 'EnableSSMSupport' }, 'true'] }
+            CreateVPCPermissions: {
+                'Fn::Equals': [{ Ref: 'EnableVPCSupport' }, 'true'],
+            },
+            CreateKMSPermissions: {
+                'Fn::Equals': [{ Ref: 'EnableKMSSupport' }, 'true'],
+            },
+            CreateSSMPermissions: {
+                'Fn::Equals': [{ Ref: 'EnableSSMSupport' }, 'true'],
+            },
         },
 
-        Resources: {}
+        Resources: {},
     };
 
     // Add IAM User
@@ -89,34 +100,52 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
             UserName: { Ref: 'DeploymentUserName' },
             ManagedPolicyArns: [
                 { Ref: 'FriggDiscoveryPolicy' },
-                { Ref: 'FriggCoreDeploymentPolicy' }
-            ]
-        }
+                { Ref: 'FriggCoreDeploymentPolicy' },
+            ],
+        },
     };
 
     // Conditionally add feature-specific policies
     if (features.vpc) {
-        template.Resources.FriggDeploymentUser.Properties.ManagedPolicyArns.push({
-            'Fn::If': ['CreateVPCPermissions', { Ref: 'FriggVPCPolicy' }, { Ref: 'AWS::NoValue' }]
-        });
+        template.Resources.FriggDeploymentUser.Properties.ManagedPolicyArns.push(
+            {
+                'Fn::If': [
+                    'CreateVPCPermissions',
+                    { Ref: 'FriggVPCPolicy' },
+                    { Ref: 'AWS::NoValue' },
+                ],
+            }
+        );
     }
     if (features.kms) {
-        template.Resources.FriggDeploymentUser.Properties.ManagedPolicyArns.push({
-            'Fn::If': ['CreateKMSPermissions', { Ref: 'FriggKMSPolicy' }, { Ref: 'AWS::NoValue' }]
-        });
+        template.Resources.FriggDeploymentUser.Properties.ManagedPolicyArns.push(
+            {
+                'Fn::If': [
+                    'CreateKMSPermissions',
+                    { Ref: 'FriggKMSPolicy' },
+                    { Ref: 'AWS::NoValue' },
+                ],
+            }
+        );
     }
     if (features.ssm) {
-        template.Resources.FriggDeploymentUser.Properties.ManagedPolicyArns.push({
-            'Fn::If': ['CreateSSMPermissions', { Ref: 'FriggSSMPolicy' }, { Ref: 'AWS::NoValue' }]
-        });
+        template.Resources.FriggDeploymentUser.Properties.ManagedPolicyArns.push(
+            {
+                'Fn::If': [
+                    'CreateSSMPermissions',
+                    { Ref: 'FriggSSMPolicy' },
+                    { Ref: 'AWS::NoValue' },
+                ],
+            }
+        );
     }
 
     // Add Access Key
     template.Resources.FriggDeploymentAccessKey = {
         Type: 'AWS::IAM::AccessKey',
         Properties: {
-            UserName: { Ref: 'FriggDeploymentUser' }
-        }
+            UserName: { Ref: 'FriggDeploymentUser' },
+        },
     };
 
     // Add Discovery Policy (always needed)
@@ -124,7 +153,8 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
         Type: 'AWS::IAM::ManagedPolicy',
         Properties: {
             ManagedPolicyName: 'FriggDiscoveryPolicy',
-            Description: 'Permissions for AWS resource discovery during Frigg build process',
+            Description:
+                'Permissions for AWS resource discovery during Frigg build process',
             PolicyDocument: {
                 Version: '2012-10-17',
                 Statement: [
@@ -140,122 +170,16 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
                             'ec2:DescribeNatGateways',
                             'ec2:DescribeAddresses',
                             'kms:ListKeys',
-                            'kms:DescribeKey'
+                            'kms:DescribeKey',
                         ],
-                        Resource: '*'
-                    }
-                ]
-            }
-        }
+                        Resource: '*',
+                    },
+                ],
+            },
+        },
     };
 
     // Add Core Deployment Policy (always needed)
-    const coreActions = [
-        // CloudFormation permissions
-        'cloudformation:CreateStack',
-        'cloudformation:UpdateStack',
-        'cloudformation:DeleteStack',
-        'cloudformation:DescribeStacks',
-        'cloudformation:DescribeStackEvents',
-        'cloudformation:DescribeStackResources',
-        'cloudformation:DescribeStackResource',
-        'cloudformation:ListStackResources',
-        'cloudformation:GetTemplate',
-        'cloudformation:DescribeChangeSet',
-        'cloudformation:CreateChangeSet',
-        'cloudformation:DeleteChangeSet',
-        'cloudformation:ExecuteChangeSet',
-        'cloudformation:ValidateTemplate',
-        
-        // Lambda permissions
-        'lambda:CreateFunction',
-        'lambda:UpdateFunctionCode',
-        'lambda:UpdateFunctionConfiguration',
-        'lambda:DeleteFunction',
-        'lambda:GetFunction',
-        'lambda:ListFunctions',
-        'lambda:PublishVersion',
-        'lambda:CreateAlias',
-        'lambda:UpdateAlias',
-        'lambda:DeleteAlias',
-        'lambda:GetAlias',
-        'lambda:AddPermission',
-        'lambda:RemovePermission',
-        'lambda:GetPolicy',
-        'lambda:PutProvisionedConcurrencyConfig',
-        'lambda:DeleteProvisionedConcurrencyConfig',
-        'lambda:PutConcurrency',
-        'lambda:DeleteConcurrency',
-        'lambda:TagResource',
-        'lambda:UntagResource',
-        'lambda:ListVersionsByFunction',
-        
-        // IAM permissions
-        'iam:CreateRole',
-        'iam:DeleteRole',
-        'iam:GetRole',
-        'iam:PassRole',
-        'iam:PutRolePolicy',
-        'iam:DeleteRolePolicy',
-        'iam:GetRolePolicy',
-        'iam:AttachRolePolicy',
-        'iam:DetachRolePolicy',
-        'iam:TagRole',
-        'iam:UntagRole',
-        'iam:ListPolicyVersions',
-        
-        // S3 permissions
-        's3:CreateBucket',
-        's3:PutObject',
-        's3:GetObject',
-        's3:DeleteObject',
-        's3:PutBucketPolicy',
-        's3:PutBucketVersioning',
-        's3:PutBucketPublicAccessBlock',
-        's3:GetBucketLocation',
-        's3:ListBucket',
-        
-        // SQS permissions
-        'sqs:CreateQueue',
-        'sqs:DeleteQueue',
-        'sqs:GetQueueAttributes',
-        'sqs:SetQueueAttributes',
-        'sqs:GetQueueUrl',
-        'sqs:TagQueue',
-        'sqs:UntagQueue',
-        
-        // SNS permissions
-        'sns:CreateTopic',
-        'sns:DeleteTopic',
-        'sns:GetTopicAttributes',
-        'sns:SetTopicAttributes',
-        'sns:Subscribe',
-        'sns:Unsubscribe',
-        'sns:ListSubscriptionsByTopic',
-        'sns:TagResource',
-        'sns:UntagResource',
-        
-        // CloudWatch and Logs permissions
-        'cloudwatch:PutMetricAlarm',
-        'cloudwatch:DeleteAlarms',
-        'cloudwatch:DescribeAlarms',
-        'logs:CreateLogGroup',
-        'logs:CreateLogStream',
-        'logs:DeleteLogGroup',
-        'logs:DescribeLogGroups',
-        'logs:DescribeLogStreams',
-        'logs:FilterLogEvents',
-        'logs:PutLogEvents',
-        'logs:PutRetentionPolicy',
-        
-        // API Gateway permissions
-        'apigateway:POST',
-        'apigateway:PUT',
-        'apigateway:DELETE',
-        'apigateway:GET',
-        'apigateway:PATCH'
-    ];
-
     const coreStatements = [
         {
             Sid: 'CloudFormationFriggStacks',
@@ -273,17 +197,20 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
                 'cloudformation:DescribeChangeSet',
                 'cloudformation:CreateChangeSet',
                 'cloudformation:DeleteChangeSet',
-                'cloudformation:ExecuteChangeSet'
+                'cloudformation:ExecuteChangeSet',
             ],
             Resource: [
-                { 'Fn::Sub': 'arn:aws:cloudformation:*:${AWS::AccountId}:stack/*frigg*/*' }
-            ]
+                {
+                    'Fn::Sub':
+                        'arn:aws:cloudformation:*:${AWS::AccountId}:stack/*frigg*/*',
+                },
+            ],
         },
         {
             Sid: 'CloudFormationValidateTemplate',
             Effect: 'Allow',
             Action: ['cloudformation:ValidateTemplate'],
-            Resource: '*'
+            Resource: '*',
         },
         {
             Sid: 'S3DeploymentBucket',
@@ -297,12 +224,12 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
                 's3:PutBucketVersioning',
                 's3:PutBucketPublicAccessBlock',
                 's3:GetBucketLocation',
-                's3:ListBucket'
+                's3:ListBucket',
             ],
             Resource: [
                 'arn:aws:s3:::*serverless*',
-                'arn:aws:s3:::*serverless*/*'
-            ]
+                'arn:aws:s3:::*serverless*/*',
+            ],
         },
         {
             Sid: 'LambdaFriggFunctions',
@@ -328,11 +255,14 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
                 'lambda:DeleteConcurrency',
                 'lambda:TagResource',
                 'lambda:UntagResource',
-                'lambda:ListVersionsByFunction'
+                'lambda:ListVersionsByFunction',
             ],
             Resource: [
-                { 'Fn::Sub': 'arn:aws:lambda:*:${AWS::AccountId}:function:*frigg*' }
-            ]
+                {
+                    'Fn::Sub':
+                        'arn:aws:lambda:*:${AWS::AccountId}:function:*frigg*',
+                },
+            ],
         },
         {
             Sid: 'IAMRolesForFriggLambda',
@@ -348,18 +278,23 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
                 'iam:AttachRolePolicy',
                 'iam:DetachRolePolicy',
                 'iam:TagRole',
-                'iam:UntagRole'
+                'iam:UntagRole',
             ],
             Resource: [
                 { 'Fn::Sub': 'arn:aws:iam::${AWS::AccountId}:role/*frigg*' },
-                { 'Fn::Sub': 'arn:aws:iam::${AWS::AccountId}:role/*frigg*LambdaRole*' }
-            ]
+                {
+                    'Fn::Sub':
+                        'arn:aws:iam::${AWS::AccountId}:role/*frigg*LambdaRole*',
+                },
+            ],
         },
         {
             Sid: 'IAMPolicyVersionPermissions',
             Effect: 'Allow',
             Action: ['iam:ListPolicyVersions'],
-            Resource: [{ 'Fn::Sub': 'arn:aws:iam::${AWS::AccountId}:policy/*' }]
+            Resource: [
+                { 'Fn::Sub': 'arn:aws:iam::${AWS::AccountId}:policy/*' },
+            ],
         },
         {
             Sid: 'FriggMessagingServices',
@@ -371,12 +306,15 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
                 'sqs:SetQueueAttributes',
                 'sqs:GetQueueUrl',
                 'sqs:TagQueue',
-                'sqs:UntagQueue'
+                'sqs:UntagQueue',
             ],
             Resource: [
                 { 'Fn::Sub': 'arn:aws:sqs:*:${AWS::AccountId}:*frigg*' },
-                { 'Fn::Sub': 'arn:aws:sqs:*:${AWS::AccountId}:internal-error-queue-*' }
-            ]
+                {
+                    'Fn::Sub':
+                        'arn:aws:sqs:*:${AWS::AccountId}:internal-error-queue-*',
+                },
+            ],
         },
         {
             Sid: 'FriggSNSTopics',
@@ -390,11 +328,11 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
                 'sns:Unsubscribe',
                 'sns:ListSubscriptionsByTopic',
                 'sns:TagResource',
-                'sns:UntagResource'
+                'sns:UntagResource',
             ],
             Resource: [
-                { 'Fn::Sub': 'arn:aws:sns:*:${AWS::AccountId}:*frigg*' }
-            ]
+                { 'Fn::Sub': 'arn:aws:sns:*:${AWS::AccountId}:*frigg*' },
+            ],
         },
         {
             Sid: 'FriggMonitoringAndLogs',
@@ -410,13 +348,22 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
                 'logs:DescribeLogStreams',
                 'logs:FilterLogEvents',
                 'logs:PutLogEvents',
-                'logs:PutRetentionPolicy'
+                'logs:PutRetentionPolicy',
             ],
             Resource: [
-                { 'Fn::Sub': 'arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*frigg*' },
-                { 'Fn::Sub': 'arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*frigg*:*' },
-                { 'Fn::Sub': 'arn:aws:cloudwatch:*:${AWS::AccountId}:alarm:*frigg*' }
-            ]
+                {
+                    'Fn::Sub':
+                        'arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*frigg*',
+                },
+                {
+                    'Fn::Sub':
+                        'arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*frigg*:*',
+                },
+                {
+                    'Fn::Sub':
+                        'arn:aws:cloudwatch:*:${AWS::AccountId}:alarm:*frigg*',
+                },
+            ],
         },
         {
             Sid: 'FriggAPIGateway',
@@ -426,17 +373,37 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
                 'apigateway:PUT',
                 'apigateway:DELETE',
                 'apigateway:GET',
-                'apigateway:PATCH'
+                'apigateway:PATCH',
             ],
             Resource: [
                 'arn:aws:apigateway:*::/restapis',
                 'arn:aws:apigateway:*::/restapis/*',
+                'arn:aws:apigateway:*::/domainnames',
+                'arn:aws:apigateway:*::/domainnames/*',
+            ],
+        },
+        {
+            Sid: 'FriggAPIGatewayV2',
+            Effect: 'Allow',
+            Action: [
+                'apigateway:GET',
+                'apigateway:DELETE',
+                'apigateway:PATCH',
+                'apigateway:POST',
+                'apigateway:PUT',
+            ],
+            Resource: [
                 'arn:aws:apigateway:*::/apis',
                 'arn:aws:apigateway:*::/apis/*',
+                'arn:aws:apigateway:*::/apis/*/stages',
+                'arn:aws:apigateway:*::/apis/*/stages/*',
+                'arn:aws:apigateway:*::/apis/*/mappings',
+                'arn:aws:apigateway:*::/apis/*/mappings/*',
                 'arn:aws:apigateway:*::/domainnames',
-                'arn:aws:apigateway:*::/domainnames/*'
-            ]
-        }
+                'arn:aws:apigateway:*::/domainnames/*',
+                'arn:aws:apigateway:*::/domainnames/*/apimappings',
+            ],
+        },
     ];
 
     template.Resources.FriggCoreDeploymentPolicy = {
@@ -446,9 +413,9 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
             Description: 'Core permissions for deploying Frigg applications',
             PolicyDocument: {
                 Version: '2012-10-17',
-                Statement: coreStatements
-            }
-        }
+                Statement: coreStatements,
+            },
+        },
     };
 
     // Add feature-specific policies only if needed
@@ -488,13 +455,15 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
                                 'ec2:AuthorizeSecurityGroupEgress',
                                 'ec2:AuthorizeSecurityGroupIngress',
                                 'ec2:RevokeSecurityGroupEgress',
-                                'ec2:RevokeSecurityGroupIngress'
+                                'ec2:RevokeSecurityGroupIngress',
+                                'ec2:DetachInternetGateway',
+                                'ec2:DeleteSubnet',
                             ],
-                            Resource: '*'
-                        }
-                    ]
-                }
-            }
+                            Resource: '*',
+                        },
+                    ],
+                },
+            },
         };
     }
 
@@ -504,32 +473,33 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
             Condition: 'CreateKMSPermissions',
             Properties: {
                 ManagedPolicyName: 'FriggKMSPolicy',
-                Description: 'KMS encryption permissions for Frigg applications',
+                Description:
+                    'KMS encryption permissions for Frigg applications',
                 PolicyDocument: {
                     Version: '2012-10-17',
                     Statement: [
                         {
                             Sid: 'FriggKMSEncryptionRuntime',
                             Effect: 'Allow',
-                            Action: [
-                                'kms:GenerateDataKey',
-                                'kms:Decrypt'
-                            ],
+                            Action: ['kms:GenerateDataKey', 'kms:Decrypt'],
                             Resource: [
-                                { 'Fn::Sub': 'arn:aws:kms:*:${AWS::AccountId}:key/*' }
+                                {
+                                    'Fn::Sub':
+                                        'arn:aws:kms:*:${AWS::AccountId}:key/*',
+                                },
                             ],
                             Condition: {
                                 StringEquals: {
                                     'kms:ViaService': [
                                         'lambda.*.amazonaws.com',
-                                        's3.*.amazonaws.com'
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            }
+                                        's3.*.amazonaws.com',
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
         };
     }
 
@@ -539,7 +509,8 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
             Condition: 'CreateSSMPermissions',
             Properties: {
                 ManagedPolicyName: 'FriggSSMPolicy',
-                Description: 'SSM Parameter Store permissions for Frigg applications',
+                Description:
+                    'SSM Parameter Store permissions for Frigg applications',
                 PolicyDocument: {
                     Version: '2012-10-17',
                     Statement: [
@@ -549,16 +520,22 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
                             Action: [
                                 'ssm:GetParameter',
                                 'ssm:GetParameters',
-                                'ssm:GetParametersByPath'
+                                'ssm:GetParametersByPath',
                             ],
                             Resource: [
-                                { 'Fn::Sub': 'arn:aws:ssm:*:${AWS::AccountId}:parameter/*frigg*' },
-                                { 'Fn::Sub': 'arn:aws:ssm:*:${AWS::AccountId}:parameter/*frigg*/*' }
-                            ]
-                        }
-                    ]
-                }
-            }
+                                {
+                                    'Fn::Sub':
+                                        'arn:aws:ssm:*:${AWS::AccountId}:parameter/*frigg*',
+                                },
+                                {
+                                    'Fn::Sub':
+                                        'arn:aws:ssm:*:${AWS::AccountId}:parameter/*frigg*/*',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
         };
     }
 
@@ -571,10 +548,11 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
             SecretString: {
                 'Fn::Sub': JSON.stringify({
                     AccessKeyId: '${FriggDeploymentAccessKey}',
-                    SecretAccessKey: '${FriggDeploymentAccessKey.SecretAccessKey}'
-                })
-            }
-        }
+                    SecretAccessKey:
+                        '${FriggDeploymentAccessKey.SecretAccessKey}',
+                }),
+            },
+        },
     };
 
     // Add Outputs
@@ -583,29 +561,30 @@ function generateIAMCloudFormation(appDefinition, options = {}) {
             Description: 'ARN of the Frigg deployment user',
             Value: { 'Fn::GetAtt': ['FriggDeploymentUser', 'Arn'] },
             Export: {
-                Name: { 'Fn::Sub': '${AWS::StackName}-UserArn' }
-            }
+                Name: { 'Fn::Sub': '${AWS::StackName}-UserArn' },
+            },
         },
         AccessKeyId: {
             Description: 'Access Key ID for the deployment user',
             Value: { Ref: 'FriggDeploymentAccessKey' },
             Export: {
-                Name: { 'Fn::Sub': '${AWS::StackName}-AccessKeyId' }
-            }
+                Name: { 'Fn::Sub': '${AWS::StackName}-AccessKeyId' },
+            },
         },
         SecretAccessKeyCommand: {
             Description: 'Command to retrieve the secret access key',
             Value: {
-                'Fn::Sub': 'aws secretsmanager get-secret-value --secret-id frigg-deployment-credentials --query SecretString --output text | jq -r .SecretAccessKey'
-            }
+                'Fn::Sub':
+                    'aws secretsmanager get-secret-value --secret-id frigg-deployment-credentials --query SecretString --output text | jq -r .SecretAccessKey',
+            },
         },
         CredentialsSecretArn: {
             Description: 'ARN of the secret containing deployment credentials',
             Value: { Ref: 'FriggDeploymentCredentials' },
             Export: {
-                Name: { 'Fn::Sub': '${AWS::StackName}-CredentialsSecretArn' }
-            }
-        }
+                Name: { 'Fn::Sub': '${AWS::StackName}-CredentialsSecretArn' },
+            },
+        },
     };
 
     // Convert to YAML
@@ -623,7 +602,7 @@ function convertToYAML(obj) {
         indent: 2,
         lineWidth: 120,
         noRefs: true,
-        sortKeys: false
+        sortKeys: false,
     });
 }
 
@@ -636,9 +615,11 @@ function getFeatureSummary(appDefinition) {
     const features = {
         core: true, // Always enabled
         vpc: appDefinition.vpc?.enable === true,
-        kms: appDefinition.encryption?.useDefaultKMSForFieldLevelEncryption === true,
+        kms:
+            appDefinition.encryption?.useDefaultKMSForFieldLevelEncryption ===
+            true,
         ssm: appDefinition.ssm?.enable === true,
-        websockets: appDefinition.websockets?.enable === true
+        websockets: appDefinition.websockets?.enable === true,
     };
 
     const integrationCount = appDefinition.integrations?.length || 0;
@@ -646,7 +627,7 @@ function getFeatureSummary(appDefinition) {
     return {
         features,
         integrationCount,
-        appName: appDefinition.name || 'Unnamed Frigg App'
+        appName: appDefinition.name || 'Unnamed Frigg App',
     };
 }
 
@@ -685,5 +666,5 @@ module.exports = {
     getFeatureSummary,
     generateBasicIAMPolicy,
     generateFullIAMPolicy,
-    generateIAMPolicy
+    generateIAMPolicy,
 };

--- a/packages/devtools/infrastructure/serverless-template.js
+++ b/packages/devtools/infrastructure/serverless-template.js
@@ -555,6 +555,14 @@ const composeServerlessDefinition = async (AppDefinition) => {
         }
     }
 
+    // Debug: log keys of env vars available during deploy (to verify GA -> Serverless pass-through)
+    try {
+        const envKeys = Object.keys(process.env || {}).sort();
+        console.log('Frigg deploy env keys (sample):', envKeys.slice(0, 30), `... total=${envKeys.length}`);
+    } catch (e) {
+        console.log('Frigg deploy env keys: <unavailable>', e?.message);
+    }
+
     const definition = {
         frameworkVersion: '>=3.17.0',
         service: AppDefinition.name || 'create-frigg-app',

--- a/packages/devtools/infrastructure/serverless-template.js
+++ b/packages/devtools/infrastructure/serverless-template.js
@@ -8,9 +8,12 @@ const { AWSDiscovery } = require('./aws-discovery');
  * @returns {boolean} True if discovery should run
  */
 const shouldRunDiscovery = (AppDefinition) => {
-    return AppDefinition.vpc?.enable === true ||
-        AppDefinition.encryption?.useDefaultKMSForFieldLevelEncryption === true ||
-        AppDefinition.ssm?.enable === true;
+    return (
+        AppDefinition.vpc?.enable === true ||
+        AppDefinition.encryption?.useDefaultKMSForFieldLevelEncryption ===
+            true ||
+        AppDefinition.ssm?.enable === true
+    );
 };
 
 /**
@@ -32,7 +35,9 @@ const findNodeModulesPath = () => {
             const potentialPath = path.join(currentDir, 'node_modules');
             if (fs.existsSync(potentialPath)) {
                 nodeModulesPath = potentialPath;
-                console.log(`Found node_modules at: ${nodeModulesPath} (method 1)`);
+                console.log(
+                    `Found node_modules at: ${nodeModulesPath} (method 1)`
+                );
                 break;
             }
             // Move up one directory
@@ -49,10 +54,14 @@ const findNodeModulesPath = () => {
             try {
                 // This requires child_process, so let's require it here
                 const { execSync } = require('node:child_process');
-                const npmRoot = execSync('npm root', { encoding: 'utf8' }).trim();
+                const npmRoot = execSync('npm root', {
+                    encoding: 'utf8',
+                }).trim();
                 if (fs.existsSync(npmRoot)) {
                     nodeModulesPath = npmRoot;
-                    console.log(`Found node_modules at: ${nodeModulesPath} (method 2)`);
+                    console.log(
+                        `Found node_modules at: ${nodeModulesPath} (method 2)`
+                    );
                 }
             } catch (npmError) {
                 console.error('Error executing npm root:', npmError);
@@ -65,10 +74,15 @@ const findNodeModulesPath = () => {
             for (let i = 0; i < 5; i++) {
                 const packageJsonPath = path.join(currentDir, 'package.json');
                 if (fs.existsSync(packageJsonPath)) {
-                    const potentialNodeModules = path.join(currentDir, 'node_modules');
+                    const potentialNodeModules = path.join(
+                        currentDir,
+                        'node_modules'
+                    );
                     if (fs.existsSync(potentialNodeModules)) {
                         nodeModulesPath = potentialNodeModules;
-                        console.log(`Found node_modules at: ${nodeModulesPath} (method 3)`);
+                        console.log(
+                            `Found node_modules at: ${nodeModulesPath} (method 3)`
+                        );
                         break;
                     }
                 }
@@ -86,7 +100,9 @@ const findNodeModulesPath = () => {
             return nodeModulesPath;
         }
 
-        console.warn('Could not find node_modules path, falling back to default');
+        console.warn(
+            'Could not find node_modules path, falling back to default'
+        );
         return path.resolve(process.cwd(), '../node_modules');
     } catch (error) {
         console.error('Error finding node_modules path:', error);
@@ -119,8 +135,13 @@ const modifyHandlerPaths = (functions) => {
         if (functionDef?.handler?.includes('node_modules/')) {
             // Replace node_modules/ with the actual path to node_modules/
             const relativePath = path.relative(process.cwd(), nodeModulesPath);
-            functionDef.handler = functionDef.handler.replace('node_modules/', `${relativePath}/`);
-            console.log(`Updated handler for ${functionName}: ${functionDef.handler}`);
+            functionDef.handler = functionDef.handler.replace(
+                'node_modules/',
+                `${relativePath}/`
+            );
+            console.log(
+                `Updated handler for ${functionName}: ${functionDef.handler}`
+            );
         }
     }
 
@@ -145,9 +166,12 @@ const createVPCInfrastructure = (AppDefinition) => {
                 EnableDnsHostnames: true,
                 EnableDnsSupport: true,
                 Tags: [
-                    { Key: 'Name', Value: '${self:service}-${self:provider.stage}-vpc' }
-                ]
-            }
+                    {
+                        Key: 'Name',
+                        Value: '${self:service}-${self:provider.stage}-vpc',
+                    },
+                ],
+            },
         },
 
         // Internet Gateway
@@ -155,9 +179,12 @@ const createVPCInfrastructure = (AppDefinition) => {
             Type: 'AWS::EC2::InternetGateway',
             Properties: {
                 Tags: [
-                    { Key: 'Name', Value: '${self:service}-${self:provider.stage}-igw' }
-                ]
-            }
+                    {
+                        Key: 'Name',
+                        Value: '${self:service}-${self:provider.stage}-igw',
+                    },
+                ],
+            },
         },
 
         // Attach Internet Gateway to VPC
@@ -165,8 +192,8 @@ const createVPCInfrastructure = (AppDefinition) => {
             Type: 'AWS::EC2::VPCGatewayAttachment',
             Properties: {
                 VpcId: { Ref: 'FriggVPC' },
-                InternetGatewayId: { Ref: 'FriggInternetGateway' }
-            }
+                InternetGatewayId: { Ref: 'FriggInternetGateway' },
+            },
         },
 
         // Public Subnet for NAT Gateway
@@ -178,9 +205,12 @@ const createVPCInfrastructure = (AppDefinition) => {
                 AvailabilityZone: { 'Fn::Select': [0, { 'Fn::GetAZs': '' }] },
                 MapPublicIpOnLaunch: true,
                 Tags: [
-                    { Key: 'Name', Value: '${self:service}-${self:provider.stage}-public-subnet' }
-                ]
-            }
+                    {
+                        Key: 'Name',
+                        Value: '${self:service}-${self:provider.stage}-public-subnet',
+                    },
+                ],
+            },
         },
 
         // Private Subnet 1 for Lambda
@@ -191,9 +221,12 @@ const createVPCInfrastructure = (AppDefinition) => {
                 CidrBlock: '10.0.2.0/24',
                 AvailabilityZone: { 'Fn::Select': [0, { 'Fn::GetAZs': '' }] },
                 Tags: [
-                    { Key: 'Name', Value: '${self:service}-${self:provider.stage}-private-subnet-1' }
-                ]
-            }
+                    {
+                        Key: 'Name',
+                        Value: '${self:service}-${self:provider.stage}-private-subnet-1',
+                    },
+                ],
+            },
         },
 
         // Private Subnet 2 for Lambda (different AZ for redundancy)
@@ -204,9 +237,12 @@ const createVPCInfrastructure = (AppDefinition) => {
                 CidrBlock: '10.0.3.0/24',
                 AvailabilityZone: { 'Fn::Select': [1, { 'Fn::GetAZs': '' }] },
                 Tags: [
-                    { Key: 'Name', Value: '${self:service}-${self:provider.stage}-private-subnet-2' }
-                ]
-            }
+                    {
+                        Key: 'Name',
+                        Value: '${self:service}-${self:provider.stage}-private-subnet-2',
+                    },
+                ],
+            },
         },
 
         // Elastic IP for NAT Gateway
@@ -215,22 +251,30 @@ const createVPCInfrastructure = (AppDefinition) => {
             Properties: {
                 Domain: 'vpc',
                 Tags: [
-                    { Key: 'Name', Value: '${self:service}-${self:provider.stage}-nat-eip' }
-                ]
+                    {
+                        Key: 'Name',
+                        Value: '${self:service}-${self:provider.stage}-nat-eip',
+                    },
+                ],
             },
-            DependsOn: 'FriggVPCGatewayAttachment'
+            DependsOn: 'FriggVPCGatewayAttachment',
         },
 
         // NAT Gateway for private subnet internet access
         FriggNATGateway: {
             Type: 'AWS::EC2::NatGateway',
             Properties: {
-                AllocationId: { 'Fn::GetAtt': ['FriggNATGatewayEIP', 'AllocationId'] },
+                AllocationId: {
+                    'Fn::GetAtt': ['FriggNATGatewayEIP', 'AllocationId'],
+                },
                 SubnetId: { Ref: 'FriggPublicSubnet' },
                 Tags: [
-                    { Key: 'Name', Value: '${self:service}-${self:provider.stage}-nat-gateway' }
-                ]
-            }
+                    {
+                        Key: 'Name',
+                        Value: '${self:service}-${self:provider.stage}-nat-gateway',
+                    },
+                ],
+            },
         },
 
         // Public Route Table
@@ -239,9 +283,12 @@ const createVPCInfrastructure = (AppDefinition) => {
             Properties: {
                 VpcId: { Ref: 'FriggVPC' },
                 Tags: [
-                    { Key: 'Name', Value: '${self:service}-${self:provider.stage}-public-rt' }
-                ]
-            }
+                    {
+                        Key: 'Name',
+                        Value: '${self:service}-${self:provider.stage}-public-rt',
+                    },
+                ],
+            },
         },
 
         // Public Route to Internet Gateway
@@ -250,9 +297,9 @@ const createVPCInfrastructure = (AppDefinition) => {
             Properties: {
                 RouteTableId: { Ref: 'FriggPublicRouteTable' },
                 DestinationCidrBlock: '0.0.0.0/0',
-                GatewayId: { Ref: 'FriggInternetGateway' }
+                GatewayId: { Ref: 'FriggInternetGateway' },
             },
-            DependsOn: 'FriggVPCGatewayAttachment'
+            DependsOn: 'FriggVPCGatewayAttachment',
         },
 
         // Associate Public Subnet with Public Route Table
@@ -260,8 +307,8 @@ const createVPCInfrastructure = (AppDefinition) => {
             Type: 'AWS::EC2::SubnetRouteTableAssociation',
             Properties: {
                 SubnetId: { Ref: 'FriggPublicSubnet' },
-                RouteTableId: { Ref: 'FriggPublicRouteTable' }
-            }
+                RouteTableId: { Ref: 'FriggPublicRouteTable' },
+            },
         },
 
         // Private Route Table
@@ -270,9 +317,12 @@ const createVPCInfrastructure = (AppDefinition) => {
             Properties: {
                 VpcId: { Ref: 'FriggVPC' },
                 Tags: [
-                    { Key: 'Name', Value: '${self:service}-${self:provider.stage}-private-rt' }
-                ]
-            }
+                    {
+                        Key: 'Name',
+                        Value: '${self:service}-${self:provider.stage}-private-rt',
+                    },
+                ],
+            },
         },
 
         // Private Route to NAT Gateway
@@ -281,8 +331,8 @@ const createVPCInfrastructure = (AppDefinition) => {
             Properties: {
                 RouteTableId: { Ref: 'FriggPrivateRouteTable' },
                 DestinationCidrBlock: '0.0.0.0/0',
-                NatGatewayId: { Ref: 'FriggNATGateway' }
-            }
+                NatGatewayId: { Ref: 'FriggNATGateway' },
+            },
         },
 
         // Associate Private Subnet 1 with Private Route Table
@@ -290,8 +340,8 @@ const createVPCInfrastructure = (AppDefinition) => {
             Type: 'AWS::EC2::SubnetRouteTableAssociation',
             Properties: {
                 SubnetId: { Ref: 'FriggPrivateSubnet1' },
-                RouteTableId: { Ref: 'FriggPrivateRouteTable' }
-            }
+                RouteTableId: { Ref: 'FriggPrivateRouteTable' },
+            },
         },
 
         // Associate Private Subnet 2 with Private Route Table
@@ -299,8 +349,8 @@ const createVPCInfrastructure = (AppDefinition) => {
             Type: 'AWS::EC2::SubnetRouteTableAssociation',
             Properties: {
                 SubnetId: { Ref: 'FriggPrivateSubnet2' },
-                RouteTableId: { Ref: 'FriggPrivateRouteTable' }
-            }
+                RouteTableId: { Ref: 'FriggPrivateRouteTable' },
+            },
         },
 
         // Security Group for Lambda functions
@@ -315,35 +365,38 @@ const createVPCInfrastructure = (AppDefinition) => {
                         FromPort: 443,
                         ToPort: 443,
                         CidrIp: '0.0.0.0/0',
-                        Description: 'HTTPS outbound'
+                        Description: 'HTTPS outbound',
                     },
                     {
                         IpProtocol: 'tcp',
                         FromPort: 80,
                         ToPort: 80,
                         CidrIp: '0.0.0.0/0',
-                        Description: 'HTTP outbound'
+                        Description: 'HTTP outbound',
                     },
                     {
                         IpProtocol: 'tcp',
                         FromPort: 53,
                         ToPort: 53,
                         CidrIp: '0.0.0.0/0',
-                        Description: 'DNS TCP'
+                        Description: 'DNS TCP',
                     },
                     {
                         IpProtocol: 'udp',
                         FromPort: 53,
                         ToPort: 53,
                         CidrIp: '0.0.0.0/0',
-                        Description: 'DNS UDP'
-                    }
+                        Description: 'DNS UDP',
+                    },
                 ],
                 Tags: [
-                    { Key: 'Name', Value: '${self:service}-${self:provider.stage}-lambda-sg' }
-                ]
-            }
-        }
+                    {
+                        Key: 'Name',
+                        Value: '${self:service}-${self:provider.stage}-lambda-sg',
+                    },
+                ],
+            },
+        },
     };
 
     // Add VPC Endpoints for cost optimization
@@ -355,10 +408,8 @@ const createVPCInfrastructure = (AppDefinition) => {
                 VpcId: { Ref: 'FriggVPC' },
                 ServiceName: 'com.amazonaws.${self:provider.region}.s3',
                 VpcEndpointType: 'Gateway',
-                RouteTableIds: [
-                    { Ref: 'FriggPrivateRouteTable' }
-                ]
-            }
+                RouteTableIds: [{ Ref: 'FriggPrivateRouteTable' }],
+            },
         };
 
         // DynamoDB Gateway Endpoint (free)
@@ -368,14 +419,15 @@ const createVPCInfrastructure = (AppDefinition) => {
                 VpcId: { Ref: 'FriggVPC' },
                 ServiceName: 'com.amazonaws.${self:provider.region}.dynamodb',
                 VpcEndpointType: 'Gateway',
-                RouteTableIds: [
-                    { Ref: 'FriggPrivateRouteTable' }
-                ]
-            }
+                RouteTableIds: [{ Ref: 'FriggPrivateRouteTable' }],
+            },
         };
 
         // KMS Interface Endpoint (paid, but useful if using KMS)
-        if (AppDefinition.encryption?.useDefaultKMSForFieldLevelEncryption === true) {
+        if (
+            AppDefinition.encryption?.useDefaultKMSForFieldLevelEncryption ===
+            true
+        ) {
             vpcResources.FriggKMSVPCEndpoint = {
                 Type: 'AWS::EC2::VPCEndpoint',
                 Properties: {
@@ -384,13 +436,13 @@ const createVPCInfrastructure = (AppDefinition) => {
                     VpcEndpointType: 'Interface',
                     SubnetIds: [
                         { Ref: 'FriggPrivateSubnet1' },
-                        { Ref: 'FriggPrivateSubnet2' }
+                        { Ref: 'FriggPrivateSubnet2' },
                     ],
                     SecurityGroupIds: [
-                        { Ref: 'FriggVPCEndpointSecurityGroup' }
+                        { Ref: 'FriggVPCEndpointSecurityGroup' },
                     ],
-                    PrivateDnsEnabled: true
-                }
+                    PrivateDnsEnabled: true,
+                },
             };
         }
 
@@ -399,17 +451,16 @@ const createVPCInfrastructure = (AppDefinition) => {
             Type: 'AWS::EC2::VPCEndpoint',
             Properties: {
                 VpcId: { Ref: 'FriggVPC' },
-                ServiceName: 'com.amazonaws.${self:provider.region}.secretsmanager',
+                ServiceName:
+                    'com.amazonaws.${self:provider.region}.secretsmanager',
                 VpcEndpointType: 'Interface',
                 SubnetIds: [
                     { Ref: 'FriggPrivateSubnet1' },
-                    { Ref: 'FriggPrivateSubnet2' }
+                    { Ref: 'FriggPrivateSubnet2' },
                 ],
-                SecurityGroupIds: [
-                    { Ref: 'FriggVPCEndpointSecurityGroup' }
-                ],
-                PrivateDnsEnabled: true
-            }
+                SecurityGroupIds: [{ Ref: 'FriggVPCEndpointSecurityGroup' }],
+                PrivateDnsEnabled: true,
+            },
         };
 
         // Security Group for VPC Endpoints
@@ -423,14 +474,19 @@ const createVPCInfrastructure = (AppDefinition) => {
                         IpProtocol: 'tcp',
                         FromPort: 443,
                         ToPort: 443,
-                        SourceSecurityGroupId: { Ref: 'FriggLambdaSecurityGroup' },
-                        Description: 'HTTPS from Lambda'
-                    }
+                        SourceSecurityGroupId: {
+                            Ref: 'FriggLambdaSecurityGroup',
+                        },
+                        Description: 'HTTPS from Lambda',
+                    },
                 ],
                 Tags: [
-                    { Key: 'Name', Value: '${self:service}-${self:provider.stage}-vpc-endpoint-sg' }
-                ]
-            }
+                    {
+                        Key: 'Name',
+                        Value: '${self:service}-${self:provider.stage}-vpc-endpoint-sg',
+                    },
+                ],
+            },
         };
     }
 
@@ -456,7 +512,9 @@ const composeServerlessDefinition = async (AppDefinition) => {
 
     // Run AWS discovery if needed
     if (shouldRunDiscovery(AppDefinition)) {
-        console.log('🔍 Running AWS resource discovery for serverless template...');
+        console.log(
+            '🔍 Running AWS resource discovery for serverless template...'
+        );
         try {
             const region = process.env.AWS_REGION || 'us-east-1';
             const discovery = new AWSDiscovery(region);
@@ -464,7 +522,7 @@ const composeServerlessDefinition = async (AppDefinition) => {
             const config = {
                 vpc: AppDefinition.vpc || {},
                 encryption: AppDefinition.encryption || {},
-                ssm: AppDefinition.ssm || {}
+                ssm: AppDefinition.ssm || {},
             };
 
             discoveredResources = await discovery.discoverResources(config);
@@ -473,14 +531,23 @@ const composeServerlessDefinition = async (AppDefinition) => {
             if (discoveredResources.defaultVpcId) {
                 console.log(`   VPC: ${discoveredResources.defaultVpcId}`);
             }
-            if (discoveredResources.privateSubnetId1 && discoveredResources.privateSubnetId2) {
-                console.log(`   Subnets: ${discoveredResources.privateSubnetId1}, ${discoveredResources.privateSubnetId2}`);
+            if (
+                discoveredResources.privateSubnetId1 &&
+                discoveredResources.privateSubnetId2
+            ) {
+                console.log(
+                    `   Subnets: ${discoveredResources.privateSubnetId1}, ${discoveredResources.privateSubnetId2}`
+                );
             }
             if (discoveredResources.defaultSecurityGroupId) {
-                console.log(`   Security Group: ${discoveredResources.defaultSecurityGroupId}`);
+                console.log(
+                    `   Security Group: ${discoveredResources.defaultSecurityGroupId}`
+                );
             }
             if (discoveredResources.defaultKmsKeyId) {
-                console.log(`   KMS Key: ${discoveredResources.defaultKmsKeyId}`);
+                console.log(
+                    `   KMS Key: ${discoveredResources.defaultKmsKeyId}`
+                );
             }
         } catch (error) {
             console.error('❌ AWS discovery failed:', error.message);
@@ -493,7 +560,11 @@ const composeServerlessDefinition = async (AppDefinition) => {
         service: AppDefinition.name || 'create-frigg-app',
         package: {
             individually: true,
-            exclude: ["!**/node_modules/aws-sdk/**", "!**/node_modules/@aws-sdk/**", "!package.json"],
+            exclude: [
+                '!**/node_modules/aws-sdk/**',
+                '!**/node_modules/@aws-sdk/**',
+                '!package.json',
+            ],
         },
         useDotenv: true,
         provider: {
@@ -505,14 +576,36 @@ const composeServerlessDefinition = async (AppDefinition) => {
             environment: {
                 STAGE: '${opt:stage, "dev"}',
                 AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1,
+                // Pass through all environment variables from the deployment process
+                ...process.env,
                 // Add discovered resources to environment if available
-                ...(discoveredResources.defaultVpcId && { AWS_DISCOVERY_VPC_ID: discoveredResources.defaultVpcId }),
-                ...(discoveredResources.defaultSecurityGroupId && { AWS_DISCOVERY_SECURITY_GROUP_ID: discoveredResources.defaultSecurityGroupId }),
-                ...(discoveredResources.privateSubnetId1 && { AWS_DISCOVERY_SUBNET_ID_1: discoveredResources.privateSubnetId1 }),
-                ...(discoveredResources.privateSubnetId2 && { AWS_DISCOVERY_SUBNET_ID_2: discoveredResources.privateSubnetId2 }),
-                ...(discoveredResources.publicSubnetId && { AWS_DISCOVERY_PUBLIC_SUBNET_ID: discoveredResources.publicSubnetId }),
-                ...(discoveredResources.defaultRouteTableId && { AWS_DISCOVERY_ROUTE_TABLE_ID: discoveredResources.defaultRouteTableId }),
-                ...(discoveredResources.defaultKmsKeyId && { AWS_DISCOVERY_KMS_KEY_ID: discoveredResources.defaultKmsKeyId }),
+                ...(discoveredResources.defaultVpcId && {
+                    AWS_DISCOVERY_VPC_ID: discoveredResources.defaultVpcId,
+                }),
+                ...(discoveredResources.defaultSecurityGroupId && {
+                    AWS_DISCOVERY_SECURITY_GROUP_ID:
+                        discoveredResources.defaultSecurityGroupId,
+                }),
+                ...(discoveredResources.privateSubnetId1 && {
+                    AWS_DISCOVERY_SUBNET_ID_1:
+                        discoveredResources.privateSubnetId1,
+                }),
+                ...(discoveredResources.privateSubnetId2 && {
+                    AWS_DISCOVERY_SUBNET_ID_2:
+                        discoveredResources.privateSubnetId2,
+                }),
+                ...(discoveredResources.publicSubnetId && {
+                    AWS_DISCOVERY_PUBLIC_SUBNET_ID:
+                        discoveredResources.publicSubnetId,
+                }),
+                ...(discoveredResources.defaultRouteTableId && {
+                    AWS_DISCOVERY_ROUTE_TABLE_ID:
+                        discoveredResources.defaultRouteTableId,
+                }),
+                ...(discoveredResources.defaultKmsKeyId && {
+                    AWS_DISCOVERY_KMS_KEY_ID:
+                        discoveredResources.defaultKmsKeyId,
+                }),
             },
             iamRoleStatements: [
                 {
@@ -528,22 +621,22 @@ const composeServerlessDefinition = async (AppDefinition) => {
                         'sqs:SendMessage',
                         'sqs:SendMessageBatch',
                         'sqs:GetQueueUrl',
-                        'sqs:GetQueueAttributes'
+                        'sqs:GetQueueAttributes',
                     ],
                     Resource: [
                         {
-                            'Fn::GetAtt': ['InternalErrorQueue', 'Arn']
+                            'Fn::GetAtt': ['InternalErrorQueue', 'Arn'],
                         },
                         {
                             'Fn::Join': [
                                 ':',
                                 [
-                                    'arn:aws:sqs:${self:provider.region}:*:${self:service}--${self:provider.stage}-*Queue'
-                                ]
-                            ]
-                        }
+                                    'arn:aws:sqs:${self:provider.region}:*:${self:service}--${self:provider.stage}-*Queue',
+                                ],
+                            ],
+                        },
                     ],
-                }
+                },
             ],
             httpApi: {
                 payload: '2.0',
@@ -555,7 +648,7 @@ const composeServerlessDefinition = async (AppDefinition) => {
                 },
                 name: '${opt:stage, "dev"}-${self:service}',
                 disableDefaultEndpoint: false,
-            }
+            },
         },
         plugins: [
             'serverless-jetpack',
@@ -585,7 +678,8 @@ const composeServerlessDefinition = async (AppDefinition) => {
         },
         functions: {
             auth: {
-                handler: 'node_modules/@friggframework/core/handlers/routers/auth.handler',
+                handler:
+                    'node_modules/@friggframework/core/handlers/routers/auth.handler',
                 events: [
                     {
                         httpApi: {
@@ -608,7 +702,8 @@ const composeServerlessDefinition = async (AppDefinition) => {
                 ],
             },
             user: {
-                handler: 'node_modules/@friggframework/core/handlers/routers/user.handler',
+                handler:
+                    'node_modules/@friggframework/core/handlers/routers/user.handler',
                 events: [
                     {
                         httpApi: {
@@ -619,7 +714,8 @@ const composeServerlessDefinition = async (AppDefinition) => {
                 ],
             },
             health: {
-                handler: 'node_modules/@friggframework/core/handlers/routers/health.handler',
+                handler:
+                    'node_modules/@friggframework/core/handlers/routers/health.handler',
                 events: [
                     {
                         httpApi: {
@@ -723,23 +819,28 @@ const composeServerlessDefinition = async (AppDefinition) => {
     };
 
     // KMS Configuration based on App Definition
-    if (AppDefinition.encryption?.useDefaultKMSForFieldLevelEncryption === true) {
+    if (
+        AppDefinition.encryption?.useDefaultKMSForFieldLevelEncryption === true
+    ) {
         // Check if a KMS key was discovered
         if (discoveredResources.defaultKmsKeyId) {
             // Use the existing discovered KMS key
-            console.log(`Using existing KMS key: ${discoveredResources.defaultKmsKeyId}`);
-            
+            console.log(
+                `Using existing KMS key: ${discoveredResources.defaultKmsKeyId}`
+            );
+
             definition.provider.iamRoleStatements.push({
                 Effect: 'Allow',
                 Action: ['kms:GenerateDataKey', 'kms:Decrypt'],
-                Resource: [discoveredResources.defaultKmsKeyId]
+                Resource: [discoveredResources.defaultKmsKeyId],
             });
 
-            definition.provider.environment.KMS_KEY_ARN = discoveredResources.defaultKmsKeyId;
+            definition.provider.environment.KMS_KEY_ARN =
+                discoveredResources.defaultKmsKeyId;
         } else {
             // No existing key found, provision a dedicated KMS key
             console.log('No existing KMS key found, creating a new one...');
-            
+
             definition.resources.Resources.FriggKMSKey = {
                 Type: 'AWS::KMS::Key',
                 Properties: {
@@ -750,29 +851,38 @@ const composeServerlessDefinition = async (AppDefinition) => {
                             {
                                 Sid: 'AllowRootAccountAdmin',
                                 Effect: 'Allow',
-                                Principal: { AWS: { 'Fn::Sub': 'arn:aws:iam::${AWS::AccountId}:root' } },
+                                Principal: {
+                                    AWS: {
+                                        'Fn::Sub':
+                                            'arn:aws:iam::${AWS::AccountId}:root',
+                                    },
+                                },
                                 Action: 'kms:*',
-                                Resource: '*'
-                            }
-                        ]
-                    }
-                }
+                                Resource: '*',
+                            },
+                        ],
+                    },
+                },
             };
 
             definition.provider.iamRoleStatements.push({
                 Effect: 'Allow',
                 Action: ['kms:GenerateDataKey', 'kms:Decrypt'],
-                Resource: [{ 'Fn::GetAtt': ['FriggKMSKey', 'Arn'] }]
+                Resource: [{ 'Fn::GetAtt': ['FriggKMSKey', 'Arn'] }],
             });
 
-            definition.provider.environment.KMS_KEY_ARN = { 'Fn::GetAtt': ['FriggKMSKey', 'Arn'] };
+            definition.provider.environment.KMS_KEY_ARN = {
+                'Fn::GetAtt': ['FriggKMSKey', 'Arn'],
+            };
         }
 
         definition.plugins.push('serverless-kms-grants');
 
         // Configure KMS grants with discovered default key or environment variable
         definition.custom.kmsGrants = {
-            kmsKeyId: discoveredResources.defaultKmsKeyId || '${env:AWS_DISCOVERY_KMS_KEY_ID}'
+            kmsKeyId:
+                discoveredResources.defaultKmsKeyId ||
+                '${env:AWS_DISCOVERY_KMS_KEY_ID}',
         };
     }
 
@@ -786,9 +896,9 @@ const composeServerlessDefinition = async (AppDefinition) => {
                 'ec2:DescribeNetworkInterfaces',
                 'ec2:DeleteNetworkInterface',
                 'ec2:AttachNetworkInterface',
-                'ec2:DetachNetworkInterface'
+                'ec2:DetachNetworkInterface',
             ],
-            Resource: '*'
+            Resource: '*',
         });
 
         // Default approach: Use AWS Discovery to find existing VPC resources
@@ -801,7 +911,9 @@ const composeServerlessDefinition = async (AppDefinition) => {
                 vpcConfig.securityGroupIds = AppDefinition.vpc.securityGroupIds;
             } else {
                 // Use auto-created security group
-                vpcConfig.securityGroupIds = [{ Ref: 'FriggLambdaSecurityGroup' }];
+                vpcConfig.securityGroupIds = [
+                    { Ref: 'FriggLambdaSecurityGroup' },
+                ];
             }
 
             if (AppDefinition.vpc.subnetIds) {
@@ -811,7 +923,7 @@ const composeServerlessDefinition = async (AppDefinition) => {
                 // Use auto-created private subnets
                 vpcConfig.subnetIds = [
                     { Ref: 'FriggPrivateSubnet1' },
-                    { Ref: 'FriggPrivateSubnet2' }
+                    { Ref: 'FriggPrivateSubnet2' },
                 ];
             }
 
@@ -825,16 +937,27 @@ const composeServerlessDefinition = async (AppDefinition) => {
             // Option 2: Use AWS Discovery (default behavior)
             // VPC configuration using discovered or explicitly provided resources
             const vpcConfig = {
-                securityGroupIds: AppDefinition.vpc.securityGroupIds ||
-                    (discoveredResources.defaultSecurityGroupId ? [discoveredResources.defaultSecurityGroupId] : []),
-                subnetIds: AppDefinition.vpc.subnetIds ||
-                    (discoveredResources.privateSubnetId1 && discoveredResources.privateSubnetId2 ?
-                        [discoveredResources.privateSubnetId1, discoveredResources.privateSubnetId2] :
-                        [])
+                securityGroupIds:
+                    AppDefinition.vpc.securityGroupIds ||
+                    (discoveredResources.defaultSecurityGroupId
+                        ? [discoveredResources.defaultSecurityGroupId]
+                        : []),
+                subnetIds:
+                    AppDefinition.vpc.subnetIds ||
+                    (discoveredResources.privateSubnetId1 &&
+                    discoveredResources.privateSubnetId2
+                        ? [
+                              discoveredResources.privateSubnetId1,
+                              discoveredResources.privateSubnetId2,
+                          ]
+                        : []),
             };
 
             // Set VPC config for Lambda functions only if we have valid subnet IDs
-            if (vpcConfig.subnetIds.length >= 2 && vpcConfig.securityGroupIds.length > 0) {
+            if (
+                vpcConfig.subnetIds.length >= 2 &&
+                vpcConfig.securityGroupIds.length > 0
+            ) {
                 definition.provider.vpc = vpcConfig;
 
                 // Check if we have an existing NAT Gateway to use
@@ -848,22 +971,35 @@ const composeServerlessDefinition = async (AppDefinition) => {
                             Properties: {
                                 Domain: 'vpc',
                                 Tags: [
-                                    { Key: 'Name', Value: '${self:service}-${self:provider.stage}-nat-eip' }
-                                ]
-                            }
+                                    {
+                                        Key: 'Name',
+                                        Value: '${self:service}-${self:provider.stage}-nat-eip',
+                                    },
+                                ],
+                            },
                         };
                     }
 
                     definition.resources.Resources.FriggNATGateway = {
                         Type: 'AWS::EC2::NatGateway',
                         Properties: {
-                            AllocationId: discoveredResources.existingElasticIpAllocationId ||
-                                { 'Fn::GetAtt': ['FriggNATGatewayEIP', 'AllocationId'] },
-                            SubnetId: discoveredResources.publicSubnetId || discoveredResources.privateSubnetId1, // Use first discovered subnet if no public subnet found
+                            AllocationId:
+                                discoveredResources.existingElasticIpAllocationId || {
+                                    'Fn::GetAtt': [
+                                        'FriggNATGatewayEIP',
+                                        'AllocationId',
+                                    ],
+                                },
+                            SubnetId:
+                                discoveredResources.publicSubnetId ||
+                                discoveredResources.privateSubnetId1, // Use first discovered subnet if no public subnet found
                             Tags: [
-                                { Key: 'Name', Value: '${self:service}-${self:provider.stage}-nat-gateway' }
-                            ]
-                        }
+                                {
+                                    Key: 'Name',
+                                    Value: '${self:service}-${self:provider.stage}-nat-gateway',
+                                },
+                            ],
+                        },
                     };
                 }
 
@@ -871,11 +1007,16 @@ const composeServerlessDefinition = async (AppDefinition) => {
                 definition.resources.Resources.FriggLambdaRouteTable = {
                     Type: 'AWS::EC2::RouteTable',
                     Properties: {
-                        VpcId: discoveredResources.defaultVpcId || { Ref: 'FriggVPC' },
+                        VpcId: discoveredResources.defaultVpcId || {
+                            Ref: 'FriggVPC',
+                        },
                         Tags: [
-                            { Key: 'Name', Value: '${self:service}-${self:provider.stage}-lambda-rt' }
-                        ]
-                    }
+                            {
+                                Key: 'Name',
+                                Value: '${self:service}-${self:provider.stage}-lambda-rt',
+                            },
+                        ],
+                    },
                 };
 
                 definition.resources.Resources.FriggNATRoute = {
@@ -883,8 +1024,11 @@ const composeServerlessDefinition = async (AppDefinition) => {
                     Properties: {
                         RouteTableId: { Ref: 'FriggLambdaRouteTable' },
                         DestinationCidrBlock: '0.0.0.0/0',
-                        NatGatewayId: discoveredResources.existingNatGatewayId || { Ref: 'FriggNATGateway' }
-                    }
+                        NatGatewayId:
+                            discoveredResources.existingNatGatewayId || {
+                                Ref: 'FriggNATGateway',
+                            },
+                    },
                 };
 
                 // Associate Lambda subnets with NAT Gateway route table
@@ -892,16 +1036,16 @@ const composeServerlessDefinition = async (AppDefinition) => {
                     Type: 'AWS::EC2::SubnetRouteTableAssociation',
                     Properties: {
                         SubnetId: vpcConfig.subnetIds[0],
-                        RouteTableId: { Ref: 'FriggLambdaRouteTable' }
-                    }
+                        RouteTableId: { Ref: 'FriggLambdaRouteTable' },
+                    },
                 };
 
                 definition.resources.Resources.FriggSubnet2RouteAssociation = {
                     Type: 'AWS::EC2::SubnetRouteTableAssociation',
                     Properties: {
                         SubnetId: vpcConfig.subnetIds[1],
-                        RouteTableId: { Ref: 'FriggLambdaRouteTable' }
-                    }
+                        RouteTableId: { Ref: 'FriggLambdaRouteTable' },
+                    },
                 };
 
                 // Add VPC endpoints for AWS service optimization (optional but recommended)
@@ -910,116 +1054,130 @@ const composeServerlessDefinition = async (AppDefinition) => {
                         Type: 'AWS::EC2::VPCEndpoint',
                         Properties: {
                             VpcId: discoveredResources.defaultVpcId,
-                            ServiceName: 'com.amazonaws.${self:provider.region}.s3',
+                            ServiceName:
+                                'com.amazonaws.${self:provider.region}.s3',
                             VpcEndpointType: 'Gateway',
-                            RouteTableIds: [{ Ref: 'FriggLambdaRouteTable' }]
-                        }
+                            RouteTableIds: [{ Ref: 'FriggLambdaRouteTable' }],
+                        },
                     };
 
                     definition.resources.Resources.VPCEndpointDynamoDB = {
                         Type: 'AWS::EC2::VPCEndpoint',
                         Properties: {
                             VpcId: discoveredResources.defaultVpcId,
-                            ServiceName: 'com.amazonaws.${self:provider.region}.dynamodb',
+                            ServiceName:
+                                'com.amazonaws.${self:provider.region}.dynamodb',
                             VpcEndpointType: 'Gateway',
-                            RouteTableIds: [{ Ref: 'FriggLambdaRouteTable' }]
-                        }
+                            RouteTableIds: [{ Ref: 'FriggLambdaRouteTable' }],
+                        },
                     };
                 }
             }
         }
 
-    // SSM Parameter Store Configuration based on App Definition  
-    if (AppDefinition.ssm?.enable === true) {
-        // Add AWS Parameters and Secrets Lambda Extension layer
-        definition.provider.layers = [
-            'arn:aws:lambda:${self:provider.region}:177933569100:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11'
-        ];
+        // SSM Parameter Store Configuration based on App Definition
+        if (AppDefinition.ssm?.enable === true) {
+            // Add AWS Parameters and Secrets Lambda Extension layer
+            definition.provider.layers = [
+                'arn:aws:lambda:${self:provider.region}:177933569100:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+            ];
 
-        // Add SSM IAM permissions
-        definition.provider.iamRoleStatements.push({
-            Effect: 'Allow',
-            Action: [
-                'ssm:GetParameter',
-                'ssm:GetParameters',
-                'ssm:GetParametersByPath'
-            ],
-            Resource: [
-                'arn:aws:ssm:${self:provider.region}:*:parameter/${self:service}/${self:provider.stage}/*'
-            ]
-        });
-
-        // Add environment variable for SSM parameter prefix
-        definition.provider.environment.SSM_PARAMETER_PREFIX = '/${self:service}/${self:provider.stage}';
-    }
-
-    // Add integration-specific functions and resources
-    if (AppDefinition.integrations && Array.isArray(AppDefinition.integrations)) {
-        for (const integration of AppDefinition.integrations) {
-            if (!integration || !integration.Definition || !integration.Definition.name) {
-                throw new Error('Invalid integration: missing Definition or name');
-            }
-            const integrationName = integration.Definition.name;
-
-            // Add function for the integration
-            definition.functions[integrationName] = {
-                handler: `node_modules/@friggframework/core/handlers/routers/integration-defined-routers.handlers.${integrationName}.handler`,
-                events: [
-                    {
-                        httpApi: {
-                            path: `/api/${integrationName}-integration/{proxy+}`,
-                            method: 'ANY',
-                        },
-                    },
+            // Add SSM IAM permissions
+            definition.provider.iamRoleStatements.push({
+                Effect: 'Allow',
+                Action: [
+                    'ssm:GetParameter',
+                    'ssm:GetParameters',
+                    'ssm:GetParametersByPath',
                 ],
-            };
+                Resource: [
+                    'arn:aws:ssm:${self:provider.region}:*:parameter/${self:service}/${self:provider.stage}/*',
+                ],
+            });
 
-            // Add SQS Queue for the integration
-            const queueReference = `${integrationName.charAt(0).toUpperCase() + integrationName.slice(1)
-                }Queue`;
-            const queueName = `\${self:service}--\${self:provider.stage}-${queueReference}`;
-            definition.resources.Resources[queueReference] = {
-                Type: 'AWS::SQS::Queue',
-                Properties: {
-                    QueueName: `\${self:custom.${queueReference}}`,
-                    MessageRetentionPeriod: 60,
-                    VisibilityTimeout: 1800,  // 30 minutes
-                    RedrivePolicy: {
-                        maxReceiveCount: 1,
-                        deadLetterTargetArn: {
-                            'Fn::GetAtt': ['InternalErrorQueue', 'Arn'],
-                        },
-                    },
-                },
-            };
+            // Add environment variable for SSM parameter prefix
+            definition.provider.environment.SSM_PARAMETER_PREFIX =
+                '/${self:service}/${self:provider.stage}';
+        }
 
-            // Add Queue Worker for the integration
-            const queueWorkerName = `${integrationName}QueueWorker`;
-            definition.functions[queueWorkerName] = {
-                handler: `node_modules/@friggframework/core/handlers/workers/integration-defined-workers.handlers.${integrationName}.queueWorker`,
-                reservedConcurrency: 5,
-                events: [
-                    {
-                        sqs: {
-                            arn: {
-                                'Fn::GetAtt': [queueReference, 'Arn'],
+        // Add integration-specific functions and resources
+        if (
+            AppDefinition.integrations &&
+            Array.isArray(AppDefinition.integrations)
+        ) {
+            for (const integration of AppDefinition.integrations) {
+                if (
+                    !integration ||
+                    !integration.Definition ||
+                    !integration.Definition.name
+                ) {
+                    throw new Error(
+                        'Invalid integration: missing Definition or name'
+                    );
+                }
+                const integrationName = integration.Definition.name;
+
+                // Add function for the integration
+                definition.functions[integrationName] = {
+                    handler: `node_modules/@friggframework/core/handlers/routers/integration-defined-routers.handlers.${integrationName}.handler`,
+                    events: [
+                        {
+                            httpApi: {
+                                path: `/api/${integrationName}-integration/{proxy+}`,
+                                method: 'ANY',
                             },
-                            batchSize: 1,
+                        },
+                    ],
+                };
+
+                // Add SQS Queue for the integration
+                const queueReference = `${
+                    integrationName.charAt(0).toUpperCase() +
+                    integrationName.slice(1)
+                }Queue`;
+                const queueName = `\${self:service}--\${self:provider.stage}-${queueReference}`;
+                definition.resources.Resources[queueReference] = {
+                    Type: 'AWS::SQS::Queue',
+                    Properties: {
+                        QueueName: `\${self:custom.${queueReference}}`,
+                        MessageRetentionPeriod: 60,
+                        VisibilityTimeout: 1800, // 30 minutes
+                        RedrivePolicy: {
+                            maxReceiveCount: 1,
+                            deadLetterTargetArn: {
+                                'Fn::GetAtt': ['InternalErrorQueue', 'Arn'],
+                            },
                         },
                     },
-                ],
-                timeout: 600,
-            };
+                };
 
-            // Add Queue URL for the integration to the ENVironment variables
-            definition.provider.environment = {
-                ...definition.provider.environment,
-                [`${integrationName.toUpperCase()}_QUEUE_URL`]: {
-                    Ref: queueReference,
-                },
-            };
+                // Add Queue Worker for the integration
+                const queueWorkerName = `${integrationName}QueueWorker`;
+                definition.functions[queueWorkerName] = {
+                    handler: `node_modules/@friggframework/core/handlers/workers/integration-defined-workers.handlers.${integrationName}.queueWorker`,
+                    reservedConcurrency: 5,
+                    events: [
+                        {
+                            sqs: {
+                                arn: {
+                                    'Fn::GetAtt': [queueReference, 'Arn'],
+                                },
+                                batchSize: 1,
+                            },
+                        },
+                    ],
+                    timeout: 600,
+                };
 
-            definition.custom[queueReference] = queueName;
+                // Add Queue URL for the integration to the ENVironment variables
+                definition.provider.environment = {
+                    ...definition.provider.environment,
+                    [`${integrationName.toUpperCase()}_QUEUE_URL`]: {
+                        Ref: queueReference,
+                    },
+                };
+
+                definition.custom[queueReference] = queueName;
             }
         }
 
@@ -1029,7 +1187,8 @@ const composeServerlessDefinition = async (AppDefinition) => {
         // Add websocket function if enabled
         if (AppDefinition.websockets?.enable === true) {
             definition.functions.defaultWebsocket = {
-                handler: 'node_modules/@friggframework/core/handlers/routers/websocket.handler',
+                handler:
+                    'node_modules/@friggframework/core/handlers/routers/websocket.handler',
                 events: [
                     {
                         websocket: {
@@ -1056,7 +1215,8 @@ const composeServerlessDefinition = async (AppDefinition) => {
         // Add websocket function if enabled
         if (AppDefinition.websockets?.enable === true) {
             definition.functions.defaultWebsocket = {
-                handler: 'node_modules/@friggframework/core/handlers/routers/websocket.handler',
+                handler:
+                    'node_modules/@friggframework/core/handlers/routers/websocket.handler',
                 events: [
                     {
                         websocket: {
@@ -1084,7 +1244,8 @@ const composeServerlessDefinition = async (AppDefinition) => {
     // Add websocket function if enabled
     if (AppDefinition.websockets?.enable === true) {
         definition.functions.defaultWebsocket = {
-            handler: 'node_modules/@friggframework/core/handlers/routers/websocket.handler',
+            handler:
+                'node_modules/@friggframework/core/handlers/routers/websocket.handler',
             events: [
                 {
                     websocket: {


### PR DESCRIPTION
This pull request updates the AWS IAM policy documentation and CloudFormation templates for Frigg deployments to improve security, clarity, and maintainability. The most important changes include splitting API Gateway permissions by version, updating resource scoping for least privilege, and enhancing documentation with clearer explanations and fallback behaviors.

**Policy and Permission Structure Improvements:**

* Split API Gateway permissions into separate policies for v1 (REST APIs) and v2 (HTTP APIs), with specific CRUD actions and resource scoping for each, both in `AWS-IAM-CREDENTIAL-NEEDS.md` and `frigg-deployment-iam-stack.yaml`. This follows the principle of least privilege and supports easier auditing. [[1]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dR241-R280) [[2]](diffhunk://#diff-39e7355856f0bb3a03e040265d8cd9015cfb1ec0c7be8d94b5a20cc674b83865R261-R280)
* Updated resource arrays and action arrays throughout the IAM policy definitions to use more concise, single-line array formatting and improved resource scoping (e.g., for Lambda, CloudFormation, SNS, IAM, and KMS resources). [[1]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dL80-R81) [[2]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dL131-R130) [[3]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dL145-R142) [[4]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dL173-R169) [[5]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dL210-R201) [[6]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dL340-R367)
* Added new EC2 permissions (`ec2:DeleteSubnet`, `ec2:DetachInternetGateway`) required for VPC-related operations, and updated the CloudFormation template accordingly. [[1]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dL304-R329) [[2]](diffhunk://#diff-39e7355856f0bb3a03e040265d8cd9015cfb1ec0c7be8d94b5a20cc674b83865R320-R321)

**Documentation and Security Enhancements:**

* Expanded documentation to explain the rationale behind permission splitting, least privilege, and resource scoping, including before/after examples and naming convention guidance for Frigg resources. [[1]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dR493-R499) [[2]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dR521-R529)
* Added detailed explanations for what each permission enables, fallback behaviors if AWS discovery fails, and regional considerations for IAM permissions. [[1]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dR43) [[2]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dR349) [[3]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dR382) [[4]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dR413) [[5]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dR589) [[6]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dR598)

**Policy Syntax and Formatting:**

* Updated all policy array formatting in both documentation and templates for consistency and readability, using single-line arrays and improved indentation. [[1]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dL430-R457) [[2]](diffhunk://#diff-7a4d6277b799c0ceea38f6965fd9ebc5d65141b62af1d91d66c186613631436dL410-R437)

These changes make the IAM policies more secure, easier to audit, and simpler to maintain for Frigg deployments.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.413.39a9576.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.413.39a9576.0
  npm install @friggframework/devtools@2.0.0--canary.413.39a9576.0
  npm install @friggframework/eslint-config@2.0.0--canary.413.39a9576.0
  npm install @friggframework/prettier-config@2.0.0--canary.413.39a9576.0
  npm install @friggframework/schemas@2.0.0--canary.413.39a9576.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.413.39a9576.0
  npm install @friggframework/test@2.0.0--canary.413.39a9576.0
  npm install @friggframework/ui@2.0.0--canary.413.39a9576.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.413.39a9576.0
  yarn add @friggframework/devtools@2.0.0--canary.413.39a9576.0
  yarn add @friggframework/eslint-config@2.0.0--canary.413.39a9576.0
  yarn add @friggframework/prettier-config@2.0.0--canary.413.39a9576.0
  yarn add @friggframework/schemas@2.0.0--canary.413.39a9576.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.413.39a9576.0
  yarn add @friggframework/test@2.0.0--canary.413.39a9576.0
  yarn add @friggframework/ui@2.0.0--canary.413.39a9576.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.34`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/devtools`
    - feat: include broader permissions to iam [#413](https://github.com/friggframework/frigg/pull/413) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - fix: add API Gateway v2 permissions for HttpApi creation [#410](https://github.com/friggframework/frigg/pull/410) ([@seanspeaks](https://github.com/seanspeaks))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
