### PR TITLE
fix: update init command to backend-first flow

### DIFF
--- a/packages/devtools/frigg-cli/index.js
+++ b/packages/devtools/frigg-cli/index.js
@@ -12,11 +12,13 @@ const { uiCommand } = require('./ui-command');
 const program = new Command();
 
 program
-    .command('init [templateName]')
+    .command('init [projectName]')
     .description('Initialize a new Frigg application')
-    .option('-t, --template <template>', 'template to use', 'backend-only')
-    .option('-n, --name <name>', 'project name')
-    .option('-d, --directory <directory>', 'target directory')
+    .option('-m, --mode <mode>', 'deployment mode (embedded|standalone)')
+    .option('--frontend', 'include demo frontend')
+    .option('--no-frontend', 'skip demo frontend')
+    .option('-f, --force', 'overwrite existing directory')
+    .option('-v, --verbose', 'enable verbose output')
     .action(initCommand);
 
 program

--- a/packages/devtools/management-ui/server/api/cli.js
+++ b/packages/devtools/management-ui/server/api/cli.js
@@ -12,9 +12,11 @@ const AVAILABLE_COMMANDS = [
         description: 'Initialize a new Frigg project',
         usage: 'frigg init [project-name]',
         options: [
-            { name: '--template', description: 'Template to use (serverless, express)' },
-            { name: '--skip-install', description: 'Skip npm install' },
-            { name: '--force', description: 'Overwrite existing directory' }
+            { name: '--mode <mode>', description: 'Deployment mode (embedded|standalone)' },
+            { name: '--frontend', description: 'Include demo frontend' },
+            { name: '--no-frontend', description: 'Skip demo frontend' },
+            { name: '--force', description: 'Overwrite existing directory' },
+            { name: '--verbose', description: 'Enable verbose output' }
         ]
     },
     {

--- a/packages/devtools/management-ui/server/utils/cliIntegration.js
+++ b/packages/devtools/management-ui/server/utils/cliIntegration.js
@@ -114,14 +114,24 @@ class FriggCLIIntegration {
 
   /**
    * Initialize a new project using CLI
-   */
+  */
   async initProject(projectDirectory, options = {}) {
     const args = [projectDirectory]
     
-    if (options.template) {
-      args.push('--template', options.template)
+    if (options.mode) {
+      args.push('--mode', options.mode)
     }
-    
+
+    if (options.frontend === false) {
+      args.push('--no-frontend')
+    } else if (options.frontend === true) {
+      args.push('--frontend')
+    }
+
+    if (options.force) {
+      args.push('--force')
+    }
+
     if (options.verbose) {
       args.push('--verbose')
     }


### PR DESCRIPTION
## Summary
- adjust `frigg init` command to use backend-first flow without legacy template flags
- sync management UI API and helpers with new init options

## Testing
- `npm run test:all` *(fails: Instance failed to start because libcrypto.so.1.1 is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8d2485dc8321a574c9d21f5a7bc5
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.416.a2540c3.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.416.a2540c3.0
  npm install @friggframework/devtools@2.0.0--canary.416.a2540c3.0
  npm install @friggframework/eslint-config@2.0.0--canary.416.a2540c3.0
  npm install @friggframework/prettier-config@2.0.0--canary.416.a2540c3.0
  npm install @friggframework/schemas@2.0.0--canary.416.a2540c3.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.416.a2540c3.0
  npm install @friggframework/test@2.0.0--canary.416.a2540c3.0
  npm install @friggframework/ui@2.0.0--canary.416.a2540c3.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.416.a2540c3.0
  yarn add @friggframework/devtools@2.0.0--canary.416.a2540c3.0
  yarn add @friggframework/eslint-config@2.0.0--canary.416.a2540c3.0
  yarn add @friggframework/prettier-config@2.0.0--canary.416.a2540c3.0
  yarn add @friggframework/schemas@2.0.0--canary.416.a2540c3.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.416.a2540c3.0
  yarn add @friggframework/test@2.0.0--canary.416.a2540c3.0
  yarn add @friggframework/ui@2.0.0--canary.416.a2540c3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
