### PR TITLE
feat: allow mongo db port in security group egress

### DIFF
--- a/packages/devtools/infrastructure/README.md
+++ b/packages/devtools/infrastructure/README.md
@@ -27,7 +27,7 @@ infrastructure/
 ├── AWS-DISCOVERY-TROUBLESHOOTING.md      # AWS discovery troubleshooting
 ├── DEPLOYMENT-INSTRUCTIONS.md            # General deployment instructions
 ├── README-TESTING.md                     # Testing strategy documentation
-├── 
+├──
 ├── cloudformation/                        # CloudFormation templates
 │   ├── monitoring-infrastructure.yaml    # Enhanced monitoring (Phase 3)
 │   ├── cdn-infrastructure.yaml          # CDN and UI distribution (Phase 3)
@@ -60,71 +60,79 @@ infrastructure/
 #### 1. Serverless Template Generator (`serverless-template.js`)
 
 Generates complete serverless.yml configurations with:
-- VPC configuration and resource discovery
-- KMS encryption for field-level encryption
-- SSM Parameter Store integration
-- Integration-specific functions and queues
-- WebSocket support for real-time features
+
+-   VPC configuration and resource discovery
+-   KMS encryption for field-level encryption
+-   SSM Parameter Store integration
+-   Integration-specific functions and queues
+-   WebSocket support for real-time features
 
 #### 2. AWS Discovery (`aws-discovery.js`)
 
 Automatically discovers existing AWS resources:
-- Default VPC and security groups
-- Private subnets for Lambda functions
-- Customer-managed KMS keys
-- Route tables for VPC endpoints
+
+-   Default VPC and security groups
+-   Private subnets for Lambda functions
+-   Customer-managed KMS keys
+-   Route tables for VPC endpoints
 
 #### 3. Build-Time Discovery (`build-time-discovery.js`)
 
 Integrates AWS discovery into the build process:
-- Pre-build hook for serverless deployments
-- Environment variable injection
-- Template variable replacement
-- Error handling and fallback values
+
+-   Pre-build hook for serverless deployments
+-   Environment variable injection
+-   Template variable replacement
+-   Error handling and fallback values
 
 ### Phase 3 Infrastructure
 
 #### 1. Enhanced Monitoring (`cloudformation/monitoring-infrastructure.yaml`)
 
 Production-ready monitoring with:
-- Code generation service monitoring
-- UI distribution monitoring
-- Advanced CloudWatch dashboards
-- Custom metrics and alarms
+
+-   Code generation service monitoring
+-   UI distribution monitoring
+-   Advanced CloudWatch dashboards
+-   Custom metrics and alarms
 
 #### 2. CDN Infrastructure (`cloudformation/cdn-infrastructure.yaml`)
 
 CloudFront distribution for UI packages:
-- S3 bucket for multi-framework UI packages
-- CloudFront distribution with custom domains
-- Lambda function for package deployment
-- API Gateway for package management
+
+-   S3 bucket for multi-framework UI packages
+-   CloudFront distribution with custom domains
+-   Lambda function for package deployment
+-   API Gateway for package management
 
 #### 3. Code Generation Infrastructure (`cloudformation/codegen-infrastructure.yaml`)
 
 Serverless code generation platform:
-- SQS queue for generation requests
-- Lambda function with AI/ML integration
-- DynamoDB tracking table
-- S3 storage for templates and generated code
-- ElastiCache for template caching
+
+-   SQS queue for generation requests
+-   Lambda function with AI/ML integration
+-   DynamoDB tracking table
+-   S3 storage for templates and generated code
+-   ElastiCache for template caching
 
 #### 4. Advanced Alerting (`cloudformation/alerting-infrastructure.yaml`)
 
 Multi-channel alerting system:
-- Multiple SNS topics for alert severity levels
-- Lambda function for alert processing
-- PagerDuty and Slack integration
-- Composite alarms for system health
-- Advanced metrics collection
+
+-   Multiple SNS topics for alert severity levels
+-   Lambda function for alert processing
+-   PagerDuty and Slack integration
+-   Composite alarms for system health
+-   Advanced metrics collection
 
 #### 5. Deployment Pipeline (`cloudformation/deployment-pipeline.yaml`)
 
 CI/CD pipeline for automated deployments:
-- CodePipeline with GitHub integration
-- CodeBuild projects for backend and UI
-- Multi-stage deployment workflow
-- Integration testing and approval gates
+
+-   CodePipeline with GitHub integration
+-   CodeBuild projects for backend and UI
+-   Multi-stage deployment workflow
+-   Integration testing and approval gates
 
 ## Configuration Options
 
@@ -135,7 +143,7 @@ const appDefinition = {
   // Basic configuration
   name: 'my-frigg-app',
   provider: 'aws',
-  
+
   // VPC configuration
   vpc: {
     enable: true,
@@ -144,22 +152,22 @@ const appDefinition = {
     subnetIds: [...],          // Optional: custom subnets
     enableVPCEndpoints: true   // Optional: create VPC endpoints
   },
-  
+
   // KMS encryption
   encryption: {
     useDefaultKMSForFieldLevelEncryption: true
   },
-  
+
   // SSM Parameter Store
   ssm: {
     enable: true
   },
-  
+
   // WebSocket support (Phase 3)
   websockets: {
     enable: true
   },
-  
+
   // Integrations
   integrations: [
     { Definition: { name: 'hubspot' } },
@@ -195,10 +203,8 @@ SERVICE_NAME=my-frigg-app
 const { composeServerlessDefinition } = require('./serverless-template');
 
 const appDefinition = {
-  name: 'my-app',
-  integrations: [
-    { Definition: { name: 'hubspot' } }
-  ]
+    name: 'my-app',
+    integrations: [{ Definition: { name: 'hubspot' } }],
 };
 
 const serverlessConfig = await composeServerlessDefinition(appDefinition);
@@ -209,13 +215,11 @@ const serverlessConfig = await composeServerlessDefinition(appDefinition);
 
 ```javascript
 const appDefinition = {
-  name: 'secure-app',
-  vpc: { enable: true },
-  encryption: { useDefaultKMSForFieldLevelEncryption: true },
-  ssm: { enable: true },
-  integrations: [
-    { Definition: { name: 'salesforce' } }
-  ]
+    name: 'secure-app',
+    vpc: { enable: true },
+    encryption: { useDefaultKMSForFieldLevelEncryption: true },
+    ssm: { enable: true },
+    integrations: [{ Definition: { name: 'salesforce' } }],
 };
 
 const serverlessConfig = await composeServerlessDefinition(appDefinition);
@@ -225,12 +229,10 @@ const serverlessConfig = await composeServerlessDefinition(appDefinition);
 
 ```javascript
 const appDefinition = {
-  name: 'realtime-app',
-  websockets: { enable: true },
-  vpc: { enable: true },
-  integrations: [
-    { Definition: { name: 'slack' } }
-  ]
+    name: 'realtime-app',
+    websockets: { enable: true },
+    vpc: { enable: true },
+    integrations: [{ Definition: { name: 'slack' } }],
 };
 
 const serverlessConfig = await composeServerlessDefinition(appDefinition);
@@ -259,19 +261,21 @@ npm test -- --watch
 ### Test Categories
 
 1. **Unit Tests**: Test individual components
-   - AWS discovery utilities
-   - Serverless template generation
-   - IAM policy generation
+
+    - AWS discovery utilities
+    - Serverless template generation
+    - IAM policy generation
 
 2. **Integration Tests**: Test end-to-end workflows
-   - Complete discovery and template generation
-   - Plugin integration
-   - Phase 3 infrastructure validation
+
+    - Complete discovery and template generation
+    - Plugin integration
+    - Phase 3 infrastructure validation
 
 3. **Performance Tests**: Validate infrastructure limits
-   - CloudFormation template sizes
-   - Resource count limits
-   - Cross-stack dependencies
+    - CloudFormation template sizes
+    - Resource count limits
+    - Cross-stack dependencies
 
 ### Mock Data
 
@@ -279,11 +283,12 @@ Tests use mock AWS resources to avoid real AWS API calls:
 
 ```javascript
 const mockAWSResources = {
-  defaultVpcId: 'vpc-12345678',
-  defaultSecurityGroupId: 'sg-12345678',
-  privateSubnetId1: 'subnet-private-1',
-  privateSubnetId2: 'subnet-private-2',
-  defaultKmsKeyId: 'arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012'
+    defaultVpcId: 'vpc-12345678',
+    defaultSecurityGroupId: 'sg-12345678',
+    privateSubnetId1: 'subnet-private-1',
+    privateSubnetId2: 'subnet-private-2',
+    defaultKmsKeyId:
+        'arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012',
 };
 ```
 
@@ -293,18 +298,18 @@ const mockAWSResources = {
 
 The infrastructure requires specific IAM permissions for AWS resource discovery and deployment:
 
-- **EC2**: Describe VPCs, subnets, security groups, route tables
-- **KMS**: List keys, describe keys
-- **STS**: Get caller identity
-- **CloudFormation**: Full access for stack operations
-- **Lambda**: Function management
-- **API Gateway**: API management
-- **S3**: Bucket and object operations (including tagging)
-- **DynamoDB**: Table operations
-- **SQS**: Queue operations
-- **SNS**: Topic operations
-- **CloudWatch**: Metrics and alarms
-- **IAM**: Role and policy management
+-   **EC2**: Describe VPCs, subnets, security groups, route tables
+-   **KMS**: List keys, describe keys
+-   **STS**: Get caller identity
+-   **CloudFormation**: Full access for stack operations
+-   **Lambda**: Function management
+-   **API Gateway**: API management
+-   **S3**: Bucket and object operations (including tagging)
+-   **DynamoDB**: Table operations
+-   **SQS**: Queue operations
+-   **SNS**: Topic operations
+-   **CloudWatch**: Metrics and alarms
+-   **IAM**: Role and policy management
 
 ### Best Practices
 
@@ -348,6 +353,8 @@ serverless print
 aws cloudformation validate-template --template-body file://template.json
 ```
 
+-   **Connectivity to external services (e.g., databases):** If your Lambda functions in a VPC cannot connect to external services, ensure that the `FriggLambdaSecurityGroup` has the correct **egress** rules to allow outbound traffic on the required ports (e.g., port 27017 for MongoDB).
+
 #### Infrastructure Test Failures
 
 ```bash
@@ -364,19 +371,22 @@ npm run test:debug
 ### Performance Optimization
 
 #### Lambda Cold Starts
-- Use provisioned concurrency for critical functions
-- Optimize function size and dependencies
-- Monitor cold start metrics
+
+-   Use provisioned concurrency for critical functions
+-   Optimize function size and dependencies
+-   Monitor cold start metrics
 
 #### VPC Performance
-- Use VPC endpoints to reduce NAT Gateway costs
-- Monitor ENI creation/deletion times
-- Consider Lambda@Edge for global distribution
+
+-   Use VPC endpoints to reduce NAT Gateway costs
+-   Monitor ENI creation/deletion times
+-   Consider Lambda@Edge for global distribution
 
 #### Cost Optimization
-- Use S3 Intelligent Tiering
-- Configure CloudWatch log retention
-- Monitor and alert on unexpected usage
+
+-   Use S3 Intelligent Tiering
+-   Configure CloudWatch log retention
+-   Monitor and alert on unexpected usage
 
 ## Contributing
 
@@ -405,17 +415,17 @@ npm run test:debug
 
 ## Support
 
-- **Documentation**: See `PHASE3-DEPLOYMENT-GUIDE.md` for detailed deployment instructions
-- **Testing**: See `README-TESTING.md` for testing strategy
-- **Troubleshooting**: See `AWS-DISCOVERY-TROUBLESHOOTING.md` for common issues
-- **Issues**: Create GitHub issues for bugs and feature requests
-- **Discussions**: Use GitHub Discussions for questions and ideas
+-   **Documentation**: See `PHASE3-DEPLOYMENT-GUIDE.md` for detailed deployment instructions
+-   **Testing**: See `README-TESTING.md` for testing strategy
+-   **Troubleshooting**: See `AWS-DISCOVERY-TROUBLESHOOTING.md` for common issues
+-   **Issues**: Create GitHub issues for bugs and feature requests
+-   **Discussions**: Use GitHub Discussions for questions and ideas
 
 ## Related Documentation
 
-- [Phase 3 Deployment Guide](./PHASE3-DEPLOYMENT-GUIDE.md)
-- [Testing Strategy](./README-TESTING.md)
-- [AWS Discovery Troubleshooting](./AWS-DISCOVERY-TROUBLESHOOTING.md)
-- [IAM Policy Templates](./IAM-POLICY-TEMPLATES.md)
-- [VPC Configuration](./VPC-CONFIGURATION.md)
-- [WebSocket Configuration](./WEBSOCKET-CONFIGURATION.md)
+-   [Phase 3 Deployment Guide](./PHASE3-DEPLOYMENT-GUIDE.md)
+-   [Testing Strategy](./README-TESTING.md)
+-   [AWS Discovery Troubleshooting](./AWS-DISCOVERY-TROUBLESHOOTING.md)
+-   [IAM Policy Templates](./IAM-POLICY-TEMPLATES.md)
+-   [VPC Configuration](./VPC-CONFIGURATION.md)
+-   [WebSocket Configuration](./WEBSOCKET-CONFIGURATION.md)

--- a/packages/devtools/infrastructure/serverless-template.js
+++ b/packages/devtools/infrastructure/serverless-template.js
@@ -450,6 +450,13 @@ const createVPCInfrastructure = (AppDefinition) => {
                         CidrIp: '0.0.0.0/0',
                         Description: 'DNS UDP',
                     },
+                    {
+                        IpProtocol: 'tcp',
+                        FromPort: 27017,
+                        ToPort: 27017,
+                        CidrIp: '0.0.0.0/0',
+                        Description: 'MongoDB outbound',
+                    },
                 ],
                 Tags: [
                     {


### PR DESCRIPTION
This pull request adds a new outbound rule to the VPC infrastructure configuration to allow TCP traffic on port 27017, which is typically used for MongoDB. This change ensures that outbound connections to MongoDB are permitted.

* Infrastructure update:
  * Added a security group rule in `serverless-template.js` to allow outbound TCP traffic on port 27017 for MongoDB.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.417.1ca8d39.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.417.1ca8d39.0
  npm install @friggframework/devtools@2.0.0--canary.417.1ca8d39.0
  npm install @friggframework/eslint-config@2.0.0--canary.417.1ca8d39.0
  npm install @friggframework/prettier-config@2.0.0--canary.417.1ca8d39.0
  npm install @friggframework/schemas@2.0.0--canary.417.1ca8d39.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.417.1ca8d39.0
  npm install @friggframework/test@2.0.0--canary.417.1ca8d39.0
  npm install @friggframework/ui@2.0.0--canary.417.1ca8d39.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.417.1ca8d39.0
  yarn add @friggframework/devtools@2.0.0--canary.417.1ca8d39.0
  yarn add @friggframework/eslint-config@2.0.0--canary.417.1ca8d39.0
  yarn add @friggframework/prettier-config@2.0.0--canary.417.1ca8d39.0
  yarn add @friggframework/schemas@2.0.0--canary.417.1ca8d39.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.417.1ca8d39.0
  yarn add @friggframework/test@2.0.0--canary.417.1ca8d39.0
  yarn add @friggframework/ui@2.0.0--canary.417.1ca8d39.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.37`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/devtools`
    - feat: allow mongo db port in security group egress [#417](https://github.com/friggframework/frigg/pull/417) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - feat: Add dynamic environment variable support from appDefinition [#414](https://github.com/friggframework/frigg/pull/414) ([@seanspeaks](https://github.com/seanspeaks) [@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
