### PR TITLE
Refactor auth integrations route for best practices

### DIFF
--- a/packages/core/integrations/integration-router.js
+++ b/packages/core/integrations/integration-router.js
@@ -16,6 +16,7 @@ function createIntegrationRouter(params) {
     router.all('/api/entities*', requireLoggedInUser);
     router.all('/api/authorize', requireLoggedInUser);
     router.all('/api/integrations*', requireLoggedInUser);
+    router.all('/api/integration-options', requireLoggedInUser);
 
     setIntegrationRoutes(router, factory, getUserId);
     setEntityRoutes(router, factory, getUserId);
@@ -48,17 +49,16 @@ function checkRequiredParams(params, requiredKeys) {
 
 function setIntegrationRoutes(router, factory, getUserId) {
     const { moduleFactory, integrationFactory, IntegrationHelper } = factory;
+    
+    // GET /api/integrations - Returns only user's integrations
     router.route('/api/integrations').get(
         catchAsyncError(async (req, res) => {
-            const results = await integrationFactory.getIntegrationOptions();
-            results.entities.authorized =
-                await moduleFactory.getEntitiesForUser(getUserId(req));
-            results.integrations =
-                await IntegrationHelper.getIntegrationsForUserId(
-                    getUserId(req)
-                );
+            const integrations = await IntegrationHelper.getIntegrationsForUserId(
+                getUserId(req)
+            );
 
-            for (const integrationRecord of results.integrations) {
+            // Add userActions to each integration
+            for (const integrationRecord of integrations) {
                 const integration =
                     await integrationFactory.getInstanceFromIntegrationId({
                         integrationId: integrationRecord.id,
@@ -66,7 +66,19 @@ function setIntegrationRoutes(router, factory, getUserId) {
                     });
                 integrationRecord.userActions = integration.userActions;
             }
-            res.json(results);
+            
+            res.json(integrations);
+        })
+    );
+    
+    // GET /api/integration-options - Returns available integration types configured in the Frigg instance
+    router.route('/api/integration-options').get(
+        catchAsyncError(async (req, res) => {
+            const options = await integrationFactory.getIntegrationOptions();
+            // Only return the integration options, not entities or user-specific data
+            res.json({
+                integrations: options.entities.options
+            });
         })
     );
 
@@ -301,6 +313,14 @@ function setEntityRoutes(router, factory, getUserId) {
             getUserId(req)
         );
     };
+    
+    // GET /api/entities - Returns all authorized entities for the user
+    router.route('/api/entities').get(
+        catchAsyncError(async (req, res) => {
+            const entities = await moduleFactory.getEntitiesForUser(getUserId(req));
+            res.json(entities);
+        })
+    );
 
     router.route('/api/authorize').get(
         catchAsyncError(async (req, res) => {

--- a/packages/devtools/management-ui/README.md
+++ b/packages/devtools/management-ui/README.md
@@ -126,7 +126,9 @@ The management UI communicates with the Frigg backend through:
 - `GET /api/frigg/status` - Server status
 - `POST /api/frigg/start` - Start Frigg server
 - `POST /api/frigg/stop` - Stop Frigg server
-- `GET /api/integrations` - List integrations
+- `GET /api/integrations` - List user's installed integrations
+- `GET /api/integration-options` - List available integration types
+- `GET /api/entities` - List user's authorized entities
 - `POST /api/integrations/install` - Install integration
 - `GET /api/environment` - Environment variables
 - `PUT /api/environment` - Update environment variables

--- a/packages/devtools/management-ui/server/api-contract.md
+++ b/packages/devtools/management-ui/server/api-contract.md
@@ -78,9 +78,55 @@ Restart the Frigg project with optional new configuration.
 
 ### 2. Integration Management
 #### GET /api/integrations
-List all available and installed integrations.
+List user's installed integrations.
 
 **Response:**
+```json
+[
+  {
+    "id": "int1",
+    "name": "slack",
+    "version": "1.0.0",
+    "installed": true,
+    "configured": true,
+    "userActions": []
+  }
+]
+```
+
+#### GET /api/integration-options
+List available integration types configured in the Frigg instance.
+
+**Response:**
+```json
+{
+  "integrations": [
+    {
+      "name": "slack",
+      "displayName": "Slack",
+      "description": "Connect your Slack workspace",
+      "category": "communication"
+    }
+  ]
+}
+```
+
+#### GET /api/entities
+List user's authorized entities/accounts.
+
+**Response:**
+```json
+[
+  {
+    "id": "entity1",
+    "type": "slack",
+    "name": "My Slack Workspace",
+    "createdAt": "2023-01-01T00:00:00.000Z"
+  }
+]
+```
+
+**Original Response (deprecated):**
 ```json
 {
   "status": "success",

--- a/packages/devtools/management-ui/server/index.js
+++ b/packages/devtools/management-ui/server/index.js
@@ -593,7 +593,41 @@ app.post('/api/frigg/restart', async (req, res) => {
 
 // Integrations
 app.get('/api/integrations', (req, res) => {
-  res.json({ integrations: mockIntegrations })
+  // Return only user's integrations following the new API structure
+  res.json(mockIntegrations.filter(i => i.installed))
+})
+
+// Integration Options - available integration types
+app.get('/api/integration-options', (req, res) => {
+  // Return available integration options
+  res.json({ 
+    integrations: mockIntegrations.map(i => ({
+      name: i.name,
+      displayName: i.displayName,
+      description: i.description,
+      category: i.category,
+      icon: i.icon
+    }))
+  })
+})
+
+// Entities - user's authorized entities
+app.get('/api/entities', (req, res) => {
+  // Return mock entities for the user
+  res.json([
+    {
+      id: 'entity1',
+      type: 'slack',
+      name: 'My Slack Workspace',
+      createdAt: new Date().toISOString()
+    },
+    {
+      id: 'entity2', 
+      type: 'salesforce',
+      name: 'Production Salesforce',
+      createdAt: new Date().toISOString()
+    }
+  ])
 })
 
 app.post('/api/integrations/install', async (req, res) => {

--- a/packages/devtools/management-ui/src/components/IntegrationExplorer.jsx
+++ b/packages/devtools/management-ui/src/components/IntegrationExplorer.jsx
@@ -23,13 +23,20 @@ export default function IntegrationExplorer({ mode = 'browse' }) {
   const fetchIntegrations = async () => {
     try {
       setLoading(true)
-      const response = await fetch('/api/integrations')
-      const data = await response.json()
       
-      // Combine installed integrations and available API modules
+      // Fetch integrations and integration options in parallel
+      const [integrationsResponse, optionsResponse] = await Promise.all([
+        fetch('/api/integrations'),
+        fetch('/api/integration-options')
+      ])
+      
+      const integrationsData = await integrationsResponse.json()
+      const optionsData = await optionsResponse.json()
+      
+      // Combine installed integrations and available integration options
       const allIntegrations = [
-        ...data.integrations.map(int => ({ ...int, source: 'installed' })),
-        ...data.availableApiModules.map(mod => ({ ...mod, source: 'available' }))
+        ...(Array.isArray(integrationsData) ? integrationsData : integrationsData.integrations || []).map(int => ({ ...int, source: 'installed' })),
+        ...(optionsData.integrations || []).map(opt => ({ ...opt, source: 'available' }))
       ]
       
       setIntegrations(allIntegrations)

--- a/packages/devtools/management-ui/src/test/mocks/server.js
+++ b/packages/devtools/management-ui/src/test/mocks/server.js
@@ -71,26 +71,50 @@ export const handlers = [
     })
   }),
 
-  // Integrations
+  // Integrations - returns user's integrations only
   http.get('/api/integrations', () => {
-    return HttpResponse.json({
-      data: {
-        integrations: [
-          {
-            name: 'slack',
-            version: '1.0.0',
-            installed: true,
-            configured: true
-          },
-          {
-            name: 'github',
-            version: '2.0.0', 
-            installed: false,
-            configured: false
-          }
-        ]
+    return HttpResponse.json([
+      {
+        id: 'int1',
+        name: 'slack',
+        version: '1.0.0',
+        installed: true,
+        configured: true,
+        userActions: []
       }
+    ])
+  }),
+
+  // Integration Options - available integration types
+  http.get('/api/integration-options', () => {
+    return HttpResponse.json({
+      integrations: [
+        {
+          name: 'slack',
+          displayName: 'Slack',
+          description: 'Connect your Slack workspace',
+          category: 'communication'
+        },
+        {
+          name: 'github',
+          displayName: 'GitHub',
+          description: 'Connect your GitHub repositories',
+          category: 'development'
+        }
+      ]
     })
+  }),
+
+  // Entities - user's authorized entities
+  http.get('/api/entities', () => {
+    return HttpResponse.json([
+      {
+        id: 'entity1',
+        type: 'slack',
+        name: 'Test Slack Workspace',
+        createdAt: new Date().toISOString()
+      }
+    ])
   }),
 
   // Environment


### PR DESCRIPTION
Refactor the `/api/integrations` route into three distinct, resource-specific endpoints to align with REST API best practices.

The original `/api/integrations` endpoint returned a mixed response of user integrations, connected entities, and available integration options. This refactoring separates these concerns into `GET /api/integrations` (user's integrations), `GET /api/entities` (user's authorized entities), and `GET /api/integration-options` (available integration types) for clearer API design and better separation of concerns.

---
<a href="https://cursor.com/background-agent?bcId=bc-5976beb0-1c06-4f1a-867d-d9d66490d951">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5976beb0-1c06-4f1a-867d-d9d66490d951">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

