### PR TITLE
Skip AWS discovery when running Frigg start locally

### DIFF
--- a/packages/devtools/frigg-cli/start-command/index.js
+++ b/packages/devtools/frigg-cli/start-command/index.js
@@ -34,6 +34,10 @@ function startCommand(options) {
     const childProcess = spawn(command, args, {
         cwd: backendPath,
         stdio: 'inherit',
+        env: {
+            ...process.env,
+            FRIGG_SKIP_AWS_DISCOVERY: 'true',
+        },
     });
 
     childProcess.on('error', (error) => {

--- a/packages/devtools/frigg-cli/start-command/index.js
+++ b/packages/devtools/frigg-cli/start-command/index.js
@@ -9,6 +9,8 @@ function startCommand(options) {
     console.log('Starting backend and optional frontend...');
     // Suppress AWS SDK warning message about maintenance mode
     process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = 1;
+    // Skip AWS discovery for local development
+    process.env.FRIGG_SKIP_AWS_DISCOVERY = 'true';
     const backendPath = path.resolve(process.cwd());
     console.log(`Starting backend in ${backendPath}...`);
     const infrastructurePath = 'infrastructure.js';

--- a/packages/devtools/frigg-cli/start-command/start-command.test.js
+++ b/packages/devtools/frigg-cli/start-command/start-command.test.js
@@ -1,0 +1,155 @@
+/**
+ * Test suite for the frigg start command
+ *
+ * These tests ensure that the start command properly:
+ * 1. Sets FRIGG_SKIP_AWS_DISCOVERY=true in the parent process to skip AWS API calls
+ * 2. Suppresses AWS SDK maintenance mode warnings
+ * 3. Spawns serverless with correct configuration
+ *
+ * This fixes the issue where frigg start would attempt AWS discovery during local development,
+ * causing unnecessary AWS API calls and potential failures when AWS credentials aren't available.
+ */
+
+const { spawn } = require('node:child_process');
+const { startCommand } = require('./index');
+
+// Mock the spawn function
+jest.mock('node:child_process', () => ({
+    spawn: jest.fn(),
+}));
+
+describe('startCommand', () => {
+    let mockChildProcess;
+
+    beforeEach(() => {
+        // Reset mocks
+        jest.clearAllMocks();
+
+        // Clear environment variables
+        delete process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE;
+        delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+
+        // Create a mock child process
+        mockChildProcess = {
+            on: jest.fn(),
+            stdout: { on: jest.fn() },
+            stderr: { on: jest.fn() },
+        };
+
+        spawn.mockReturnValue(mockChildProcess);
+    });
+
+    afterEach(() => {
+        // Clean up environment
+        delete process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE;
+        delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+    });
+
+    it('should set FRIGG_SKIP_AWS_DISCOVERY to true in the parent process', () => {
+        const options = { stage: 'dev' };
+
+        startCommand(options);
+
+        // Verify the environment variable is set in the parent process
+        expect(process.env.FRIGG_SKIP_AWS_DISCOVERY).toBe('true');
+    });
+
+    it('should set AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE to suppress warnings', () => {
+        const options = { stage: 'dev' };
+
+        startCommand(options);
+
+        expect(process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE).toBe('1');
+    });
+
+    it('should spawn serverless with correct arguments', () => {
+        const options = { stage: 'prod' };
+
+        startCommand(options);
+
+        expect(spawn).toHaveBeenCalledWith(
+            'serverless',
+            ['offline', '--config', 'infrastructure.js', '--stage', 'prod'],
+            expect.objectContaining({
+                cwd: expect.any(String),
+                stdio: 'inherit',
+                env: expect.objectContaining({
+                    FRIGG_SKIP_AWS_DISCOVERY: 'true',
+                }),
+            })
+        );
+    });
+
+    it('should include verbose flag when verbose option is enabled', () => {
+        const options = { stage: 'dev', verbose: true };
+
+        startCommand(options);
+
+        expect(spawn).toHaveBeenCalledWith(
+            'serverless',
+            ['offline', '--config', 'infrastructure.js', '--stage', 'dev', '--verbose'],
+            expect.any(Object)
+        );
+    });
+
+    it('should pass FRIGG_SKIP_AWS_DISCOVERY in spawn environment', () => {
+        const options = { stage: 'dev' };
+
+        startCommand(options);
+
+        const spawnCall = spawn.mock.calls[0];
+        const spawnOptions = spawnCall[2];
+
+        expect(spawnOptions.env).toHaveProperty('FRIGG_SKIP_AWS_DISCOVERY', 'true');
+    });
+
+    it('should handle child process errors', () => {
+        const options = { stage: 'dev' };
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+        startCommand(options);
+
+        // Simulate an error
+        const errorCallback = mockChildProcess.on.mock.calls.find(call => call[0] === 'error')[1];
+        const testError = new Error('Test error');
+        errorCallback(testError);
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Error executing command: Test error');
+
+        consoleErrorSpy.mockRestore();
+    });
+
+    it('should handle child process exit with non-zero code', () => {
+        const options = { stage: 'dev' };
+        const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+        startCommand(options);
+
+        // Simulate exit with error code
+        const closeCallback = mockChildProcess.on.mock.calls.find(call => call[0] === 'close')[1];
+        closeCallback(1);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith('Child process exited with code 1');
+
+        consoleLogSpy.mockRestore();
+    });
+
+    it('should not log on successful exit', () => {
+        const options = { stage: 'dev' };
+        const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+        startCommand(options);
+
+        // Clear the spy calls from startCommand execution
+        consoleLogSpy.mockClear();
+
+        // Simulate successful exit
+        const closeCallback = mockChildProcess.on.mock.calls.find(call => call[0] === 'close')[1];
+        closeCallback(0);
+
+        // Should not log anything for successful exit
+        expect(consoleLogSpy).not.toHaveBeenCalledWith(expect.stringContaining('exited'));
+
+        consoleLogSpy.mockRestore();
+    });
+});

--- a/packages/devtools/infrastructure/serverless-template.js
+++ b/packages/devtools/infrastructure/serverless-template.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const { AWSDiscovery } = require('./aws-discovery');
 
 const shouldRunDiscovery = (AppDefinition) => {
+    console.log('⚙️  Checking FRIGG_SKIP_AWS_DISCOVERY:', process.env.FRIGG_SKIP_AWS_DISCOVERY);
     if (process.env.FRIGG_SKIP_AWS_DISCOVERY === 'true') {
         console.log('⚙️  Skipping AWS discovery because FRIGG_SKIP_AWS_DISCOVERY is set.');
         return false;
@@ -657,6 +658,12 @@ const applyKmsConfiguration = (definition, AppDefinition, discoveredResources) =
         return;
     }
 
+    // Skip KMS configuration for local development when AWS discovery is disabled
+    if (process.env.FRIGG_SKIP_AWS_DISCOVERY === 'true') {
+        console.log('⚙️  Skipping KMS configuration for local development (FRIGG_SKIP_AWS_DISCOVERY is set)');
+        return;
+    }
+
     if (discoveredResources.defaultKmsKeyId) {
         console.log(`Using existing KMS key: ${discoveredResources.defaultKmsKeyId}`);
         definition.resources.Resources.FriggKMSKeyAlias = {
@@ -851,6 +858,12 @@ const healVpcConfiguration = (discoveredResources, AppDefinition) => {
 
 const configureVpc = (definition, AppDefinition, discoveredResources) => {
     if (AppDefinition.vpc?.enable !== true) {
+        return;
+    }
+
+    // Skip VPC configuration for local development when AWS discovery is disabled
+    if (process.env.FRIGG_SKIP_AWS_DISCOVERY === 'true') {
+        console.log('⚙️  Skipping VPC configuration for local development (FRIGG_SKIP_AWS_DISCOVERY is set)');
         return;
     }
 

--- a/packages/devtools/infrastructure/serverless-template.js
+++ b/packages/devtools/infrastructure/serverless-template.js
@@ -2,10 +2,18 @@ const path = require('path');
 const fs = require('fs');
 const { AWSDiscovery } = require('./aws-discovery');
 
-const shouldRunDiscovery = (AppDefinition) =>
-    AppDefinition.vpc?.enable === true ||
-    AppDefinition.encryption?.fieldLevelEncryptionMethod === 'kms' ||
-    AppDefinition.ssm?.enable === true;
+const shouldRunDiscovery = (AppDefinition) => {
+    if (process.env.FRIGG_SKIP_AWS_DISCOVERY === 'true') {
+        console.log('⚙️  Skipping AWS discovery because FRIGG_SKIP_AWS_DISCOVERY is set.');
+        return false;
+    }
+
+    return (
+        AppDefinition.vpc?.enable === true ||
+        AppDefinition.encryption?.fieldLevelEncryptionMethod === 'kms' ||
+        AppDefinition.ssm?.enable === true
+    );
+};
 
 const getAppEnvironmentVars = (AppDefinition) => {
     const envVars = {};

--- a/packages/devtools/infrastructure/serverless-template.test.js
+++ b/packages/devtools/infrastructure/serverless-template.test.js
@@ -55,6 +55,7 @@ describe('composeServerlessDefinition', () => {
         jest.restoreAllMocks();
         // Restore env
         delete process.env.AWS_REGION;
+        delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
         process.argv = ['node', 'test'];
     });
 
@@ -85,6 +86,50 @@ describe('composeServerlessDefinition', () => {
             await composeServerlessDefinition(appDefinition);
 
             expect(AWSDiscovery).toHaveBeenCalledTimes(1);
+        });
+
+        it('should skip AWS discovery when FRIGG_SKIP_AWS_DISCOVERY is set to true', async () => {
+            AWSDiscovery.mockClear();
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = 'true';
+
+            const appDefinition = {
+                integrations: [],
+                vpc: { enable: true },
+                encryption: { fieldLevelEncryptionMethod: 'kms' },
+                ssm: { enable: true },
+            };
+
+            await composeServerlessDefinition(appDefinition);
+
+            expect(AWSDiscovery).not.toHaveBeenCalled();
+        });
+
+        it('should run AWS discovery when FRIGG_SKIP_AWS_DISCOVERY is not set', async () => {
+            AWSDiscovery.mockClear();
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+
+            const appDefinition = {
+                integrations: [],
+                vpc: { enable: true },
+            };
+
+            await composeServerlessDefinition(appDefinition);
+
+            expect(AWSDiscovery).toHaveBeenCalledTimes(1);
+        });
+
+        it('should skip VPC configuration when FRIGG_SKIP_AWS_DISCOVERY is true', async () => {
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = 'true';
+
+            const appDefinition = {
+                integrations: [],
+                vpc: { enable: true, management: 'discover' },
+            };
+
+            const result = await composeServerlessDefinition(appDefinition);
+
+            // VPC configuration should not be present when skipped
+            expect(result.provider.vpc).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
## Summary

- set the Frigg start CLI command to pass an environment flag that skips AWS discovery while running serverless offline
- gate serverless template discovery logic on the new FRIGG_SKIP_AWS_DISCOVERY flag so local runs avoid remote AWS lookups

## Testing

- npm test --workspace @friggframework/devtools -- serverless-template.test.js _(fails: existing Jest suites in frigg-cli currently break on virtual mocks and AWS SDK configuration)_

---

https://chatgpt.com/codex/tasks/task_e_68d57cd7c2a48321914f144c7bf5d5ce

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->

# Version

Published prerelease version: `v2.0.0-next.41`

<details>
<summary>Changelog</summary>

#### 🚀 Enhancement

- `@friggframework/devtools`
    - Skip AWS discovery when running Frigg start locally [#431](https://github.com/friggframework/frigg/pull/431) ([@seanspeaks](https://github.com/seanspeaks))
- `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - feat: add KMS decrypt capability check to health endpoint [#428](https://github.com/friggframework/frigg/pull/428) ([@d-klotz](https://github.com/d-klotz) [@seanspeaks](https://github.com/seanspeaks))

#### Authors: 2

- Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
- Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))

</details>

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->