### PR TITLE
fix: export UserActionModal from integration module

### DIFF
--- a/packages/ui/lib/integration/index.js
+++ b/packages/ui/lib/integration/index.js
@@ -15,6 +15,7 @@ export { default as IntegrationBuilder } from './IntegrationBuilder';
 export { default as EntityManager } from './EntityManager';
 export { default as IntegrationList } from './IntegrationList';
 export { default as RedirectFromAuth } from './RedirectFromAuth';
+export { UserActionModal } from './modals';
 
 // Export presentation components
 export { EntityCard } from './presentation/components/EntityCard';


### PR DESCRIPTION
## Summary
- export the UserActionModal from the integration barrel file so it can be bundled

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deb38912dc83219ccca77107d99261