### PR TITLE
Fix: frigg minor issues

### DIFF
--- a/packages/core/handlers/routers/user.js
+++ b/packages/core/handlers/routers/user.js
@@ -1,7 +1,9 @@
 const express = require('express');
 const { createAppHandler } = require('../app-handler-helpers');
 const { checkRequiredParams } = require('@friggframework/core');
-const { createUserRepository } = require('../../user/user-repository-factory');
+const {
+    createUserRepository,
+} = require('../../user/repositories/user-repository-factory');
 const {
     CreateIndividualUser,
 } = require('../../user/use-cases/create-individual-user');

--- a/packages/core/modules/module.js
+++ b/packages/core/modules/module.js
@@ -42,7 +42,7 @@ class Module extends Delegate {
         const apiParams = {
             ...this.definition.env,
             delegate: this,
-            ...this.apiParamsFromCredential(this.credential.data), // todo: check if this works for mongo as well
+            ...(this.credential?.data ? this.apiParamsFromCredential(this.credential.data) : {}), // Handle case when credential is undefined
             ...this.apiParamsFromEntity(this.entity),
         };
         this.api = new this.apiClass(apiParams);

--- a/packages/core/modules/use-cases/process-authorization-callback.js
+++ b/packages/core/modules/use-cases/process-authorization-callback.js
@@ -93,7 +93,8 @@ class ProcessAuthorizationCallback {
         );
         credentialDetails.details.authIsValid = true;
 
-        await this.credentialRepository.upsertCredential(credentialDetails);
+        const persisted = await this.credentialRepository.upsertCredential(credentialDetails);
+        module.credential = persisted;
     }
 
     async findOrCreateEntity(entityDetails, moduleName, credentialId) {

--- a/packages/core/prisma-mongodb/schema.prisma
+++ b/packages/core/prisma-mongodb/schema.prisma
@@ -159,9 +159,6 @@ model Integration {
   entities  Entity[] @relation("IntegrationEntities", fields: [entityIds], references: [id])
   entityIds String[] @db.ObjectId
 
-  // Entity reference map (Map<String, String> stored as JSON)
-  entityReferenceMap Json? @default("{}")
-
   // Message arrays (stored as JSON)
   errors   Json @default("[]")
   warnings Json @default("[]")

--- a/packages/core/prisma-postgresql/migrations/20251010000000_remove_unused_entity_reference_map/migration.sql
+++ b/packages/core/prisma-postgresql/migrations/20251010000000_remove_unused_entity_reference_map/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+-- Remove unused entityReferenceMap field from Integration table
+ALTER TABLE "Integration" DROP COLUMN "entityReferenceMap";

--- a/packages/core/prisma-postgresql/schema.prisma
+++ b/packages/core/prisma-postgresql/schema.prisma
@@ -151,9 +151,6 @@ model Integration {
   // Entity references (many-to-many via implicit join table)
   entities Entity[]
 
-  // Entity reference map (Map<String, String> stored as JSON)
-  entityReferenceMap Json? @default("{}")
-
   // Message arrays (stored as JSON)
   errors   Json @default("[]")
   warnings Json @default("[]")

--- a/packages/devtools/management-ui/src/App.jsx
+++ b/packages/devtools/management-ui/src/App.jsx
@@ -1,68 +1,14 @@
 import React from 'react'
-<<<<<<< HEAD
-<<<<<<< HEAD
 import { BrowserRouter as Router } from 'react-router-dom'
 import AppRouter from './components/AppRouter'
-=======
-<<<<<<< HEAD
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
-import Layout from './components/Layout'
-import Dashboard from './pages/Dashboard'
-import Integrations from './pages/Integrations'
-import IntegrationDiscovery from './pages/IntegrationDiscovery'
-import IntegrationConfigure from './pages/IntegrationConfigure'
-import IntegrationTest from './pages/IntegrationTest'
-import Environment from './pages/Environment'
-import Users from './pages/Users'
-import ConnectionsEnhanced from './pages/ConnectionsEnhanced'
-import Simulation from './pages/Simulation'
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
-import Monitoring from './pages/Monitoring'
-import CodeGeneration from './pages/CodeGeneration'
-=======
-import { BrowserRouter as Router } from 'react-router-dom'
-import AppRouter from './components/AppRouter'
->>>>>>> d6114470 (feat: add comprehensive DDD/Hexagonal architecture RFC series)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
-import { BrowserRouter as Router } from 'react-router-dom'
-import AppRouter from './components/AppRouter'
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
 import ErrorBoundary from './components/ErrorBoundary'
 import { SocketProvider } from './hooks/useSocket'
 import { FriggProvider } from './hooks/useFrigg'
 import { ThemeProvider } from './components/theme-provider'
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
-import ErrorBoundary from './components/ErrorBoundary'
-import { SocketProvider } from './hooks/useSocket'
-import { FriggProvider } from './hooks/useFrigg'
->>>>>>> 652520a5 (Claude Flow RFC related development)
-=======
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
 
 function App() {
   return (
     <ErrorBoundary>
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
       <ThemeProvider defaultTheme="system">
         <SocketProvider>
           <FriggProvider>
@@ -72,36 +18,6 @@ function App() {
           </FriggProvider>
         </SocketProvider>
       </ThemeProvider>
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
-      <SocketProvider>
-        <FriggProvider>
-          <Router>
-            <Layout>
-              <Routes>
-                <Route path="/" element={<Navigate to="/dashboard" />} />
-                <Route path="/dashboard" element={<Dashboard />} />
-                <Route path="/integrations" element={<IntegrationDiscovery />} />
-                <Route path="/integrations/:integrationName/configure" element={<IntegrationConfigure />} />
-                <Route path="/integrations/:integrationName/test" element={<IntegrationTest />} />
-                <Route path="/environment" element={<Environment />} />
-                <Route path="/users" element={<Users />} />
-                <Route path="/connections" element={<ConnectionsEnhanced />} />
-                <Route path="/simulation" element={<Simulation />} />
-              </Routes>
-            </Layout>
-          </Router>
-        </FriggProvider>
-      </SocketProvider>
->>>>>>> 652520a5 (Claude Flow RFC related development)
-=======
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
     </ErrorBoundary>
   )
 }

--- a/packages/devtools/management-ui/src/hooks/useFrigg.jsx
+++ b/packages/devtools/management-ui/src/hooks/useFrigg.jsx
@@ -21,35 +21,11 @@ export const FriggProvider = ({ children }) => {
   const [users, setUsers] = useState([])
   const [connections, setConnections] = useState([])
   const [currentUser, setCurrentUser] = useState(null)
-<<<<<<< HEAD
-<<<<<<< HEAD
   const [repositories, setRepositories] = useState([])
   const [currentRepository, setCurrentRepository] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
-  const [repositories, setRepositories] = useState([])
-  const [currentRepository, setCurrentRepository] = useState(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState(null)
-<<<<<<< HEAD
-=======
->>>>>>> 652520a5 (Claude Flow RFC related development)
-=======
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState(null)
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
 
   useEffect(() => {
     // Listen for status updates
@@ -123,114 +99,34 @@ export const FriggProvider = ({ children }) => {
 
   const fetchInitialData = async () => {
     try {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
       setLoading(true)
       setError(null)
 
       const [statusRes, integrationsRes, envRes, usersRes, connectionsRes] = await Promise.all([
         api.get('/api/project/status'),
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
-      const [statusRes, integrationsRes, envRes, usersRes, connectionsRes] = await Promise.all([
-        api.get('/api/frigg/status'),
->>>>>>> 652520a5 (Claude Flow RFC related development)
-=======
-      setLoading(true)
-      setError(null)
-      
-      const [statusRes, integrationsRes, envRes, usersRes, connectionsRes] = await Promise.all([
-        api.get('/api/project/status'),
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
         api.get('/api/integrations'),
         api.get('/api/environment'),
         api.get('/api/users'),
         api.get('/api/connections'),
       ])
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
       setStatus(statusRes.data.data?.status || statusRes.data.status || 'stopped')
       setIntegrations(integrationsRes.data.data?.integrations || integrationsRes.data.integrations || [])
       setEnvVariables(envRes.data.data?.variables || envRes.data.variables || {})
       setUsers(usersRes.data.data?.users || usersRes.data.users || [])
       setConnections(connectionsRes.data.data?.connections || connectionsRes.data.connections || [])
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
     } catch (error) {
       console.error('Error fetching initial data:', error)
       setError(error.message || 'Failed to fetch data')
     } finally {
       setLoading(false)
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
-      setStatus(statusRes.data.status)
-      setIntegrations(integrationsRes.data.integrations || [])
-      setEnvVariables(envRes.data.variables || {})
-      setUsers(usersRes.data.users || [])
-      setConnections(connectionsRes.data.connections || [])
-    } catch (error) {
-      console.error('Error fetching initial data:', error)
->>>>>>> 652520a5 (Claude Flow RFC related development)
-=======
-    } catch (error) {
-      console.error('Error fetching initial data:', error)
-      setError(error.message || 'Failed to fetch data')
-    } finally {
-      setLoading(false)
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
     }
   }
 
   const startFrigg = async (options = {}) => {
     try {
       setStatus('starting')
-<<<<<<< HEAD
-<<<<<<< HEAD
       await api.post('/api/project/start', options)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-      await api.post('/api/project/start', options)
-=======
-      await api.post('/api/frigg/start', options)
->>>>>>> 652520a5 (Claude Flow RFC related development)
-=======
-      await api.post('/api/project/start', options)
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
-      await api.post('/api/project/start', options)
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
     } catch (error) {
       console.error('Error starting Frigg:', error)
       setStatus('stopped')
@@ -239,23 +135,7 @@ export const FriggProvider = ({ children }) => {
 
   const stopFrigg = async (force = false) => {
     try {
-<<<<<<< HEAD
-<<<<<<< HEAD
       await api.post('/api/project/stop', { force })
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-      await api.post('/api/project/stop', { force })
-=======
-      await api.post('/api/frigg/stop', { force })
->>>>>>> 652520a5 (Claude Flow RFC related development)
-=======
-      await api.post('/api/project/stop', { force })
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
-      await api.post('/api/project/stop', { force })
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
       setStatus('stopped')
     } catch (error) {
       console.error('Error stopping Frigg:', error)
@@ -264,23 +144,7 @@ export const FriggProvider = ({ children }) => {
 
   const restartFrigg = async (options = {}) => {
     try {
-<<<<<<< HEAD
-<<<<<<< HEAD
       await api.post('/api/project/restart', options)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-      await api.post('/api/project/restart', options)
-=======
-      await api.post('/api/frigg/restart', options)
->>>>>>> 652520a5 (Claude Flow RFC related development)
-=======
-      await api.post('/api/project/restart', options)
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
-      await api.post('/api/project/restart', options)
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
     } catch (error) {
       console.error('Error restarting Frigg:', error)
     }
@@ -288,28 +152,8 @@ export const FriggProvider = ({ children }) => {
 
   const getLogs = async (limit = 100) => {
     try {
-<<<<<<< HEAD
-<<<<<<< HEAD
       const response = await api.get(`/api/project/logs?limit=${limit}`)
       return response.data.data?.logs || response.data.logs || []
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-      const response = await api.get(`/api/project/logs?limit=${limit}`)
-      return response.data.data?.logs || response.data.logs || []
-=======
-      const response = await api.get(`/api/frigg/logs?limit=${limit}`)
-      return response.data.logs || []
->>>>>>> 652520a5 (Claude Flow RFC related development)
-=======
-      const response = await api.get(`/api/project/logs?limit=${limit}`)
-      return response.data.data?.logs || response.data.logs || []
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
-      const response = await api.get(`/api/project/logs?limit=${limit}`)
-      return response.data.data?.logs || response.data.logs || []
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
     } catch (error) {
       console.error('Error fetching logs:', error)
       return []
@@ -318,48 +162,14 @@ export const FriggProvider = ({ children }) => {
 
   const getMetrics = async () => {
     try {
-<<<<<<< HEAD
-<<<<<<< HEAD
       const response = await api.get('/api/project/metrics')
       return response.data.data || response.data
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-      const response = await api.get('/api/project/metrics')
-      return response.data.data || response.data
-=======
-      const response = await api.get('/api/frigg/metrics')
-      return response.data
->>>>>>> 652520a5 (Claude Flow RFC related development)
-=======
-      const response = await api.get('/api/project/metrics')
-      return response.data.data || response.data
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
-      const response = await api.get('/api/project/metrics')
-      return response.data.data || response.data
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
     } catch (error) {
       console.error('Error fetching metrics:', error)
       return null
     }
   }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-
-=======
->>>>>>> 652520a5 (Claude Flow RFC related development)
-=======
-
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
   const installIntegration = async (integrationName) => {
     try {
       const response = await api.post('/api/integrations/install', { name: integrationName })
@@ -539,35 +349,11 @@ export const FriggProvider = ({ children }) => {
     users,
     connections,
     currentUser,
-<<<<<<< HEAD
-<<<<<<< HEAD
     repositories,
     currentRepository,
     isLoading,
     loading,
     error,
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
-    repositories,
-    currentRepository,
-    isLoading,
-    loading,
-    error,
-<<<<<<< HEAD
-=======
->>>>>>> 652520a5 (Claude Flow RFC related development)
-=======
-    loading,
-    error,
->>>>>>> f153939e (refactor: clean up CLI help display and remove unused dependencies)
->>>>>>> 860052b4 (feat: integrate complete management-ui and additional features)
-=======
->>>>>>> 7e97f01c (fix: resolve ui-command merge conflicts and update package.json)
     startFrigg,
     stopFrigg,
     restartFrigg,


### PR DESCRIPTION
This pull request focuses on cleaning up unused code and improving robustness in user and module handling. The main changes include removing the unused `entityReferenceMap` field from integration models and database schemas, updating repository imports for clarity, and enhancing error handling for credentials and module instantiation.

**Database and Model Cleanup:**

* Removed the unused `entityReferenceMap` field from the `Integration` model in both MongoDB and PostgreSQL Prisma schemas (`schema.prisma`) and dropped the corresponding column in the PostgreSQL migration script (`migration.sql`). [[1]](diffhunk://#diff-2c3631ca1b5d5c099393718424067dd609822af0362f9da6c8b23e871434efe5L162-L164) [[2]](diffhunk://#diff-cee6b39c44034c6cb70fe56958e86301ec3074ec9a268496653392a4bd608cf4L154-L156) [[3]](diffhunk://#diff-f3f29600e743d115867a9341697690bdc45d2be3f5393236d9b0bfc846260ee3R1-R3)

**Codebase Maintenance:**

* Updated the import path for `createUserRepository` in `user.js` to reflect its new location in `repositories/user-repository-factory`, improving code organization.

**Robustness Improvements:**

* Added a check to ensure `credential` is defined before calling `apiParamsFromCredential` in the module initialization logic, preventing potential runtime errors.
* Ensured the module's `credential` property is updated with the persisted credential after upserting, maintaining consistency in authorization callback processing.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.458.c150d9a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.458.c150d9a.0
  npm install @friggframework/devtools@2.0.0--canary.458.c150d9a.0
  npm install @friggframework/eslint-config@2.0.0--canary.458.c150d9a.0
  npm install @friggframework/prettier-config@2.0.0--canary.458.c150d9a.0
  npm install @friggframework/schemas@2.0.0--canary.458.c150d9a.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.458.c150d9a.0
  npm install @friggframework/test@2.0.0--canary.458.c150d9a.0
  npm install @friggframework/ui@2.0.0--canary.458.c150d9a.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.458.c150d9a.0
  yarn add @friggframework/devtools@2.0.0--canary.458.c150d9a.0
  yarn add @friggframework/eslint-config@2.0.0--canary.458.c150d9a.0
  yarn add @friggframework/prettier-config@2.0.0--canary.458.c150d9a.0
  yarn add @friggframework/schemas@2.0.0--canary.458.c150d9a.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.458.c150d9a.0
  yarn add @friggframework/test@2.0.0--canary.458.c150d9a.0
  yarn add @friggframework/ui@2.0.0--canary.458.c150d9a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.43`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/core`, `@friggframework/devtools`
    - Fix: frigg minor issues [#458](https://github.com/friggframework/frigg/pull/458) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - refactor: adopt some hexagonal architecture components to better organize the core package [#395](https://github.com/friggframework/frigg/pull/395) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
