### PR TITLE
refactor: add jetpack bundle handling back and improve readability

### DIFF
--- a/packages/core/handlers/backend-utils.js
+++ b/packages/core/handlers/backend-utils.js
@@ -19,6 +19,7 @@ const {
 const {
     getModulesDefinitionFromIntegrationClasses,
 } = require('../integrations/utils/map-integration-dto');
+const { loadAppDefinition } = require('./app-definition-loader');
 
 const loadRouterFromObject = (IntegrationClass, routerObject) => {
     const router = Router();
@@ -50,37 +51,29 @@ const loadRouterFromObject = (IntegrationClass, routerObject) => {
 };
 
 const initializeRepositories = () => {
-    const processRepository = createProcessRepository();
-    const integrationRepository = createIntegrationRepository();
-    const moduleRepository = createModuleRepository();
-
-    return { processRepository, integrationRepository, moduleRepository };
+    return {
+        processRepository: createProcessRepository(),
+        integrationRepository: createIntegrationRepository(),
+        moduleRepository: createModuleRepository(),
+    };
 };
 
-const createModuleFactoryWithDefinitions = (
-    moduleRepository,
-    integrationClasses
-) => {
-    const moduleDefinitions =
-        getModulesDefinitionFromIntegrationClasses(integrationClasses);
+/**
+ * Load hydrated integration instance for webhook events WITH integrationId.
+ * Must load app definition to find all integration classes, then match
+ * against the integration record's type.
+ */
+const loadIntegrationForWebhook = async (integrationId) => {
+    const { integrations: integrationClasses } = loadAppDefinition();
+    const { integrationRepository, moduleRepository } = initializeRepositories();
 
-    return new ModuleFactory({
+    const moduleDefinitions = getModulesDefinitionFromIntegrationClasses(
+        integrationClasses
+    );
+    const moduleFactory = new ModuleFactory({
         moduleRepository,
         moduleDefinitions,
     });
-};
-
-const loadIntegrationForWebhook = async (integrationId) => {
-    const { loadAppDefinition } = require('./app-definition-loader');
-    const { integrations: integrationClasses } = loadAppDefinition();
-
-    const { integrationRepository, moduleRepository } =
-        initializeRepositories();
-
-    const moduleFactory = createModuleFactoryWithDefinitions(
-        moduleRepository,
-        integrationClasses
-    );
 
     const getIntegrationInstance = new GetIntegrationInstance({
         integrationRepository,
@@ -92,29 +85,48 @@ const loadIntegrationForWebhook = async (integrationId) => {
         integrationId
     );
 
+    if (!integrationRecord) {
+        throw new Error(
+            `No integration found by the ID of ${integrationId}`
+        );
+    }
+
     return await getIntegrationInstance.execute(
         integrationId,
         integrationRecord.userId
     );
 };
 
+/**
+ * Load hydrated integration instance for process-based events.
+ * Integration class is already known from queue worker context,
+ * so we receive it as a parameter rather than loading all classes.
+ */
 const loadIntegrationForProcess = async (processId, integrationClass) => {
+    if (!integrationClass) {
+        throw new Error('integrationClass parameter is required');
+    }
+
+    if (!processId) {
+        throw new Error('processId is required in queue message data');
+    }
+
     const { processRepository, integrationRepository, moduleRepository } =
         initializeRepositories();
 
-    const moduleFactory = createModuleFactoryWithDefinitions(moduleRepository, [
+    const moduleDefinitions = getModulesDefinitionFromIntegrationClasses([
         integrationClass,
     ]);
+    const moduleFactory = new ModuleFactory({
+        moduleRepository,
+        moduleDefinitions,
+    });
 
     const getIntegrationInstance = new GetIntegrationInstance({
         integrationRepository,
         integrationClasses: [integrationClass],
         moduleFactory,
     });
-
-    if (!processId) {
-        throw new Error('processId is required in queue message data');
-    }
 
     const process = await processRepository.findById(processId);
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,67 +1,74 @@
 {
-  "name": "@friggframework/core",
-  "prettier": "@friggframework/prettier-config",
-  "version": "2.0.0-next.0",
-  "dependencies": {
-    "@hapi/boom": "^10.0.1",
-    "@prisma/client": "^6.16.3",
-    "aws-sdk": "^2.1200.0",
-    "bcryptjs": "^2.4.3",
-    "body-parser": "^1.20.2",
-    "common-tags": "^1.8.2",
-    "cors": "^2.8.5",
-    "dotenv": "^16.4.7",
-    "express": "^4.19.2",
-    "express-async-handler": "^1.2.0",
-    "form-data": "^4.0.0",
-    "fs-extra": "^11.2.0",
-    "lodash": "4.17.21",
-    "lodash.get": "^4.4.2",
-    "mongoose": "6.11.6",
-    "node-fetch": "^2.6.7",
-    "serverless-http": "^2.7.0",
-    "uuid": "^9.0.1"
-  },
-  "devDependencies": {
-    "@friggframework/eslint-config": "^2.0.0-next.0",
-    "@friggframework/prettier-config": "^2.0.0-next.0",
-    "@friggframework/test": "^2.0.0-next.0",
-    "@types/lodash": "4.17.15",
-    "@typescript-eslint/eslint-plugin": "^8.0.0",
-    "chai": "^4.3.6",
-    "eslint": "^8.22.0",
-    "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-n": "^17.10.2",
-    "eslint-plugin-promise": "^7.0.0",
-    "jest": "^29.7.0",
-    "prettier": "^2.7.1",
-    "prisma": "^6.16.3",
-    "sinon": "^16.1.1",
-    "typescript": "^5.0.2"
-  },
-  "scripts": {
-    "lint:fix": "prettier --write --loglevel error . && eslint . --fix",
-    "test": "jest --passWithNoTests # TODO",
-    "prisma:generate:mongo": "npx prisma generate --schema ./prisma-mongodb/schema.prisma",
-    "prisma:generate:postgres": "npx prisma generate --schema ./prisma-postgresql/schema.prisma",
-    "prisma:generate": "npm run prisma:generate:mongo && npm run prisma:generate:postgres",
-    "prisma:push:mongo": "npx prisma db push --schema ./prisma-mongodb/schema.prisma",
-    "prisma:migrate:postgres": "npx prisma migrate dev --schema ./prisma-postgresql/schema.prisma",
-    "postinstall": "npm run prisma:generate"
-  },
-  "author": "",
-  "license": "MIT",
-  "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/friggframework/frigg.git"
-  },
-  "bugs": {
-    "url": "https://github.com/friggframework/frigg/issues"
-  },
-  "homepage": "https://github.com/friggframework/frigg#readme",
-  "description": "",
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@friggframework/core",
+    "prettier": "@friggframework/prettier-config",
+    "version": "2.0.0-next.0",
+    "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@prisma/client": "^6.16.3",
+        "bcryptjs": "^2.4.3",
+        "body-parser": "^1.20.2",
+        "common-tags": "^1.8.2",
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.7",
+        "express": "^4.19.2",
+        "express-async-handler": "^1.2.0",
+        "form-data": "^4.0.0",
+        "fs-extra": "^11.2.0",
+        "lodash": "4.17.21",
+        "lodash.get": "^4.4.2",
+        "mongoose": "6.11.6",
+        "node-fetch": "^2.6.7",
+        "serverless-http": "^2.7.0",
+        "uuid": "^9.0.1"
+    },
+    "peerDependencies": {
+        "aws-sdk": "^2.1200.0"
+    },
+    "peerDependenciesMeta": {
+        "aws-sdk": {
+            "optional": true
+        }
+    },
+    "devDependencies": {
+        "@friggframework/eslint-config": "^2.0.0-next.0",
+        "@friggframework/prettier-config": "^2.0.0-next.0",
+        "@friggframework/test": "^2.0.0-next.0",
+        "@types/lodash": "4.17.15",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "chai": "^4.3.6",
+        "eslint": "^8.22.0",
+        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-n": "^17.10.2",
+        "eslint-plugin-promise": "^7.0.0",
+        "jest": "^29.7.0",
+        "prettier": "^2.7.1",
+        "prisma": "^6.16.3",
+        "sinon": "^16.1.1",
+        "typescript": "^5.0.2"
+    },
+    "scripts": {
+        "lint:fix": "prettier --write --loglevel error . && eslint . --fix",
+        "test": "jest --passWithNoTests # TODO",
+        "prisma:generate:mongo": "npx prisma generate --schema ./prisma-mongodb/schema.prisma",
+        "prisma:generate:postgres": "npx prisma generate --schema ./prisma-postgresql/schema.prisma",
+        "prisma:generate": "npm run prisma:generate:mongo && npm run prisma:generate:postgres",
+        "prisma:push:mongo": "npx prisma db push --schema ./prisma-mongodb/schema.prisma",
+        "prisma:migrate:postgres": "npx prisma migrate dev --schema ./prisma-postgresql/schema.prisma",
+        "postinstall": "npm run prisma:generate"
+    },
+    "author": "",
+    "license": "MIT",
+    "main": "index.js",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/friggframework/frigg.git"
+    },
+    "bugs": {
+        "url": "https://github.com/friggframework/frigg/issues"
+    },
+    "homepage": "https://github.com/friggframework/frigg#readme",
+    "description": "",
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/devtools/infrastructure/serverless-template.js
+++ b/packages/devtools/infrastructure/serverless-template.js
@@ -68,7 +68,8 @@ const getAppEnvironmentVars = (AppDefinition) => {
     }
     if (skippedKeys.length > 0) {
         console.log(
-            `   ⚠️  Skipped ${skippedKeys.length
+            `   ⚠️  Skipped ${
+                skippedKeys.length
             } reserved AWS Lambda variables: ${skippedKeys.join(', ')}`
         );
     }
@@ -674,8 +675,7 @@ const createBaseDefinition = (
             },
         },
         plugins: [
-            // Temporarily disabled Jetpack - it ignores package.patterns in dependency mode
-            // 'serverless-jetpack',
+            'serverless-jetpack',
             'serverless-dotenv-plugin',
             'serverless-offline-sqs',
             'serverless-offline',
@@ -696,10 +696,9 @@ const createBaseDefinition = (
                 secretAccessKey: 'root',
                 skipCacheInvalidation: false,
             },
-            // Jetpack config removed - testing with standard Serverless packaging
-            // jetpack: {
-            //     base: '..',
-            // },
+            jetpack: {
+                base: '..',
+            },
         },
         functions: {
             auth: {
@@ -851,7 +850,7 @@ const applyKmsConfiguration = (
         if (AppDefinition.encryption?.createResourceIfNoneFound !== true) {
             throw new Error(
                 'KMS field-level encryption is enabled but no KMS key was found. ' +
-                'Either provide an existing KMS key or set encryption.createResourceIfNoneFound to true to create a new key.'
+                    'Either provide an existing KMS key or set encryption.createResourceIfNoneFound to true to create a new key.'
             );
         }
 
@@ -890,8 +889,9 @@ const applyKmsConfiguration = (
                             Resource: '*',
                             Condition: {
                                 StringEquals: {
-                                    'kms:ViaService': `lambda.${process.env.AWS_REGION || 'us-east-1'
-                                        }.amazonaws.com`,
+                                    'kms:ViaService': `lambda.${
+                                        process.env.AWS_REGION || 'us-east-1'
+                                    }.amazonaws.com`,
                                 },
                             },
                         },
@@ -1293,13 +1293,13 @@ const configureVpc = (definition, AppDefinition, discoveredResources) => {
             };
 
             definition.resources.Resources.FriggPublicSubnetRouteTableAssociation =
-            {
-                Type: 'AWS::EC2::SubnetRouteTableAssociation',
-                Properties: {
-                    SubnetId: { Ref: 'FriggPublicSubnet' },
-                    RouteTableId: { Ref: 'FriggPublicRouteTable' },
-                },
-            };
+                {
+                    Type: 'AWS::EC2::SubnetRouteTableAssociation',
+                    Properties: {
+                        SubnetId: { Ref: 'FriggPublicSubnet' },
+                        RouteTableId: { Ref: 'FriggPublicRouteTable' },
+                    },
+                };
 
             definition.resources.Resources.FriggLambdaRouteTable = {
                 Type: 'AWS::EC2::RouteTable',
@@ -1316,22 +1316,22 @@ const configureVpc = (definition, AppDefinition, discoveredResources) => {
             };
 
             definition.resources.Resources.FriggPrivateSubnet1RouteTableAssociation =
-            {
-                Type: 'AWS::EC2::SubnetRouteTableAssociation',
-                Properties: {
-                    SubnetId: { Ref: 'FriggPrivateSubnet1' },
-                    RouteTableId: { Ref: 'FriggLambdaRouteTable' },
-                },
-            };
+                {
+                    Type: 'AWS::EC2::SubnetRouteTableAssociation',
+                    Properties: {
+                        SubnetId: { Ref: 'FriggPrivateSubnet1' },
+                        RouteTableId: { Ref: 'FriggLambdaRouteTable' },
+                    },
+                };
 
             definition.resources.Resources.FriggPrivateSubnet2RouteTableAssociation =
-            {
-                Type: 'AWS::EC2::SubnetRouteTableAssociation',
-                Properties: {
-                    SubnetId: { Ref: 'FriggPrivateSubnet2' },
-                    RouteTableId: { Ref: 'FriggLambdaRouteTable' },
-                },
-            };
+                {
+                    Type: 'AWS::EC2::SubnetRouteTableAssociation',
+                    Properties: {
+                        SubnetId: { Ref: 'FriggPrivateSubnet2' },
+                        RouteTableId: { Ref: 'FriggLambdaRouteTable' },
+                    },
+                };
         }
     } else if (subnetManagement === 'use-existing') {
         if (
@@ -1348,12 +1348,12 @@ const configureVpc = (definition, AppDefinition, discoveredResources) => {
             AppDefinition.vpc.subnets?.ids?.length > 0
                 ? AppDefinition.vpc.subnets.ids
                 : discoveredResources.privateSubnetId1 &&
-                    discoveredResources.privateSubnetId2
-                    ? [
-                        discoveredResources.privateSubnetId1,
-                        discoveredResources.privateSubnetId2,
-                    ]
-                    : [];
+                  discoveredResources.privateSubnetId2
+                ? [
+                      discoveredResources.privateSubnetId1,
+                      discoveredResources.privateSubnetId2,
+                  ]
+                : [];
 
         if (vpcConfig.subnetIds.length < 2) {
             if (AppDefinition.vpc.selfHeal) {
@@ -1560,13 +1560,13 @@ const configureVpc = (definition, AppDefinition, discoveredResources) => {
                     };
 
                     definition.resources.Resources.FriggPublicSubnetRouteTableAssociation =
-                    {
-                        Type: 'AWS::EC2::SubnetRouteTableAssociation',
-                        Properties: {
-                            SubnetId: { Ref: 'FriggPublicSubnet' },
-                            RouteTableId: { Ref: 'FriggPublicRouteTable' },
-                        },
-                    };
+                        {
+                            Type: 'AWS::EC2::SubnetRouteTableAssociation',
+                            Properties: {
+                                SubnetId: { Ref: 'FriggPublicSubnet' },
+                                RouteTableId: { Ref: 'FriggPublicRouteTable' },
+                            },
+                        };
                 }
 
                 definition.resources.Resources.FriggNATGateway = {
@@ -1577,11 +1577,11 @@ const configureVpc = (definition, AppDefinition, discoveredResources) => {
                         AllocationId: useExistingEip
                             ? discoveredResources.existingElasticIpAllocationId
                             : {
-                                'Fn::GetAtt': [
-                                    'FriggNATGatewayEIP',
-                                    'AllocationId',
-                                ],
-                            },
+                                  'Fn::GetAtt': [
+                                      'FriggNATGatewayEIP',
+                                      'AllocationId',
+                                  ],
+                              },
                         SubnetId: discoveredResources.publicSubnetId || {
                             Ref: 'FriggPublicSubnet',
                         },
@@ -1955,8 +1955,9 @@ const attachIntegrations = (definition, AppDefinition) => {
         }
 
         const integrationName = integration.Definition.name;
-        const queueReference = `${integrationName.charAt(0).toUpperCase() + integrationName.slice(1)
-            }Queue`;
+        const queueReference = `${
+            integrationName.charAt(0).toUpperCase() + integrationName.slice(1)
+        }Queue`;
         const queueName = `\${self:service}--\${self:provider.stage}-${queueReference}`;
 
         definition.functions[integrationName] = {
@@ -2012,7 +2013,10 @@ const attachIntegrations = (definition, AppDefinition) => {
 
         // Add webhook handler if enabled
         const webhookConfig = integration.Definition.webhooks;
-        if (webhookConfig && (webhookConfig === true || webhookConfig.enabled === true)) {
+        if (
+            webhookConfig &&
+            (webhookConfig === true || webhookConfig.enabled === true)
+        ) {
             const webhookFunctionName = `${integrationName}Webhook`;
 
             definition.functions[webhookFunctionName] = {


### PR DESCRIPTION
This pull request refactors and improves integration instance loading logic in `backend-utils.js` and updates the Serverless infrastructure template to re-enable Jetpack packaging and improve code readability. The main focus is on simplifying module factory creation, adding error handling, and restoring Jetpack support in the development tooling.

**Integration loading and error handling improvements:**

* Refactored the `loadIntegrationForWebhook` and `loadIntegrationForProcess` functions in `backend-utils.js` to simplify module factory creation and add explicit error handling for missing integration IDs and classes. This removes the `createModuleFactoryWithDefinitions` helper and inlines module factory setup for clarity. [[1]](diffhunk://#diff-4dc8dc98505c8a49f0bf2a68a20dab4449c2a530d4f7db3d6f9ff755bf1f976eR22) [[2]](diffhunk://#diff-4dc8dc98505c8a49f0bf2a68a20dab4449c2a530d4f7db3d6f9ff755bf1f976eL53-R76) [[3]](diffhunk://#diff-4dc8dc98505c8a49f0bf2a68a20dab4449c2a530d4f7db3d6f9ff755bf1f976eR88-L118)

**Serverless infrastructure and packaging updates:**

* Re-enabled the `serverless-jetpack` plugin and restored its configuration in the Serverless template, switching back to Jetpack packaging for improved deployment performance. [[1]](diffhunk://#diff-ba3d278f90c660143a55e943daac072a53fe4f012518e5c638efd51f9385c326L677-R678) [[2]](diffhunk://#diff-ba3d278f90c660143a55e943daac072a53fe4f012518e5c638efd51f9385c326L699-R701)
* Improved code readability throughout `serverless-template.js` by formatting template literals and conditional logic for better clarity and maintainability. [[1]](diffhunk://#diff-ba3d278f90c660143a55e943daac072a53fe4f012518e5c638efd51f9385c326L71-R72) [[2]](diffhunk://#diff-ba3d278f90c660143a55e943daac072a53fe4f012518e5c638efd51f9385c326L893-R893) [[3]](diffhunk://#diff-ba3d278f90c660143a55e943daac072a53fe4f012518e5c638efd51f9385c326L1958-R1959) [[4]](diffhunk://#diff-ba3d278f90c660143a55e943daac072a53fe4f012518e5c638efd51f9385c326L2015-R2019)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.463.62579dd.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.463.62579dd.0
  npm install @friggframework/devtools@2.0.0--canary.463.62579dd.0
  npm install @friggframework/eslint-config@2.0.0--canary.463.62579dd.0
  npm install @friggframework/prettier-config@2.0.0--canary.463.62579dd.0
  npm install @friggframework/schemas@2.0.0--canary.463.62579dd.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.463.62579dd.0
  npm install @friggframework/test@2.0.0--canary.463.62579dd.0
  npm install @friggframework/ui@2.0.0--canary.463.62579dd.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.463.62579dd.0
  yarn add @friggframework/devtools@2.0.0--canary.463.62579dd.0
  yarn add @friggframework/eslint-config@2.0.0--canary.463.62579dd.0
  yarn add @friggframework/prettier-config@2.0.0--canary.463.62579dd.0
  yarn add @friggframework/schemas@2.0.0--canary.463.62579dd.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.463.62579dd.0
  yarn add @friggframework/test@2.0.0--canary.463.62579dd.0
  yarn add @friggframework/ui@2.0.0--canary.463.62579dd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
