### PR TITLE
Needed to update the order of operations for the webhook router to properly register, and cleaned up the path so that it matches properly

### DIFF
--- a/packages/core/handlers/routers/integration-webhook-routers.js
+++ b/packages/core/handlers/routers/integration-webhook-routers.js
@@ -20,7 +20,7 @@ for (const IntegrationClass of integrationClasses) {
     console.log(`\n│ Configuring webhook routes for ${IntegrationClass.Definition.name}:`);
 
     // General webhook route (no integration ID)
-    router.post('/', async (req, res, next) => {
+    router.post(basePath, async (req, res, next) => {
         try {
             const integrationInstance = new IntegrationClass();
             const dispatcher = new IntegrationEventDispatcher(integrationInstance);
@@ -37,7 +37,7 @@ for (const IntegrationClass of integrationClasses) {
     console.log(`│ POST ${basePath}`);
 
     // Integration-specific webhook route (with integration ID)
-    router.post('/:integrationId', async (req, res, next) => {
+    router.post(`${basePath}/:integrationId`, async (req, res, next) => {
         try {
             const integrationInstance = new IntegrationClass();
             const dispatcher = new IntegrationEventDispatcher(integrationInstance);

--- a/packages/devtools/infrastructure/serverless-template.js
+++ b/packages/devtools/infrastructure/serverless-template.js
@@ -1959,6 +1959,30 @@ const attachIntegrations = (definition, AppDefinition) => {
             }Queue`;
         const queueName = `\${self:service}--\${self:provider.stage}-${queueReference}`;
 
+        // Add webhook handler if enabled (BEFORE catch-all proxy route)
+        const webhookConfig = integration.Definition.webhooks;
+        if (webhookConfig && (webhookConfig === true || webhookConfig.enabled === true)) {
+            const webhookFunctionName = `${integrationName}Webhook`;
+
+            definition.functions[webhookFunctionName] = {
+                handler: `node_modules/@friggframework/core/handlers/routers/integration-webhook-routers.handlers.${integrationName}Webhook.handler`,
+                events: [
+                    {
+                        httpApi: {
+                            path: `/api/${integrationName}-integration/webhooks`,
+                            method: 'POST',
+                        },
+                    },
+                    {
+                        httpApi: {
+                            path: `/api/${integrationName}-integration/webhooks/{integrationId}`,
+                            method: 'POST',
+                        },
+                    },
+                ],
+            };
+        }
+
         definition.functions[integrationName] = {
             handler: `node_modules/@friggframework/core/handlers/routers/integration-defined-routers.handlers.${integrationName}.handler`,
             events: [
@@ -2009,30 +2033,6 @@ const attachIntegrations = (definition, AppDefinition) => {
         };
 
         definition.custom[queueReference] = queueName;
-
-        // Add webhook handler if enabled
-        const webhookConfig = integration.Definition.webhooks;
-        if (webhookConfig && (webhookConfig === true || webhookConfig.enabled === true)) {
-            const webhookFunctionName = `${integrationName}Webhook`;
-
-            definition.functions[webhookFunctionName] = {
-                handler: `node_modules/@friggframework/core/handlers/routers/integration-webhook-routers.handlers.${integrationName}Webhook.handler`,
-                events: [
-                    {
-                        httpApi: {
-                            path: `/api/${integrationName}-integration/webhooks`,
-                            method: 'POST',
-                        },
-                    },
-                    {
-                        httpApi: {
-                            path: `/api/${integrationName}-integration/webhooks/{integrationId}`,
-                            method: 'POST',
-                        },
-                    },
-                ],
-            };
-        }
     }
 };
 


### PR DESCRIPTION
### TL;DR

Fixed webhook routing issues and improved serverless function ordering for integration webhooks.

### What changed?

- Fixed webhook router paths in `integration-webhook-routers.js` by using the correct `basePath` variable instead of hardcoded paths
- Reordered webhook function registration in `serverless-template.js` to ensure webhook routes are registered before the catch-all proxy route

### How to test?

1. Deploy an application with integrations that use webhooks
2. Verify that webhook endpoints are accessible at the correct paths:
   - `/api/{integration-name}-integration/webhooks`
   - `/api/{integration-name}-integration/webhooks/{integrationId}`
3. Send test webhook payloads to these endpoints and confirm they're properly processed

### Why make this change?

The previous implementation had two issues:
1. Webhook routes were using incorrect paths, causing webhooks to be unreachable
2. The webhook functions were being registered after the catch-all proxy route in the serverless configuration, which could prevent them from being properly routed

This change ensures webhooks are properly routed and accessible for integrations that require them.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.464.f9d3fc0.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.464.f9d3fc0.0
  npm install @friggframework/devtools@2.0.0--canary.464.f9d3fc0.0
  npm install @friggframework/eslint-config@2.0.0--canary.464.f9d3fc0.0
  npm install @friggframework/prettier-config@2.0.0--canary.464.f9d3fc0.0
  npm install @friggframework/schemas@2.0.0--canary.464.f9d3fc0.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.464.f9d3fc0.0
  npm install @friggframework/test@2.0.0--canary.464.f9d3fc0.0
  npm install @friggframework/ui@2.0.0--canary.464.f9d3fc0.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.464.f9d3fc0.0
  yarn add @friggframework/devtools@2.0.0--canary.464.f9d3fc0.0
  yarn add @friggframework/eslint-config@2.0.0--canary.464.f9d3fc0.0
  yarn add @friggframework/prettier-config@2.0.0--canary.464.f9d3fc0.0
  yarn add @friggframework/schemas@2.0.0--canary.464.f9d3fc0.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.464.f9d3fc0.0
  yarn add @friggframework/test@2.0.0--canary.464.f9d3fc0.0
  yarn add @friggframework/ui@2.0.0--canary.464.f9d3fc0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
