### PR TITLE
fix(infrastructure): Prevent CloudFormation resource replacement on redeployment

### DIFF
--- a/packages/devtools/infrastructure/domains/networking/vpc-builder.js
+++ b/packages/devtools/infrastructure/domains/networking/vpc-builder.js
@@ -233,7 +233,14 @@ class VpcBuilder extends InfrastructureBuilder {
             existingEndpoints.kms || existingEndpoints.secretsManager || existingEndpoints.sqs;
 
         if (appDefinition.vpc.enableVPCEndpoints !== false) {
-            if (vpcManagement === 'create-new') {
+            // Check if resources came from CloudFormation stack
+            const fromCfStack = discoveredResources.fromCloudFormationStack === true;
+            const existingLogicalIds = discoveredResources.existingLogicalIds || [];
+
+            if (fromCfStack && existingLogicalIds.length > 0 && allEndpointsExist) {
+                console.log('  All VPC endpoints exist in CloudFormation stack - skipping creation');
+                // Skip VPC endpoint creation entirely
+            } else if (vpcManagement === 'create-new') {
                 // Always create in create-new mode
                 this.buildVpcEndpoints(appDefinition, discoveredResources, result, existingEndpoints);
             } else if (vpcManagement === 'discover') {
@@ -417,6 +424,27 @@ class VpcBuilder extends InfrastructureBuilder {
         }
 
         result.vpcId = discoveredResources.defaultVpcId;
+
+        // Check if resources came from CloudFormation stack
+        const fromCfStack = discoveredResources.fromCloudFormationStack === true;
+        const existingLogicalIds = discoveredResources.existingLogicalIds || [];
+
+        if (fromCfStack && existingLogicalIds.length > 0) {
+            console.log(`  ✓ VPC discovered from CloudFormation stack: ${discoveredResources.stackName}`);
+            console.log(`  ✓ Found ${existingLogicalIds.length} existing resources in stack`);
+            console.log('  ℹ Skipping resource creation - will reuse existing CloudFormation resources');
+
+            // Set security group IDs from discovered resources
+            if (discoveredResources.securityGroupId) {
+                result.vpcConfig.securityGroupIds = [discoveredResources.securityGroupId];
+            }
+
+            // Don't create any new resources - they already exist in the CF stack
+            return;
+        }
+
+        // VPC discovered from AWS API (not from CF stack) - create needed resources
+        console.log('  ℹ VPC discovered from AWS API - will create Lambda security group');
 
         // Create a Lambda security group in the discovered VPC
         // This is needed even in discover mode so other resources can reference it
@@ -694,6 +722,15 @@ class VpcBuilder extends InfrastructureBuilder {
         const natManagement = appDefinition.vpc.natGateway?.management || 'discover';
 
         console.log(`  NAT Gateway Management: ${natManagement}`);
+
+        // Check if resources came from CloudFormation stack
+        const fromCfStack = discoveredResources.fromCloudFormationStack === true;
+        const existingLogicalIds = discoveredResources.existingLogicalIds || [];
+
+        if (fromCfStack && existingLogicalIds.length > 0) {
+            console.log('    Skipping NAT Gateway - will reuse from CloudFormation stack');
+            return;
+        }
 
         // Check if we should create NAT Gateway
         const needsNatGateway = natManagement === 'createAndManage' ||

--- a/packages/devtools/infrastructure/domains/shared/cloudformation-discovery.js
+++ b/packages/devtools/infrastructure/domains/shared/cloudformation-discovery.js
@@ -22,7 +22,7 @@ class CloudFormationDiscovery {
 
     /**
      * Discover resources from an existing CloudFormation stack
-     * 
+     *
      * @param {string} stackName - Name of the CloudFormation stack
      * @returns {Promise<Object|null>} Discovered resources or null if stack doesn't exist
      */
@@ -35,7 +35,12 @@ class CloudFormationDiscovery {
             const resources = await this.provider.listStackResources(stackName);
 
             // Extract discovered resources from outputs and resources
-            const discovered = {};
+            const discovered = {
+                // Metadata to indicate resources came from CloudFormation stack
+                fromCloudFormationStack: true,
+                stackName: stackName,
+                existingLogicalIds: []
+            };
 
             // Extract from outputs
             if (stack.Outputs && stack.Outputs.length > 0) {
@@ -45,6 +50,11 @@ class CloudFormationDiscovery {
             // Extract from resources (now async to query AWS for details)
             // Always call this even if resources is empty, as it may query AWS for resources
             await this._extractFromResources(resources || [], discovered);
+
+            // Clean up metadata if no resources were discovered
+            if (discovered.existingLogicalIds.length === 0) {
+                delete discovered.existingLogicalIds;
+            }
 
             return discovered;
         } catch (error) {
@@ -103,15 +113,25 @@ class CloudFormationDiscovery {
 
     /**
      * Extract discovered resources from CloudFormation stack resources
-     * 
+     *
      * @private
      * @param {Array} resources - CloudFormation stack resources
      * @param {Object} discovered - Object to populate with discovered resources
      */
     async _extractFromResources(resources, discovered) {
         console.log(`  DEBUG: Processing ${resources.length} CloudFormation resources...`);
+
+        // Initialize existingLogicalIds array if not present
+        if (!discovered.existingLogicalIds) {
+            discovered.existingLogicalIds = [];
+        }
         for (const resource of resources) {
             const { LogicalResourceId, PhysicalResourceId, ResourceType } = resource;
+
+            // Track Frigg-managed resources by logical ID
+            if (LogicalResourceId.startsWith('Frigg') || LogicalResourceId.includes('Migration')) {
+                discovered.existingLogicalIds.push(LogicalResourceId);
+            }
 
             // Debug Aurora detection
             if (LogicalResourceId.includes('Aurora')) {


### PR DESCRIPTION
## Problem
When redeploying with an existing CloudFormation stack, infrastructure builders were creating NEW resources with the same logical IDs (FriggVPC, FriggInternetGateway, FriggVPCGatewayAttachment, etc.), causing CloudFormation to:
1. See the logical IDs as new resources
2. Attempt to replace existing resources
3. Delete old resources (sometimes failing due to dependencies)
4. Result in deployment failures and resource churn

## Root Cause
Discovery found physical resource IDs but didn't indicate WHERE they came from:
- CloudFormation stack (should reuse existing logical IDs)
- AWS API (can create new resources)

Builders always generated NEW CloudFormation resources regardless of source, causing CloudFormation to see duplicate logical IDs and trigger replacement.

## Solution

### 1. CloudFormation Discovery Metadata
Added metadata to discovery results indicating source:

```javascript
{
    fromCloudFormationStack: true,
    stackName: 'quo-integrations-dev',
    existingLogicalIds: ['FriggVPC', 'FriggInternetGateway', ...]
}
```

### 2. VPC Builder Updates
- `discoverVpc()`: Checks if resources from CF stack, skips creating new resources
- `buildNatGateway()`: Skips NAT Gateway creation for CF stack resources
- VPC Endpoints: Skips creation when all endpoints exist in CF stack

### 3. Behavior Changes

**Before:**
- Discovery finds VPC vpc-037ec55fe87aec1e7
- Builder creates NEW FriggVPC, FriggInternetGateway, etc.
- CloudFormation replaces resources ❌

**After:**
- Discovery finds VPC from CF stack quo-integrations-dev
- Builder sees fromCloudFormationStack=true
- Builder skips resource creation, reuses existing ✅

## Impact
- Prevents resource replacement on existing stack deployments
- Eliminates resource deletion failures
- Reduces deployment time (no unnecessary creates/deletes)
- Maintains proper resource lifecycle management

## Testing
Test with existing stack deployment:
1. Stack quo-integrations-dev exists with VPC/subnets/gateways
2. Run deployment
3. Should log: "Skipping resource creation - will reuse existing CloudFormation resources"
4. No resources should be replaced or deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)