### PR TITLE
fix(cli): propagate stage parameter to resource discovery via SLS_STAGE

### DIFF
--- a/packages/devtools/frigg-cli/__tests__/unit/commands/build.test.js
+++ b/packages/devtools/frigg-cli/__tests__/unit/commands/build.test.js
@@ -157,6 +157,34 @@ describe('CLI Command: build', () => {
       delete process.env.TEST_VAR;
     });
 
+    it('should set SLS_STAGE environment variable to match stage option', async () => {
+      await buildCommand({ stage: 'qa' });
+
+      const call = spawnSync.mock.calls[0];
+      const options = call[2];
+
+      // Verify SLS_STAGE is set for discovery to use
+      expect(options.env.SLS_STAGE).toBe('qa');
+    });
+
+    it('should set SLS_STAGE for production stage', async () => {
+      await buildCommand({ stage: 'production' });
+
+      const call = spawnSync.mock.calls[0];
+      const options = call[2];
+
+      expect(options.env.SLS_STAGE).toBe('production');
+    });
+
+    it('should set SLS_STAGE for dev stage', async () => {
+      await buildCommand({ stage: 'dev' });
+
+      const call = spawnSync.mock.calls[0];
+      const options = call[2];
+
+      expect(options.env.SLS_STAGE).toBe('dev');
+    });
+
     it('should use infrastructure.js as config file', async () => {
       await buildCommand({ stage: 'dev' });
 

--- a/packages/devtools/frigg-cli/build-command/index.js
+++ b/packages/devtools/frigg-cli/build-command/index.js
@@ -43,6 +43,7 @@ async function buildCommand(options) {
         env: {
             ...process.env,
             NODE_PATH: path.resolve(backendPath, 'node_modules'),
+            SLS_STAGE: options.stage, // Set stage for resource discovery
         }
     });
 

--- a/packages/devtools/infrastructure/domains/shared/resource-discovery.test.js
+++ b/packages/devtools/infrastructure/domains/shared/resource-discovery.test.js
@@ -392,6 +392,29 @@ describe('Resource Discovery', () => {
             );
         });
 
+        it('should read stage from SLS_STAGE environment variable for CLI integration', async () => {
+            // This test documents the contract between frigg CLI and discovery
+            // The CLI sets SLS_STAGE environment variable when user passes --stage flag
+            process.env.SLS_STAGE = 'qa';
+
+            const appDefinition = {
+                name: 'quo-integrations',
+                vpc: { enable: true },
+            };
+
+            await gatherDiscoveredResources(appDefinition);
+
+            // Verify stage is read from SLS_STAGE
+            expect(mockVpcDiscovery.discover).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    serviceName: 'quo-integrations',
+                    stage: 'qa',
+                })
+            );
+
+            delete process.env.SLS_STAGE;
+        });
+
         it('should include secrets in SSM discovery by default', async () => {
             const appDefinition = {
                 ssm: { enable: true },


### PR DESCRIPTION
## Problem
When running `frigg build --stage=qa`, the discovery flow was not using the correct stage. It was defaulting to 'dev' and looking for CloudFormation stack 'quo-integrations-dev' instead of 'quo-integrations-qa'.

## Root Cause
The build command passed --stage to serverless but did not set the SLS_STAGE environment variable that the discovery service reads to determine the stage.

## Solution (TDD/DDD Approach)
Following Test-Driven Development:
1. Added failing tests to document expected behavior
2. Implemented fix in build command to set SLS_STAGE environment variable
3. Added integration test to document CLI-to-discovery contract

Changes:
- build-command/index.js: Set SLS_STAGE in spawned process environment
- build.test.js: Added tests verifying SLS_STAGE is set for qa, production, and dev
- resource-discovery.test.js: Added test documenting SLS_STAGE contract

## DDD/Hexagonal Architecture Alignment
- Maintains separation between CLI (application layer) and discovery (domain layer)
- Uses environment variable as the port between layers
- Discovery service remains cloud-agnostic and testable

🤖 Generated with [Claude Code](https://claude.com/claude-code)