### PR TITLE
fix(serverless-plugin): fix offline queue environment mapping and apply DDD architecture

### DIFF
--- a/packages/serverless-plugin/index.js
+++ b/packages/serverless-plugin/index.js
@@ -1,227 +1,121 @@
-const { spawn } = require("child_process");
+const { QueueEnvironmentMapper } = require('./lib/queue-environment-mapper');
+const { LocalStackQueueService } = require('./lib/localstack-queue-service');
+const { EsbuildDirectoryManager } = require('./lib/esbuild-directory-manager');
 
-/**
- * Frigg Serverless Plugin - Handles AWS discovery and local development setup
- */
 class FriggServerlessPlugin {
-  /**
-   * Creates an instance of FriggServerlessPlugin
-   * @param {Object} serverless - Serverless framework instance
-   * @param {Object} options - Plugin options
-   */
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    this.provider = serverless.getProvider("aws");
+    this.provider = serverless.getProvider('aws');
 
-    // Create .esbuild/.serverless directory IMMEDIATELY, synchronously,
-    // before any hooks run. This ensures serverless-esbuild has the
-    // directory it needs regardless of hook execution order.
     const fs = require('fs');
     const path = require('path');
-    const esbuildDir = path.join(
-      serverless.config.servicePath || process.cwd(),
-      '.esbuild',
-      '.serverless'
-    );
+    const basePath = serverless.config.servicePath || process.cwd();
 
+    const dirManager = new EsbuildDirectoryManager(fs, path);
     try {
-      fs.mkdirSync(esbuildDir, { recursive: true });
+      const esbuildDir = dirManager.ensureDirectory(basePath);
       console.log(`✓ Frigg plugin created ${esbuildDir}`);
     } catch (error) {
-      console.error(`⚠️  Failed to create ${esbuildDir}:`, error.message);
+      console.error(`⚠️  Failed to create esbuild directory:`, error.message);
     }
 
     this.hooks = {
       initialize: () => this.init(),
-      "before:package:initialize": () => this.beforePackageInitialize(),
-      "after:package:package": () => this.afterPackage(),
-      "before:deploy:deploy": () => this.beforeDeploy(),
+      'before:package:initialize': () => this.beforePackageInitialize(),
+      'after:package:package': () => this.afterPackage(),
+      'before:deploy:deploy': () => this.beforeDeploy(),
     };
   }
-  /**
-   * Asynchronous initialization for offline mode
-   * Creates SQS queues in localstack for local development
-   * @returns {Promise<void>}
-   */
+
   async asyncInit() {
-    this.serverless.cli.log("Initializing Frigg Serverless Plugin...");
-    console.log("Hello from Frigg Serverless Plugin!");
-    
-    // CRITICAL: Create .esbuild/.serverless directory before serverless-esbuild needs it
-    // This prevents ENOENT errors during packaging
+    this.serverless.cli.log('Initializing Frigg Serverless Plugin...');
+    console.log('Hello from Frigg Serverless Plugin!');
+
     const fs = require('fs');
     const path = require('path');
-    const esbuildDir = path.join(this.serverless.config.servicePath || process.cwd(), '.esbuild', '.serverless');
+    const basePath = this.serverless.config.servicePath || process.cwd();
 
-    if (!fs.existsSync(esbuildDir)) {
-      fs.mkdirSync(esbuildDir, { recursive: true });
-      console.log(`✓ Created ${esbuildDir} directory for serverless-esbuild`);
-    }
-    
-    if (this.serverless.processedInput.commands.includes("offline")) {
-      console.log("Running in offline mode. Making queues!");
-      const queues = Object.keys(this.serverless.service.custom)
-        .filter((key) => key.endsWith("Queue"))
-        .map((key) => {
-          return {
-            key,
-            name: this.serverless.service.custom[key],
-          };
-        });
-      console.log("Queues to be created:", queues);
+    const dirManager = new EsbuildDirectoryManager(fs, path);
+    const esbuildDir = dirManager.ensureDirectory(basePath);
 
-      const AWS = require("aws-sdk");
-
-      const endpointUrl = process.env.AWS_ENDPOINT || "http://localhost:4566"; // LocalStack SQS endpoint
-      const region = process.env.AWS_REGION || "us-east-1";
-      const accessKeyId = process.env.AWS_ACCESS_KEY_ID || "root"; // LocalStack default
-      const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY || "root"; // LocalStack default
-
-      // Configure AWS SDK for LocalStack
-      AWS.config.update({
-        region: region,
-        endpoint: endpointUrl,
-        accessKeyId: accessKeyId,
-        secretAccessKey: secretAccessKey,
-        s3ForcePathStyle: true, // Required for LocalStack
-        sslEnabled: false, // Disable SSL for LocalStack
-      });
-
-      const sqs = new AWS.SQS({
-        sslEnabled: false, // Disable SSL validation for LocalStack
-      });
-      // Find the environment variables that we need to override and create an easy map
-      const environmentMap = {};
-      const environment = this.serverless.service.provider.environment;
-
-      for (const [key, value] of Object.entries(environment)) {
-        if (typeof value === "object" && value.Ref) {
-          environmentMap[value.Ref] = key;
-        }
-      }
-
-      const queueCreationPromises = queues.map((queue) => {
-        return new Promise((resolve, reject) => {
-          const params = {
-            QueueName: queue.name,
-          };
-
-          sqs.createQueue(params, (err, data) => {
-            if (err) {
-              console.error(
-                `Error creating queue ${queue.name}: ${err.message}`
-              );
-              reject(err);
-            } else {
-              const queueUrl = data.QueueUrl;
-              console.log(
-                `Queue ${queue.name} created successfully. URL: ${queueUrl}`
-              );
-
-              const environmentKey = environmentMap[queue.key];
-              this.serverless.extendConfiguration(
-                ["provider", "environment", environmentKey],
-                queueUrl
-              );
-              console.log(`Set ${environmentKey} to ${queueUrl}`);
-              resolve(queueUrl);
-            }
-          });
-        });
-      });
-
-      await Promise.all(queueCreationPromises);
+    if (this.serverless.processedInput.commands.includes('offline')) {
+      console.log('Running in offline mode. Making queues!');
+      await this.setupOfflineQueues();
     } else {
-      console.log("Running in online mode, doing nothing");
+      console.log('Running in online mode, doing nothing');
     }
   }
 
-  /**
-   * Hook that runs before serverless package initialization
-   * AWS discovery is now handled in serverless-template.js
-   * @returns {Promise<void>}
-   */
+  async setupOfflineQueues() {
+    const queues = this.extractQueueDefinitions();
+    console.log('Queues to be created:', queues);
+
+    const sqsClient = this.createLocalStackSQSClient();
+    const queueService = new LocalStackQueueService(sqsClient);
+    const mapper = new QueueEnvironmentMapper();
+
+    const environmentMap = mapper.createMapping(queues);
+    const createdQueues = await queueService.createQueues(queues);
+
+    createdQueues.forEach(({ key, url }) => {
+      const envKey = mapper.getEnvironmentKey(key, environmentMap);
+      this.serverless.extendConfiguration(['provider', 'environment', envKey], url);
+      console.log(`Set ${envKey} to ${url}`);
+    });
+  }
+
+  extractQueueDefinitions() {
+    return Object.keys(this.serverless.service.custom)
+      .filter((key) => key.endsWith('Queue'))
+      .map((key) => ({
+        key,
+        name: this.serverless.service.custom[key],
+      }));
+  }
+
+  createLocalStackSQSClient() {
+    const AWS = require('aws-sdk');
+
+    AWS.config.update({
+      region: process.env.AWS_REGION || 'us-east-1',
+      endpoint: process.env.AWS_ENDPOINT || 'http://localhost:4566',
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'root',
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'root',
+      s3ForcePathStyle: true,
+      sslEnabled: false,
+    });
+
+    return new AWS.SQS({ sslEnabled: false });
+  }
+
   async beforePackageInitialize() {
-    // AWS discovery is now handled directly in serverless-template.js
-    // This hook remains for potential future use or other pre-package tasks
-    this.serverless.cli.log("Frigg Serverless Plugin: Pre-package hook");
+    this.serverless.cli.log('Frigg Serverless Plugin: Pre-package hook');
 
-    // Ensure .esbuild/.serverless directory exists to prevent ENOENT errors
-    // serverless-esbuild may try to access this directory during packaging
     const fs = require('fs');
     const path = require('path');
-    const esbuildDir = path.join(this.serverless.config.servicePath || process.cwd(), '.esbuild', '.serverless');
+    const basePath = this.serverless.config.servicePath || process.cwd();
 
-    if (!fs.existsSync(esbuildDir)) {
-      fs.mkdirSync(esbuildDir, { recursive: true });
-    }
+    const dirManager = new EsbuildDirectoryManager(fs, path);
+    dirManager.ensureDirectory(basePath);
   }
 
-
-  /**
-   * Initialization hook - runs very early, before packaging
-   * Create .esbuild/.serverless directory to prevent ENOENT errors
-   */
   init() {
-    // Ensure .esbuild/.serverless directory exists to prevent ENOENT errors
-    // serverless-esbuild may try to access this directory during packaging
     const fs = require('fs');
     const path = require('path');
-    const esbuildDir = path.join(this.serverless.config.servicePath || process.cwd(), '.esbuild', '.serverless');
+    const basePath = this.serverless.config.servicePath || process.cwd();
 
-    if (!fs.existsSync(esbuildDir)) {
-      fs.mkdirSync(esbuildDir, { recursive: true });
-      console.log(`Created ${esbuildDir} directory for serverless-esbuild`);
-    }
+    const dirManager = new EsbuildDirectoryManager(fs, path);
+    const esbuildDir = dirManager.ensureDirectory(basePath);
+    console.log(`Created ${esbuildDir} directory for serverless-esbuild`);
   }
-  /**
-   * Hook that runs after serverless package
-   */
+
   afterPackage() {
-    console.log("After package hook called");
-    // // const queues = Object.keys(infrastructure.custom)
-    // //     .filter((key) => key.endsWith('Queue'))
-    // //     .map((key) => infrastructure.custom[key]);
-    // // console.log('Queues to be created:', queues);
-    // //
-    // // const endpointUrl = 'http://localhost:4566'; // Assuming localstack is running on port 4
-    // // const region = 'us-east-1';
-    // // const command = 'aws';
-    // // queues.forEach((queue) => {
-    // //     const args = [
-    // //         '--endpoint-url',
-    // //         endpointUrl,
-    // //         'sqs',
-    // //         'create-queue',
-    // //         '--queue-name',
-    // //         queue,
-    // //         '--region',
-    // //         region,
-    // //         '--output',
-    // //         'table',
-    // //     ];
-    // //
-    // //     const childProcess = spawn(command, args, {
-    // //         cwd: backendPath,
-    // //         stdio: 'inherit',
-    // //     });
-    // //     childProcess.on('error', (error) => {
-    // //         console.error(`Error executing command: ${error.message}`);
-    // //     });
-    // //
-    // //     childProcess.on('close', (code) => {
-    // //         if (code !== 0) {
-    // //             console.log(`Child process exited with code ${code}`);
-    // //         }
-    // //     });
-    // });
+    console.log('After package hook called');
   }
-  /**
-   * Hook that runs before serverless deploy
-   */
+
   beforeDeploy() {
-    console.log("Before deploy hook called");
+    console.log('Before deploy hook called');
   }
 }
 

--- a/packages/serverless-plugin/index.test.js
+++ b/packages/serverless-plugin/index.test.js
@@ -1,307 +1,227 @@
 const FriggServerlessPlugin = require('./index');
-const fs = require('fs');
-const path = require('path');
 
-// Mock fs module
-jest.mock('fs');
+jest.mock('./lib/queue-environment-mapper');
+jest.mock('./lib/localstack-queue-service');
+jest.mock('./lib/esbuild-directory-manager');
+
+const { QueueEnvironmentMapper } = require('./lib/queue-environment-mapper');
+const { LocalStackQueueService } = require('./lib/localstack-queue-service');
+const { EsbuildDirectoryManager } = require('./lib/esbuild-directory-manager');
 
 describe('FriggServerlessPlugin', () => {
-    let plugin;
-    let mockServerless;
-    let mockOptions;
-    let mockServicePath;
+  let plugin;
+  let mockServerless;
+  let mockOptions;
 
-    beforeEach(() => {
-        mockServicePath = '/test/service/path';
+  beforeEach(() => {
+    mockServerless = {
+      config: { servicePath: '/test/path' },
+      cli: { log: jest.fn() },
+      service: {
+        custom: {},
+        provider: { environment: {} },
+      },
+      processedInput: { commands: [] },
+      getProvider: jest.fn().mockReturnValue({}),
+      extendConfiguration: jest.fn(),
+    };
 
-        mockServerless = {
-            config: {
-                servicePath: mockServicePath,
-            },
-            cli: {
-                log: jest.fn(),
-            },
-            service: {
-                custom: {},
-                provider: {
-                    environment: {},
-                },
-            },
-            processedInput: {
-                commands: [],
-            },
-            getProvider: jest.fn().mockReturnValue({}),
-            extendConfiguration: jest.fn(),
-        };
+    mockOptions = { stage: 'test' };
 
-        mockOptions = {
-            stage: 'test',
-        };
+    EsbuildDirectoryManager.mockImplementation(() => ({
+      ensureDirectory: jest.fn().mockReturnValue('/test/path/.esbuild/.serverless'),
+    }));
 
-        // Clear all mocks before each test
-        jest.clearAllMocks();
+    jest.clearAllMocks();
+  });
+
+  describe('Constructor', () => {
+    it('should initialize with serverless instance and options', () => {
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+
+      expect(plugin.serverless).toBe(mockServerless);
+      expect(plugin.options).toBe(mockOptions);
+      expect(plugin.hooks).toBeDefined();
     });
 
-    describe('Constructor', () => {
-        it('should initialize with serverless instance and options', () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+    it('should register required hooks', () => {
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
 
-            expect(plugin.serverless).toBe(mockServerless);
-            expect(plugin.options).toBe(mockOptions);
-            expect(plugin.hooks).toBeDefined();
-        });
-
-        it('should register required hooks', () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
-
-            expect(plugin.hooks).toHaveProperty('initialize');
-            expect(plugin.hooks).toHaveProperty('before:package:initialize');
-            expect(plugin.hooks).toHaveProperty('after:package:package');
-            expect(plugin.hooks).toHaveProperty('before:deploy:deploy');
-        });
+      expect(plugin.hooks).toHaveProperty('initialize');
+      expect(plugin.hooks).toHaveProperty('before:package:initialize');
+      expect(plugin.hooks).toHaveProperty('after:package:package');
+      expect(plugin.hooks).toHaveProperty('before:deploy:deploy');
     });
 
-    describe('asyncInit - Directory Creation', () => {
-        it('should create .esbuild/.serverless directory if it does not exist', async () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+    it('should create esbuild directory on construction', () => {
+      const mockEnsureDir = jest.fn().mockReturnValue('/test/.esbuild/.serverless');
+      EsbuildDirectoryManager.mockImplementation(() => ({
+        ensureDirectory: mockEnsureDir,
+      }));
 
-            // Mock fs.existsSync to return false (directory doesn't exist)
-            fs.existsSync.mockReturnValue(false);
-            fs.mkdirSync.mockImplementation(() => { });
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
 
-            // Spy on console.log
-            const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+      expect(mockEnsureDir).toHaveBeenCalledWith('/test/path');
+    });
+  });
 
-            await plugin.asyncInit();
+  describe('asyncInit', () => {
+    it('should log initialization messages', async () => {
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
 
-            const expectedPath = path.join(mockServicePath, '.esbuild', '.serverless');
+      await plugin.asyncInit();
 
-            // Verify directory existence check
-            expect(fs.existsSync).toHaveBeenCalledWith(expectedPath);
+      expect(mockServerless.cli.log).toHaveBeenCalledWith('Initializing Frigg Serverless Plugin...');
+      expect(consoleLogSpy).toHaveBeenCalledWith('Hello from Frigg Serverless Plugin!');
 
-            // Verify directory creation
-            expect(fs.mkdirSync).toHaveBeenCalledWith(expectedPath, { recursive: true });
-
-            // Verify success message
-            expect(consoleLogSpy).toHaveBeenCalledWith(
-                expect.stringContaining('Created')
-            );
-            expect(consoleLogSpy).toHaveBeenCalledWith(
-                expect.stringContaining('.esbuild')
-            );
-
-            consoleLogSpy.mockRestore();
-        });
-
-        it('should not create directory if it already exists', async () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
-
-            // Mock fs.existsSync to return true (directory exists)
-            fs.existsSync.mockReturnValue(true);
-            fs.mkdirSync.mockImplementation(() => { });
-
-            const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-
-            await plugin.asyncInit();
-
-            const expectedPath = path.join(mockServicePath, '.esbuild', '.serverless');
-
-            // Verify directory existence check
-            expect(fs.existsSync).toHaveBeenCalledWith(expectedPath);
-
-            // Verify directory creation was NOT called
-            expect(fs.mkdirSync).not.toHaveBeenCalled();
-
-            // Verify success message was NOT logged
-            expect(consoleLogSpy).not.toHaveBeenCalledWith(
-                expect.stringContaining('Created')
-            );
-
-            consoleLogSpy.mockRestore();
-        });
-
-        it('should use process.cwd() if servicePath is not available', async () => {
-            // Remove servicePath from config
-            mockServerless.config.servicePath = undefined;
-
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
-
-            fs.existsSync.mockReturnValue(false);
-            fs.mkdirSync.mockImplementation(() => { });
-
-            await plugin.asyncInit();
-
-            const expectedPath = path.join(process.cwd(), '.esbuild', '.serverless');
-
-            expect(fs.existsSync).toHaveBeenCalledWith(expectedPath);
-            expect(fs.mkdirSync).toHaveBeenCalledWith(expectedPath, { recursive: true });
-        });
-
-        it('should log initialization messages', async () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
-
-            fs.existsSync.mockReturnValue(true);
-
-            const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-
-            await plugin.asyncInit();
-
-            // Verify plugin initialization messages
-            expect(mockServerless.cli.log).toHaveBeenCalledWith('Initializing Frigg Serverless Plugin...');
-            expect(consoleLogSpy).toHaveBeenCalledWith('Hello from Frigg Serverless Plugin!');
-
-            consoleLogSpy.mockRestore();
-        });
+      consoleLogSpy.mockRestore();
     });
 
-    describe('asyncInit - Offline Mode', () => {
-        it('should not create SQS queues when not in offline mode', async () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+    it('should run in online mode when not offline', async () => {
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+      mockServerless.processedInput.commands = ['deploy'];
 
-            fs.existsSync.mockReturnValue(true);
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
 
-            // Not in offline mode
-            mockServerless.processedInput.commands = ['deploy'];
+      await plugin.asyncInit();
 
-            const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-
-            await plugin.asyncInit();
-
-            expect(consoleLogSpy).toHaveBeenCalledWith('Running in online mode, doing nothing');
-            expect(consoleLogSpy).not.toHaveBeenCalledWith(
-                expect.stringContaining('offline mode')
-            );
-
-            consoleLogSpy.mockRestore();
-        });
-
-        it('should create SQS queues when in offline mode', async () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
-
-            fs.existsSync.mockReturnValue(true);
-
-            // Set offline mode
-            mockServerless.processedInput.commands = ['offline'];
-            mockServerless.service.custom = {
-                testQueue: 'test-queue-name',
-            };
-
-            // Mock AWS SDK
-            const mockCreateQueue = jest.fn((params, callback) => {
-                callback(null, { QueueUrl: 'http://localhost:4566/queue/test-queue-name' });
-            });
-
-            jest.mock('aws-sdk', () => ({
-                SQS: jest.fn(() => ({
-                    createQueue: mockCreateQueue,
-                })),
-                config: {
-                    update: jest.fn(),
-                },
-            }));
-
-            const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-
-            await plugin.asyncInit();
-
-            expect(consoleLogSpy).toHaveBeenCalledWith(
-                expect.stringContaining('offline mode')
-            );
-
-            consoleLogSpy.mockRestore();
-        });
+      expect(consoleLogSpy).toHaveBeenCalledWith('Running in online mode, doing nothing');
+      consoleLogSpy.mockRestore();
     });
 
-    describe('beforePackageInitialize', () => {
-        it('should create .esbuild/.serverless directory', () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+    it('should setup offline queues when in offline mode', async () => {
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+      mockServerless.processedInput.commands = ['offline'];
+      mockServerless.service.custom = { AsanaQueue: 'test-queue' };
 
-            fs.existsSync.mockReturnValue(false);
-            fs.mkdirSync.mockImplementation(() => { });
+      const mockMapper = {
+        createMapping: jest.fn().mockReturnValue({ AsanaQueue: 'ASANA_QUEUE_URL' }),
+        getEnvironmentKey: jest.fn().mockReturnValue('ASANA_QUEUE_URL'),
+      };
+      QueueEnvironmentMapper.mockImplementation(() => mockMapper);
 
-            plugin.beforePackageInitialize();
+      const mockQueueService = {
+        createQueues: jest.fn().mockResolvedValue([
+          { key: 'AsanaQueue', url: 'http://localhost:4566/queue' },
+        ]),
+      };
+      LocalStackQueueService.mockImplementation(() => mockQueueService);
 
-            const expectedPath = path.join(mockServicePath, '.esbuild', '.serverless');
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
 
-            expect(fs.existsSync).toHaveBeenCalledWith(expectedPath);
-            expect(fs.mkdirSync).toHaveBeenCalledWith(expectedPath, { recursive: true });
-        });
+      await plugin.asyncInit();
 
-        it('should log pre-package hook message', () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+      expect(consoleLogSpy).toHaveBeenCalledWith('Running in offline mode. Making queues!');
+      expect(mockQueueService.createQueues).toHaveBeenCalled();
+      expect(mockServerless.extendConfiguration).toHaveBeenCalledWith(
+        ['provider', 'environment', 'ASANA_QUEUE_URL'],
+        'http://localhost:4566/queue'
+      );
 
-            fs.existsSync.mockReturnValue(true);
+      consoleLogSpy.mockRestore();
+    });
+  });
 
-            plugin.beforePackageInitialize();
+  describe('setupOfflineQueues', () => {
+    it('should orchestrate queue creation and environment configuration', async () => {
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+      mockServerless.service.custom = {
+        AsanaQueue: 'test-asana-queue',
+        SlackQueue: 'test-slack-queue',
+      };
 
-            expect(mockServerless.cli.log).toHaveBeenCalledWith('Frigg Serverless Plugin: Pre-package hook');
-        });
+      const mockMapper = {
+        createMapping: jest.fn().mockReturnValue({
+          AsanaQueue: 'ASANA_QUEUE_URL',
+          SlackQueue: 'SLACK_QUEUE_URL',
+        }),
+        getEnvironmentKey: jest.fn()
+          .mockReturnValueOnce('ASANA_QUEUE_URL')
+          .mockReturnValueOnce('SLACK_QUEUE_URL'),
+      };
+      QueueEnvironmentMapper.mockImplementation(() => mockMapper);
+
+      const mockQueueService = {
+        createQueues: jest.fn().mockResolvedValue([
+          { key: 'AsanaQueue', url: 'http://localhost:4566/asana' },
+          { key: 'SlackQueue', url: 'http://localhost:4566/slack' },
+        ]),
+      };
+      LocalStackQueueService.mockImplementation(() => mockQueueService);
+
+      await plugin.setupOfflineQueues();
+
+      expect(mockMapper.createMapping).toHaveBeenCalled();
+      expect(mockQueueService.createQueues).toHaveBeenCalled();
+      expect(mockServerless.extendConfiguration).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('extractQueueDefinitions', () => {
+    it('should extract queue definitions from custom config', () => {
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+      mockServerless.service.custom = {
+        AsanaQueue: 'test-asana-queue',
+        someOtherConfig: 'something-else',
+        SlackQueue: 'test-slack-queue',
+      };
+
+      const queues = plugin.extractQueueDefinitions();
+
+      expect(queues).toEqual([
+        { key: 'AsanaQueue', name: 'test-asana-queue' },
+        { key: 'SlackQueue', name: 'test-slack-queue' },
+      ]);
     });
 
-    describe('init', () => {
-        it('should create .esbuild/.serverless directory', () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+    it('should return empty array when no queues defined', () => {
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+      mockServerless.service.custom = { someConfig: 'value' };
 
-            fs.existsSync.mockReturnValue(false);
-            fs.mkdirSync.mockImplementation(() => { });
+      const queues = plugin.extractQueueDefinitions();
 
-            const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+      expect(queues).toEqual([]);
+    });
+  });
 
-            plugin.init();
+  describe('Hooks', () => {
+    it('should execute init hook', () => {
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
 
-            const expectedPath = path.join(mockServicePath, '.esbuild', '.serverless');
+      plugin.init();
 
-            expect(fs.existsSync).toHaveBeenCalledWith(expectedPath);
-            expect(fs.mkdirSync).toHaveBeenCalledWith(expectedPath, { recursive: true });
-            expect(consoleLogSpy).toHaveBeenCalledWith(
-                expect.stringContaining('Created')
-            );
-
-            consoleLogSpy.mockRestore();
-        });
+      expect(consoleLogSpy).toHaveBeenCalled();
+      consoleLogSpy.mockRestore();
     });
 
-    describe('afterPackage', () => {
-        it('should log after package hook message', () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+    it('should execute beforePackageInitialize hook', async () => {
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
 
-            const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+      await plugin.beforePackageInitialize();
 
-            plugin.afterPackage();
-
-            expect(consoleLogSpy).toHaveBeenCalledWith('After package hook called');
-
-            consoleLogSpy.mockRestore();
-        });
+      expect(mockServerless.cli.log).toHaveBeenCalledWith('Frigg Serverless Plugin: Pre-package hook');
     });
 
-    describe('beforeDeploy', () => {
-        it('should log before deploy hook message', () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+    it('should execute afterPackage hook', () => {
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
 
-            const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+      plugin.afterPackage();
 
-            plugin.beforeDeploy();
-
-            expect(consoleLogSpy).toHaveBeenCalledWith('Before deploy hook called');
-
-            consoleLogSpy.mockRestore();
-        });
+      expect(consoleLogSpy).toHaveBeenCalledWith('After package hook called');
+      consoleLogSpy.mockRestore();
     });
 
-    describe('Error Handling', () => {
-        it('should handle fs.mkdirSync errors gracefully', async () => {
-            plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+    it('should execute beforeDeploy hook', () => {
+      plugin = new FriggServerlessPlugin(mockServerless, mockOptions);
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
 
-            fs.existsSync.mockReturnValue(false);
-            fs.mkdirSync.mockImplementation(() => {
-                throw new Error('Permission denied');
-            });
+      plugin.beforeDeploy();
 
-            // Should not throw - error should be caught or allowed to propagate
-            await expect(plugin.asyncInit()).rejects.toThrow('Permission denied');
-        });
+      expect(consoleLogSpy).toHaveBeenCalledWith('Before deploy hook called');
+      consoleLogSpy.mockRestore();
     });
+  });
 });
-
-

--- a/packages/serverless-plugin/lib/esbuild-directory-manager.js
+++ b/packages/serverless-plugin/lib/esbuild-directory-manager.js
@@ -1,0 +1,27 @@
+/**
+ * Infrastructure Service - ESBuild Directory Management
+ *
+ * Ensures .esbuild/.serverless directory exists to prevent ENOENT errors.
+ */
+class EsbuildDirectoryManager {
+  constructor(fs, path) {
+    this.fs = fs;
+    this.path = path;
+  }
+
+  /**
+   * @param {string} basePath - Base service path
+   * @returns {string} Created directory path
+   */
+  ensureDirectory(basePath) {
+    const esbuildDir = this.path.join(basePath, '.esbuild', '.serverless');
+
+    if (!this.fs.existsSync(esbuildDir)) {
+      this.fs.mkdirSync(esbuildDir, { recursive: true });
+    }
+
+    return esbuildDir;
+  }
+}
+
+module.exports = { EsbuildDirectoryManager };

--- a/packages/serverless-plugin/lib/esbuild-directory-manager.test.js
+++ b/packages/serverless-plugin/lib/esbuild-directory-manager.test.js
@@ -1,0 +1,65 @@
+const { EsbuildDirectoryManager } = require('./esbuild-directory-manager');
+
+describe('EsbuildDirectoryManager', () => {
+  let manager;
+  let mockFs;
+  let mockPath;
+
+  beforeEach(() => {
+    mockFs = {
+      existsSync: jest.fn(),
+      mkdirSync: jest.fn(),
+    };
+    mockPath = {
+      join: jest.fn((...args) => args.join('/')),
+    };
+    manager = new EsbuildDirectoryManager(mockFs, mockPath);
+  });
+
+  describe('ensureDirectory', () => {
+    it('should create directory if it does not exist', () => {
+      mockFs.existsSync.mockReturnValue(false);
+
+      const result = manager.ensureDirectory('/test/path');
+
+      expect(mockPath.join).toHaveBeenCalledWith('/test/path', '.esbuild', '.serverless');
+      expect(mockFs.existsSync).toHaveBeenCalledWith('/test/path/.esbuild/.serverless');
+      expect(mockFs.mkdirSync).toHaveBeenCalledWith('/test/path/.esbuild/.serverless', {
+        recursive: true,
+      });
+      expect(result).toBe('/test/path/.esbuild/.serverless');
+    });
+
+    it('should not create directory if it already exists', () => {
+      mockFs.existsSync.mockReturnValue(true);
+
+      const result = manager.ensureDirectory('/test/path');
+
+      expect(mockFs.existsSync).toHaveBeenCalledWith('/test/path/.esbuild/.serverless');
+      expect(mockFs.mkdirSync).not.toHaveBeenCalled();
+      expect(result).toBe('/test/path/.esbuild/.serverless');
+    });
+
+    it('should handle different base paths', () => {
+      mockFs.existsSync.mockReturnValue(false);
+
+      manager.ensureDirectory('/different/base');
+
+      expect(mockPath.join).toHaveBeenCalledWith('/different/base', '.esbuild', '.serverless');
+      expect(mockFs.mkdirSync).toHaveBeenCalledWith('/different/base/.esbuild/.serverless', {
+        recursive: true,
+      });
+    });
+
+    it('should propagate fs errors', () => {
+      mockFs.existsSync.mockReturnValue(false);
+      mockFs.mkdirSync.mockImplementation(() => {
+        throw new Error('Permission denied');
+      });
+
+      expect(() => {
+        manager.ensureDirectory('/test/path');
+      }).toThrow('Permission denied');
+    });
+  });
+});

--- a/packages/serverless-plugin/lib/localstack-queue-service.js
+++ b/packages/serverless-plugin/lib/localstack-queue-service.js
@@ -1,0 +1,44 @@
+/**
+ * Infrastructure Service - LocalStack Queue Management
+ *
+ * Handles SQS queue creation in LocalStack for offline development.
+ */
+class LocalStackQueueService {
+  constructor(sqsClient) {
+    this.sqs = sqsClient;
+  }
+
+  /**
+   * @param {string} queueName - Name of queue to create
+   * @returns {Promise<string>} Queue URL
+   */
+  async createQueue(queueName) {
+    return new Promise((resolve, reject) => {
+      this.sqs.createQueue({ QueueName: queueName }, (err, data) => {
+        if (err) {
+          reject(new Error(`Failed to create queue ${queueName}: ${err.message}`));
+        } else {
+          resolve(data.QueueUrl);
+        }
+      });
+    });
+  }
+
+  /**
+   * @param {Array<{key: string, name: string}>} queues - Queue definitions
+   * @returns {Promise<Array<{key: string, url: string}>>} Created queues with URLs
+   */
+  async createQueues(queues) {
+    const results = await Promise.all(
+      queues.map(async (queue) => {
+        const url = await this.createQueue(queue.name);
+        console.log(`Queue ${queue.name} created successfully. URL: ${url}`);
+        return { key: queue.key, url };
+      })
+    );
+
+    return results;
+  }
+}
+
+module.exports = { LocalStackQueueService };

--- a/packages/serverless-plugin/lib/localstack-queue-service.test.js
+++ b/packages/serverless-plugin/lib/localstack-queue-service.test.js
@@ -1,0 +1,94 @@
+const { LocalStackQueueService } = require('./localstack-queue-service');
+
+describe('LocalStackQueueService', () => {
+  let service;
+  let mockSQS;
+
+  beforeEach(() => {
+    mockSQS = {
+      createQueue: jest.fn(),
+    };
+    service = new LocalStackQueueService(mockSQS);
+  });
+
+  describe('createQueue', () => {
+    it('should create queue and return URL on success', async () => {
+      const queueUrl = 'http://localhost:4566/000000000000/test-queue';
+      mockSQS.createQueue.mockImplementation((params, callback) => {
+        callback(null, { QueueUrl: queueUrl });
+      });
+
+      const result = await service.createQueue('test-queue');
+
+      expect(result).toBe(queueUrl);
+      expect(mockSQS.createQueue).toHaveBeenCalledWith(
+        { QueueName: 'test-queue' },
+        expect.any(Function)
+      );
+    });
+
+    it('should reject with error on failure', async () => {
+      const error = new Error('SQS Error');
+      mockSQS.createQueue.mockImplementation((params, callback) => {
+        callback(error);
+      });
+
+      await expect(service.createQueue('test-queue')).rejects.toThrow(
+        'Failed to create queue test-queue: SQS Error'
+      );
+    });
+  });
+
+  describe('createQueues', () => {
+    it('should create multiple queues and return results', async () => {
+      mockSQS.createQueue.mockImplementation((params, callback) => {
+        const url = `http://localhost:4566/000000000000/${params.QueueName}`;
+        callback(null, { QueueUrl: url });
+      });
+
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      const queues = [
+        { key: 'AsanaQueue', name: 'test-asana-queue' },
+        { key: 'SlackQueue', name: 'test-slack-queue' },
+      ];
+
+      const results = await service.createQueues(queues);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]).toEqual({
+        key: 'AsanaQueue',
+        url: 'http://localhost:4566/000000000000/test-asana-queue',
+      });
+      expect(results[1]).toEqual({
+        key: 'SlackQueue',
+        url: 'http://localhost:4566/000000000000/test-slack-queue',
+      });
+
+      expect(consoleLogSpy).toHaveBeenCalledTimes(2);
+      consoleLogSpy.mockRestore();
+    });
+
+    it('should handle empty queue array', async () => {
+      const results = await service.createQueues([]);
+      expect(results).toEqual([]);
+    });
+
+    it('should reject if any queue creation fails', async () => {
+      mockSQS.createQueue.mockImplementation((params, callback) => {
+        if (params.QueueName === 'failing-queue') {
+          callback(new Error('Failed'));
+        } else {
+          callback(null, { QueueUrl: 'http://localhost:4566/queue' });
+        }
+      });
+
+      const queues = [
+        { key: 'SuccessQueue', name: 'success-queue' },
+        { key: 'FailQueue', name: 'failing-queue' },
+      ];
+
+      await expect(service.createQueues(queues)).rejects.toThrow('Failed to create queue failing-queue');
+    });
+  });
+});

--- a/packages/serverless-plugin/lib/queue-environment-mapper.js
+++ b/packages/serverless-plugin/lib/queue-environment-mapper.js
@@ -1,0 +1,44 @@
+/**
+ * Domain Service - Queue to Environment Variable Mapper
+ *
+ * Maps queue keys to environment variable names using naming convention.
+ * Pattern: AsanaQueue -> ASANA_QUEUE_URL
+ */
+class QueueEnvironmentMapper {
+  /**
+   * @param {Array<{key: string, name: string}>} queues - Queue definitions
+   * @returns {Object} Map of queue keys to environment variable names
+   */
+  createMapping(queues) {
+    const mapping = {};
+
+    queues.forEach(queue => {
+      const baseName = queue.key.replace(/Queue$/, '');
+      const envVarName = `${baseName.toUpperCase()}_QUEUE_URL`;
+      mapping[queue.key] = envVarName;
+    });
+
+    return mapping;
+  }
+
+  /**
+   * @param {string} queueKey - Queue key to look up
+   * @param {Object} mapping - Environment variable mapping
+   * @returns {string} Environment variable name
+   * @throws {Error} If no mapping found
+   */
+  getEnvironmentKey(queueKey, mapping) {
+    const envKey = mapping[queueKey];
+
+    if (!envKey) {
+      throw new Error(
+        `No environment variable mapping found for queue "${queueKey}". ` +
+        `Expected pattern: {QueueName}Queue -> {QUEUENAME}_QUEUE_URL`
+      );
+    }
+
+    return envKey;
+  }
+}
+
+module.exports = { QueueEnvironmentMapper };

--- a/packages/serverless-plugin/lib/queue-environment-mapper.test.js
+++ b/packages/serverless-plugin/lib/queue-environment-mapper.test.js
@@ -1,0 +1,74 @@
+const { QueueEnvironmentMapper } = require('./queue-environment-mapper');
+
+describe('QueueEnvironmentMapper', () => {
+  let mapper;
+
+  beforeEach(() => {
+    mapper = new QueueEnvironmentMapper();
+  });
+
+  describe('createMapping', () => {
+    it('should map single queue key to environment variable name', () => {
+      const queues = [{ key: 'AsanaQueue', name: 'test-asana-queue' }];
+      const result = mapper.createMapping(queues);
+
+      expect(result).toEqual({
+        AsanaQueue: 'ASANA_QUEUE_URL',
+      });
+    });
+
+    it('should map multiple queue keys to environment variable names', () => {
+      const queues = [
+        { key: 'AsanaQueue', name: 'test-asana-queue' },
+        { key: 'SlackQueue', name: 'test-slack-queue' },
+        { key: 'HubspotQueue', name: 'test-hubspot-queue' },
+      ];
+      const result = mapper.createMapping(queues);
+
+      expect(result).toEqual({
+        AsanaQueue: 'ASANA_QUEUE_URL',
+        SlackQueue: 'SLACK_QUEUE_URL',
+        HubspotQueue: 'HUBSPOT_QUEUE_URL',
+      });
+    });
+
+    it('should handle empty queue array', () => {
+      const result = mapper.createMapping([]);
+      expect(result).toEqual({});
+    });
+
+    it('should preserve case in base name conversion', () => {
+      const queues = [{ key: 'MyCustomQueue', name: 'test-queue' }];
+      const result = mapper.createMapping(queues);
+
+      expect(result).toEqual({
+        MyCustomQueue: 'MYCUSTOM_QUEUE_URL',
+      });
+    });
+  });
+
+  describe('getEnvironmentKey', () => {
+    it('should return environment variable name for valid queue key', () => {
+      const mapping = { AsanaQueue: 'ASANA_QUEUE_URL' };
+      const result = mapper.getEnvironmentKey('AsanaQueue', mapping);
+
+      expect(result).toBe('ASANA_QUEUE_URL');
+    });
+
+    it('should throw error for missing queue key', () => {
+      const mapping = { AsanaQueue: 'ASANA_QUEUE_URL' };
+
+      expect(() => {
+        mapper.getEnvironmentKey('InvalidQueue', mapping);
+      }).toThrow('No environment variable mapping found for queue "InvalidQueue"');
+    });
+
+    it('should throw error with helpful message pattern', () => {
+      const mapping = {};
+
+      expect(() => {
+        mapper.getEnvironmentKey('TestQueue', mapping);
+      }).toThrow('Expected pattern: {QueueName}Queue -> {QUEUENAME}_QUEUE_URL');
+    });
+  });
+});


### PR DESCRIPTION

Root Cause:
- Plugin was searching for CloudFormation Refs in environment variables
- By the time asyncInit() runs, OSLS has already resolved Refs to values
- Environment map was empty, causing extendConfiguration() to fail

Solution:
- Use naming convention instead: AsanaQueue -> ASANA_QUEUE_URL
- Extract domain services following DDD/Hexagonal architecture:
  * QueueEnvironmentMapper (Domain Service) - naming convention logic
  * LocalStackQueueService (Infrastructure) - SQS queue creation
  * EsbuildDirectoryManager (Infrastructure) - directory management
- Reduce excessive comments, focus on business logic
- Add comprehensive unit tests for all services

Architecture:
- Plugin (index.js) = Application Layer (orchestration)
- Domain Services = Pure business logic
- Infrastructure Services = External system adapters

Tests: 29 passing (4 test suites)
- Unit tests for all domain and infrastructure services
- Integration tests for plugin orchestration
