### PR TITLE
Get health check working with prisma db connections

### DIFF
--- a/packages/core/database/encryption/README.md
+++ b/packages/core/database/encryption/README.md
@@ -501,8 +501,9 @@ database: {
 # Run encryption tests
 npm test -- database/encryption/
 
-# Tests use explicit database type parameter for testing:
-# createHealthCheckRepository('mongodb')
+# Tests use explicit prismaClient injection:
+# const { prisma } = require('../prisma');
+# const repository = createHealthCheckRepository({ prismaClient: prisma });
 ```
 
 ## Error Handling & Logging

--- a/packages/core/database/encryption/encryption-integration.test.js
+++ b/packages/core/database/encryption/encryption-integration.test.js
@@ -49,9 +49,28 @@ const { createHealthCheckRepository } = require('../repositories/health-check-re
 const { mongoose } = require('../mongoose');
 
 describe('Field-Level Encryption Integration Tests', () => {
-    // Use externalId for test identification (works with both MongoDB and PostgreSQL)
     const testExternalId = 'test-encryption-integration-id';
     let repository;
+
+    describe('Factory Dependency Injection', () => {
+        it('should require explicit prismaClient parameter', () => {
+            expect(() => {
+                createHealthCheckRepository();
+            }).toThrow('prismaClient is required');
+        });
+
+        it('should reject null prismaClient', () => {
+            expect(() => {
+                createHealthCheckRepository({ prismaClient: null });
+            }).toThrow('prismaClient is required');
+        });
+
+        it('should accept explicit prismaClient', () => {
+            const repo = createHealthCheckRepository({ prismaClient: prisma });
+            expect(repo).toBeDefined();
+            expect(repo.prisma).toBe(prisma);
+        });
+    });
 
     beforeAll(async () => {
         await connectPrisma();
@@ -59,9 +78,7 @@ describe('Field-Level Encryption Integration Tests', () => {
         if (mongoose.connection.readyState === 0) {
             await mongoose.connect(process.env.DATABASE_URL);
         }
-        // Create database-specific repository for raw access
-        // Pass explicit database type for testing
-        repository = createHealthCheckRepository('mongodb');
+        repository = createHealthCheckRepository({ prismaClient: prisma });
     });
 
     afterAll(async () => {

--- a/packages/core/database/repositories/health-check-repository-factory.js
+++ b/packages/core/database/repositories/health-check-repository-factory.js
@@ -1,27 +1,22 @@
 const { HealthCheckRepositoryMongoDB } = require('./health-check-repository-mongodb');
 const { HealthCheckRepositoryPostgreSQL } = require('./health-check-repository-postgres');
+const { prisma } = require('../prisma');
 const config = require('../config');
 
 /**
- * Health Check Repository Factory
- * Creates the appropriate repository adapter based on database type
- *
- * Usage:
- * ```javascript
- * const repository = createHealthCheckRepository();
- * ```
- *
- * @returns {HealthCheckRepositoryInterface} Configured repository adapter
+ * @param {Object} [options]
+ * @param {Object} [options.prismaClient] - Prisma client (defaults to singleton)
+ * @returns {HealthCheckRepositoryInterface}
  */
-function createHealthCheckRepository() {
+function createHealthCheckRepository({ prismaClient = prisma } = {}) {
     const dbType = config.DB_TYPE;
 
     switch (dbType) {
         case 'mongodb':
-            return new HealthCheckRepositoryMongoDB();
+            return new HealthCheckRepositoryMongoDB({ prismaClient });
 
         case 'postgresql':
-            return new HealthCheckRepositoryPostgreSQL();
+            return new HealthCheckRepositoryPostgreSQL({ prismaClient });
 
         default:
             throw new Error(
@@ -32,7 +27,6 @@ function createHealthCheckRepository() {
 
 module.exports = {
     createHealthCheckRepository,
-    // Export adapters for direct testing
     HealthCheckRepositoryMongoDB,
     HealthCheckRepositoryPostgreSQL,
 };

--- a/packages/core/database/repositories/health-check-repository-factory.js
+++ b/packages/core/database/repositories/health-check-repository-factory.js
@@ -1,14 +1,25 @@
 const { HealthCheckRepositoryMongoDB } = require('./health-check-repository-mongodb');
 const { HealthCheckRepositoryPostgreSQL } = require('./health-check-repository-postgres');
-const { prisma } = require('../prisma');
 const config = require('../config');
 
 /**
- * @param {Object} [options]
- * @param {Object} [options.prismaClient] - Prisma client (defaults to singleton)
- * @returns {HealthCheckRepositoryInterface}
+ * Factory function to create a health check repository for the configured database type.
+ * Requires explicit prismaClient injection to support IoC container patterns.
+ *
+ * @param {Object} options
+ * @param {Object} options.prismaClient - Prisma client instance (required for dependency injection)
+ * @returns {HealthCheckRepositoryInterface} Database-specific health check repository
+ * @throws {Error} If prismaClient is not provided
+ *
+ * @example
+ * const { prisma } = require('../prisma');
+ * const repository = createHealthCheckRepository({ prismaClient: prisma });
  */
-function createHealthCheckRepository({ prismaClient = prisma } = {}) {
+function createHealthCheckRepository({ prismaClient } = {}) {
+    if (!prismaClient) {
+        throw new Error('prismaClient is required');
+    }
+
     const dbType = config.DB_TYPE;
 
     switch (dbType) {

--- a/packages/core/database/repositories/health-check-repository-interface.js
+++ b/packages/core/database/repositories/health-check-repository-interface.js
@@ -76,9 +76,10 @@ class HealthCheckRepositoryInterface {
     /**
      * Get database connection state
      *
-     * @returns {Object} Connection state info
+     * @returns {Promise<Object>} Connection state info
+     * @abstract
      */
-    getDatabaseConnectionState() {
+    async getDatabaseConnectionState() {
         throw new Error('Method getDatabaseConnectionState must be implemented by subclass');
     }
 }

--- a/packages/core/database/repositories/health-check-repository-mongodb.js
+++ b/packages/core/database/repositories/health-check-repository-mongodb.js
@@ -8,32 +8,42 @@ const {
  * MongoDB-specific Health Check Repository
  *
  * Provides MongoDB-specific database operations for health testing.
- * Uses Mongoose for MongoDB-specific operations (raw access, ping).
+ * Uses Prisma for MongoDB operations (Mongoose is legacy/unused).
  */
 class HealthCheckRepositoryMongoDB extends HealthCheckRepositoryInterface {
     constructor() {
         super();
     }
 
-    getDatabaseConnectionState() {
-        const stateMap = {
-            0: 'disconnected',
-            1: 'connected',
-            2: 'connecting',
-            3: 'disconnecting',
-        };
-        const readyState = mongoose.connection.readyState;
+    async getDatabaseConnectionState() {
+        // Prisma doesn't expose connection state like Mongoose
+        // We need to actually test the connection
+        let isConnected = false;
+        let stateName = 'unknown';
+        
+        try {
+            // Try a quick query to see if we're connected
+            await prisma.$runCommandRaw({ ping: 1 });
+            isConnected = true;
+            stateName = 'connected';
+        } catch (error) {
+            stateName = 'disconnected';
+        }
 
         return {
-            readyState,
-            stateName: stateMap[readyState],
-            isConnected: readyState === 1,
+            readyState: isConnected ? 1 : 0,
+            stateName,
+            isConnected,
         };
     }
 
     async pingDatabase(maxTimeMS = 2000) {
         const pingStart = Date.now();
-        await mongoose.connection.db.admin().ping({ maxTimeMS });
+        // Use Prisma's $queryRaw to execute a ping command
+        await prisma.$queryRaw`SELECT 1`.catch(() => {
+            // For MongoDB, use runCommandRaw instead
+            return prisma.$runCommandRaw({ ping: 1 });
+        });
         return Date.now() - pingStart;
     }
 

--- a/packages/core/database/repositories/health-check-repository-mongodb.js
+++ b/packages/core/database/repositories/health-check-repository-mongodb.js
@@ -30,20 +30,31 @@ class HealthCheckRepositoryMongoDB extends HealthCheckRepositoryInterface {
 
         return {
             readyState: isConnected ? 1 : 0,
+            readyState: isConnected ? 1 : 0,
             stateName,
             isConnected,
         };
     }
 
-    /**
-     * @param {number} maxTimeMS
-     * @returns {Promise<number>} Response time in milliseconds
-     */
     async pingDatabase(maxTimeMS = 2000) {
         const pingStart = Date.now();
-        await this.prisma.$queryRaw`SELECT 1`.catch(async () => {
-            return await this.prisma.$runCommandRaw({ ping: 1 });
-        });
+        
+        // Create a timeout promise that rejects after maxTimeMS
+        const timeoutPromise = new Promise((_, reject) => 
+            setTimeout(() => reject(new Error('Database ping timeout')), maxTimeMS)
+        );
+        
+        // Race between the database ping and the timeout
+        await Promise.race([
+            prisma.$queryRaw`SELECT 1`.catch(() => {
+                // For MongoDB, use runCommandRaw instead
+                return prisma.$runCommandRaw({ ping: 1 });
+            }),
+            timeoutPromise
+        ]);
+        
+        return Date.now() - pingStart;
+    }
         return Date.now() - pingStart;
     }
 

--- a/packages/core/database/repositories/health-check-repository-mongodb.js
+++ b/packages/core/database/repositories/health-check-repository-mongodb.js
@@ -41,8 +41,8 @@ class HealthCheckRepositoryMongoDB extends HealthCheckRepositoryInterface {
      */
     async pingDatabase(maxTimeMS = 2000) {
         const pingStart = Date.now();
-        await this.prisma.$queryRaw`SELECT 1`.catch(() => {
-            return this.prisma.$runCommandRaw({ ping: 1 });
+        await this.prisma.$queryRaw`SELECT 1`.catch(async () => {
+            return await this.prisma.$runCommandRaw({ ping: 1 });
         });
         return Date.now() - pingStart;
     }

--- a/packages/core/database/repositories/health-check-repository-mongodb.js
+++ b/packages/core/database/repositories/health-check-repository-mongodb.js
@@ -1,29 +1,27 @@
-const { prisma } = require('../prisma');
 const { mongoose } = require('../mongoose');
 const {
     HealthCheckRepositoryInterface,
 } = require('./health-check-repository-interface');
 
-/**
- * MongoDB-specific Health Check Repository
- *
- * Provides MongoDB-specific database operations for health testing.
- * Uses Prisma for MongoDB operations (Mongoose is legacy/unused).
- */
 class HealthCheckRepositoryMongoDB extends HealthCheckRepositoryInterface {
-    constructor() {
+    /**
+     * @param {Object} params
+     * @param {Object} params.prismaClient - Prisma client instance
+     */
+    constructor({ prismaClient }) {
         super();
+        this.prisma = prismaClient;
     }
 
+    /**
+     * @returns {Promise<{readyState: number, stateName: string, isConnected: boolean}>}
+     */
     async getDatabaseConnectionState() {
-        // Prisma doesn't expose connection state like Mongoose
-        // We need to actually test the connection
         let isConnected = false;
         let stateName = 'unknown';
         
         try {
-            // Try a quick query to see if we're connected
-            await prisma.$runCommandRaw({ ping: 1 });
+            await this.prisma.$runCommandRaw({ ping: 1 });
             isConnected = true;
             stateName = 'connected';
         } catch (error) {
@@ -37,36 +35,33 @@ class HealthCheckRepositoryMongoDB extends HealthCheckRepositoryInterface {
         };
     }
 
+    /**
+     * @param {number} maxTimeMS
+     * @returns {Promise<number>} Response time in milliseconds
+     */
     async pingDatabase(maxTimeMS = 2000) {
         const pingStart = Date.now();
-        // Use Prisma's $queryRaw to execute a ping command
-        await prisma.$queryRaw`SELECT 1`.catch(() => {
-            // For MongoDB, use runCommandRaw instead
-            return prisma.$runCommandRaw({ ping: 1 });
+        await this.prisma.$queryRaw`SELECT 1`.catch(() => {
+            return this.prisma.$runCommandRaw({ ping: 1 });
         });
         return Date.now() - pingStart;
     }
 
     async createCredential(credentialData) {
-        // Note: Collection existence is ensured at application startup via
-        // initializeMongoDBSchema() in database/utils/mongodb-schema-init.js
-        // This prevents "Cannot create namespace in multi-document transaction" errors
-        return await prisma.credential.create({
+        return await this.prisma.credential.create({
             data: credentialData,
         });
     }
 
     async findCredentialById(id) {
-        return await prisma.credential.findUnique({
+        return await this.prisma.credential.findUnique({
             where: { id },
         });
     }
 
     /**
-     * Get raw credential from MongoDB bypassing Prisma encryption extension
-     * Uses Mongoose to access raw MongoDB collection
-     * @param {string} id - Credential ID
-     * @returns {Promise<Object|null>} Raw credential from database
+     * @param {string} id
+     * @returns {Promise<Object|null>}
      */
     async getRawCredentialById(id) {
         const { ObjectId } = require('mongodb');
@@ -76,7 +71,7 @@ class HealthCheckRepositoryMongoDB extends HealthCheckRepositoryInterface {
     }
 
     async deleteCredential(id) {
-        await prisma.credential.delete({
+        await this.prisma.credential.delete({
             where: { id },
         });
     }

--- a/packages/core/database/repositories/health-check-repository-mongodb.test.js
+++ b/packages/core/database/repositories/health-check-repository-mongodb.test.js
@@ -1,32 +1,23 @@
-/**
- * Tests for HealthCheckRepositoryMongoDB
- * 
- * Tests database connection state detection and ping functionality
- */
-
 const { HealthCheckRepositoryMongoDB } = require('./health-check-repository-mongodb');
-
-// Mock the prisma module
-jest.mock('../prisma', () => ({
-    prisma: {
-        $runCommandRaw: jest.fn(),
-        $queryRaw: jest.fn(),
-    },
-}));
-
-const { prisma } = require('../prisma');
 
 describe('HealthCheckRepositoryMongoDB', () => {
     let repository;
+    let mockPrismaClient;
 
     beforeEach(() => {
-        repository = new HealthCheckRepositoryMongoDB();
-        jest.clearAllMocks();
+        mockPrismaClient = {
+            $runCommandRaw: jest.fn(),
+            $queryRaw: jest.fn(),
+        };
+        
+        repository = new HealthCheckRepositoryMongoDB({ 
+            prismaClient: mockPrismaClient 
+        });
     });
 
     describe('getDatabaseConnectionState()', () => {
         it('should return connected state when ping succeeds', async () => {
-            prisma.$runCommandRaw.mockResolvedValue({ ok: 1 });
+            mockPrismaClient.$runCommandRaw.mockResolvedValue({ ok: 1 });
 
             const result = await repository.getDatabaseConnectionState();
 
@@ -35,11 +26,11 @@ describe('HealthCheckRepositoryMongoDB', () => {
                 stateName: 'connected',
                 isConnected: true,
             });
-            expect(prisma.$runCommandRaw).toHaveBeenCalledWith({ ping: 1 });
+            expect(mockPrismaClient.$runCommandRaw).toHaveBeenCalledWith({ ping: 1 });
         });
 
         it('should return disconnected state when ping fails', async () => {
-            prisma.$runCommandRaw.mockRejectedValue(new Error('Connection failed'));
+            mockPrismaClient.$runCommandRaw.mockRejectedValue(new Error('Connection failed'));
 
             const result = await repository.getDatabaseConnectionState();
 
@@ -48,11 +39,11 @@ describe('HealthCheckRepositoryMongoDB', () => {
                 stateName: 'disconnected',
                 isConnected: false,
             });
-            expect(prisma.$runCommandRaw).toHaveBeenCalledWith({ ping: 1 });
+            expect(mockPrismaClient.$runCommandRaw).toHaveBeenCalledWith({ ping: 1 });
         });
 
         it('should return disconnected state when ping throws network error', async () => {
-            prisma.$runCommandRaw.mockRejectedValue(new Error('ECONNREFUSED'));
+            mockPrismaClient.$runCommandRaw.mockRejectedValue(new Error('ECONNREFUSED'));
 
             const result = await repository.getDatabaseConnectionState();
 
@@ -64,7 +55,7 @@ describe('HealthCheckRepositoryMongoDB', () => {
         });
 
         it('should return disconnected state when ping times out', async () => {
-            prisma.$runCommandRaw.mockRejectedValue(new Error('Timeout'));
+            mockPrismaClient.$runCommandRaw.mockRejectedValue(new Error('Timeout'));
 
             const result = await repository.getDatabaseConnectionState();
 
@@ -75,35 +66,34 @@ describe('HealthCheckRepositoryMongoDB', () => {
 
     describe('pingDatabase()', () => {
         it('should return response time when ping succeeds', async () => {
-            // MongoDB ping uses $queryRaw which fails, then falls back to $runCommandRaw
-            prisma.$queryRaw.mockRejectedValue(new Error('Not MongoDB'));
-            prisma.$runCommandRaw.mockResolvedValue({ ok: 1 });
+            mockPrismaClient.$queryRaw.mockRejectedValue(new Error('Not MongoDB'));
+            mockPrismaClient.$runCommandRaw.mockResolvedValue({ ok: 1 });
 
             const responseTime = await repository.pingDatabase(2000);
 
             expect(typeof responseTime).toBe('number');
             expect(responseTime).toBeGreaterThanOrEqual(0);
-            expect(prisma.$runCommandRaw).toHaveBeenCalledWith({ ping: 1 });
+            expect(mockPrismaClient.$runCommandRaw).toHaveBeenCalledWith({ ping: 1 });
         });
 
         it('should throw error when ping fails', async () => {
             const error = new Error('Database unreachable');
-            prisma.$queryRaw.mockRejectedValue(new Error('Not MongoDB'));
-            prisma.$runCommandRaw.mockRejectedValue(error);
+            mockPrismaClient.$queryRaw.mockRejectedValue(new Error('Not MongoDB'));
+            mockPrismaClient.$runCommandRaw.mockRejectedValue(error);
 
             await expect(repository.pingDatabase(2000)).rejects.toThrow('Database unreachable');
         });
 
         it('should measure actual response time', async () => {
-            prisma.$queryRaw.mockRejectedValue(new Error('Not MongoDB'));
-            prisma.$runCommandRaw.mockImplementation(() => 
+            mockPrismaClient.$queryRaw.mockRejectedValue(new Error('Not MongoDB'));
+            mockPrismaClient.$runCommandRaw.mockImplementation(() => 
                 new Promise(resolve => setTimeout(() => resolve({ ok: 1 }), 50))
             );
 
             const responseTime = await repository.pingDatabase(2000);
 
             expect(responseTime).toBeGreaterThanOrEqual(50);
-            expect(responseTime).toBeLessThan(200); // Allow some buffer
+            expect(responseTime).toBeLessThan(200);
         });
     });
 });

--- a/packages/core/database/repositories/health-check-repository-mongodb.test.js
+++ b/packages/core/database/repositories/health-check-repository-mongodb.test.js
@@ -1,0 +1,110 @@
+/**
+ * Tests for HealthCheckRepositoryMongoDB
+ * 
+ * Tests database connection state detection and ping functionality
+ */
+
+const { HealthCheckRepositoryMongoDB } = require('./health-check-repository-mongodb');
+
+// Mock the prisma module
+jest.mock('../prisma', () => ({
+    prisma: {
+        $runCommandRaw: jest.fn(),
+        $queryRaw: jest.fn(),
+    },
+}));
+
+const { prisma } = require('../prisma');
+
+describe('HealthCheckRepositoryMongoDB', () => {
+    let repository;
+
+    beforeEach(() => {
+        repository = new HealthCheckRepositoryMongoDB();
+        jest.clearAllMocks();
+    });
+
+    describe('getDatabaseConnectionState()', () => {
+        it('should return connected state when ping succeeds', async () => {
+            prisma.$runCommandRaw.mockResolvedValue({ ok: 1 });
+
+            const result = await repository.getDatabaseConnectionState();
+
+            expect(result).toEqual({
+                readyState: 1,
+                stateName: 'connected',
+                isConnected: true,
+            });
+            expect(prisma.$runCommandRaw).toHaveBeenCalledWith({ ping: 1 });
+        });
+
+        it('should return disconnected state when ping fails', async () => {
+            prisma.$runCommandRaw.mockRejectedValue(new Error('Connection failed'));
+
+            const result = await repository.getDatabaseConnectionState();
+
+            expect(result).toEqual({
+                readyState: 0,
+                stateName: 'disconnected',
+                isConnected: false,
+            });
+            expect(prisma.$runCommandRaw).toHaveBeenCalledWith({ ping: 1 });
+        });
+
+        it('should return disconnected state when ping throws network error', async () => {
+            prisma.$runCommandRaw.mockRejectedValue(new Error('ECONNREFUSED'));
+
+            const result = await repository.getDatabaseConnectionState();
+
+            expect(result).toEqual({
+                readyState: 0,
+                stateName: 'disconnected',
+                isConnected: false,
+            });
+        });
+
+        it('should return disconnected state when ping times out', async () => {
+            prisma.$runCommandRaw.mockRejectedValue(new Error('Timeout'));
+
+            const result = await repository.getDatabaseConnectionState();
+
+            expect(result.isConnected).toBe(false);
+            expect(result.stateName).toBe('disconnected');
+        });
+    });
+
+    describe('pingDatabase()', () => {
+        it('should return response time when ping succeeds', async () => {
+            // MongoDB ping uses $queryRaw which fails, then falls back to $runCommandRaw
+            prisma.$queryRaw.mockRejectedValue(new Error('Not MongoDB'));
+            prisma.$runCommandRaw.mockResolvedValue({ ok: 1 });
+
+            const responseTime = await repository.pingDatabase(2000);
+
+            expect(typeof responseTime).toBe('number');
+            expect(responseTime).toBeGreaterThanOrEqual(0);
+            expect(prisma.$runCommandRaw).toHaveBeenCalledWith({ ping: 1 });
+        });
+
+        it('should throw error when ping fails', async () => {
+            const error = new Error('Database unreachable');
+            prisma.$queryRaw.mockRejectedValue(new Error('Not MongoDB'));
+            prisma.$runCommandRaw.mockRejectedValue(error);
+
+            await expect(repository.pingDatabase(2000)).rejects.toThrow('Database unreachable');
+        });
+
+        it('should measure actual response time', async () => {
+            prisma.$queryRaw.mockRejectedValue(new Error('Not MongoDB'));
+            prisma.$runCommandRaw.mockImplementation(() => 
+                new Promise(resolve => setTimeout(() => resolve({ ok: 1 }), 50))
+            );
+
+            const responseTime = await repository.pingDatabase(2000);
+
+            expect(responseTime).toBeGreaterThanOrEqual(50);
+            expect(responseTime).toBeLessThan(200); // Allow some buffer
+        });
+    });
+});
+

--- a/packages/core/database/repositories/health-check-repository-postgres.js
+++ b/packages/core/database/repositories/health-check-repository-postgres.js
@@ -1,28 +1,26 @@
-const { prisma } = require('../prisma');
 const {
     HealthCheckRepositoryInterface,
 } = require('./health-check-repository-interface');
 
-/**
- * PostgreSQL-specific Health Check Repository
- *
- * Provides PostgreSQL-specific database operations for health testing.
- * Uses Prisma raw queries for PostgreSQL-specific operations.
- */
 class HealthCheckRepositoryPostgreSQL extends HealthCheckRepositoryInterface {
-    constructor() {
+    /**
+     * @param {Object} params
+     * @param {Object} params.prismaClient - Prisma client instance
+     */
+    constructor({ prismaClient }) {
         super();
+        this.prisma = prismaClient;
     }
 
+    /**
+     * @returns {Promise<{readyState: number, stateName: string, isConnected: boolean}>}
+     */
     async getDatabaseConnectionState() {
-        // PostgreSQL connection state via Prisma
-        // Prisma doesn't expose connection state, so we test it
         let isConnected = false;
         let stateName = 'unknown';
         
         try {
-            // Try a quick query to see if we're connected
-            await prisma.$queryRaw`SELECT 1`;
+            await this.prisma.$queryRaw`SELECT 1`;
             isConnected = true;
             stateName = 'connected';
         } catch (error) {
@@ -36,35 +34,34 @@ class HealthCheckRepositoryPostgreSQL extends HealthCheckRepositoryInterface {
         };
     }
 
+    /**
+     * @param {number} maxTimeMS
+     * @returns {Promise<number>} Response time in milliseconds
+     */
     async pingDatabase(maxTimeMS = 2000) {
         const pingStart = Date.now();
-
-        // PostgreSQL ping using SELECT 1
-        await prisma.$queryRaw`SELECT 1`;
-
+        await this.prisma.$queryRaw`SELECT 1`;
         return Date.now() - pingStart;
     }
 
     async createCredential(credentialData) {
-        return await prisma.credential.create({
+        return await this.prisma.credential.create({
             data: credentialData,
         });
     }
 
     async findCredentialById(id) {
-        return await prisma.credential.findUnique({
+        return await this.prisma.credential.findUnique({
             where: { id },
         });
     }
 
     /**
-     * Get raw credential from PostgreSQL bypassing Prisma encryption extension
-     * Uses $queryRaw to access raw PostgreSQL table
-     * @param {string} id - Credential ID
-     * @returns {Promise<Object|null>} Raw credential from database
+     * @param {string} id
+     * @returns {Promise<Object|null>}
      */
     async getRawCredentialById(id) {
-        const results = await prisma.$queryRaw`
+        const results = await this.prisma.$queryRaw`
             SELECT * FROM "Credential" WHERE id = ${id}
         `;
 
@@ -72,12 +69,11 @@ class HealthCheckRepositoryPostgreSQL extends HealthCheckRepositoryInterface {
             return null;
         }
 
-        // Return first result
         return results[0];
     }
 
     async deleteCredential(id) {
-        await prisma.credential.delete({
+        await this.prisma.credential.delete({
             where: { id },
         });
     }

--- a/packages/core/database/repositories/health-check-repository-postgres.js
+++ b/packages/core/database/repositories/health-check-repository-postgres.js
@@ -14,14 +14,25 @@ class HealthCheckRepositoryPostgreSQL extends HealthCheckRepositoryInterface {
         super();
     }
 
-    getDatabaseConnectionState() {
+    async getDatabaseConnectionState() {
         // PostgreSQL connection state via Prisma
-        // Note: Prisma doesn't expose connection state like Mongoose
-        // We check if prisma is connected by attempting a query
+        // Prisma doesn't expose connection state, so we test it
+        let isConnected = false;
+        let stateName = 'unknown';
+        
+        try {
+            // Try a quick query to see if we're connected
+            await prisma.$queryRaw`SELECT 1`;
+            isConnected = true;
+            stateName = 'connected';
+        } catch (error) {
+            stateName = 'disconnected';
+        }
+
         return {
-            readyState: 1, // Assume connected if Prisma instance exists
-            stateName: 'connected',
-            isConnected: true,
+            readyState: isConnected ? 1 : 0,
+            stateName,
+            isConnected,
         };
     }
 

--- a/packages/core/database/repositories/health-check-repository-postgres.test.js
+++ b/packages/core/database/repositories/health-check-repository-postgres.test.js
@@ -1,0 +1,104 @@
+/**
+ * Tests for HealthCheckRepositoryPostgreSQL
+ * 
+ * Tests database connection state detection and ping functionality
+ */
+
+const { HealthCheckRepositoryPostgreSQL } = require('./health-check-repository-postgres');
+
+// Mock the prisma module
+jest.mock('../prisma', () => ({
+    prisma: {
+        $queryRaw: jest.fn(),
+    },
+}));
+
+const { prisma } = require('../prisma');
+
+describe('HealthCheckRepositoryPostgreSQL', () => {
+    let repository;
+
+    beforeEach(() => {
+        repository = new HealthCheckRepositoryPostgreSQL();
+        jest.clearAllMocks();
+    });
+
+    describe('getDatabaseConnectionState()', () => {
+        it('should return connected state when query succeeds', async () => {
+            prisma.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+
+            const result = await repository.getDatabaseConnectionState();
+
+            expect(result).toEqual({
+                readyState: 1,
+                stateName: 'connected',
+                isConnected: true,
+            });
+            expect(prisma.$queryRaw).toHaveBeenCalled();
+        });
+
+        it('should return disconnected state when query fails', async () => {
+            prisma.$queryRaw.mockRejectedValue(new Error('Connection failed'));
+
+            const result = await repository.getDatabaseConnectionState();
+
+            expect(result).toEqual({
+                readyState: 0,
+                stateName: 'disconnected',
+                isConnected: false,
+            });
+        });
+
+        it('should return disconnected state when database is unreachable', async () => {
+            prisma.$queryRaw.mockRejectedValue(new Error('ECONNREFUSED'));
+
+            const result = await repository.getDatabaseConnectionState();
+
+            expect(result.isConnected).toBe(false);
+            expect(result.stateName).toBe('disconnected');
+        });
+
+        it('should return disconnected state on authentication error', async () => {
+            prisma.$queryRaw.mockRejectedValue(new Error('Authentication failed'));
+
+            const result = await repository.getDatabaseConnectionState();
+
+            expect(result).toEqual({
+                readyState: 0,
+                stateName: 'disconnected',
+                isConnected: false,
+            });
+        });
+    });
+
+    describe('pingDatabase()', () => {
+        it('should return response time when ping succeeds', async () => {
+            prisma.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+
+            const responseTime = await repository.pingDatabase(2000);
+
+            expect(typeof responseTime).toBe('number');
+            expect(responseTime).toBeGreaterThanOrEqual(0);
+            expect(prisma.$queryRaw).toHaveBeenCalled();
+        });
+
+        it('should throw error when ping fails', async () => {
+            const error = new Error('Database unreachable');
+            prisma.$queryRaw.mockRejectedValue(error);
+
+            await expect(repository.pingDatabase(2000)).rejects.toThrow('Database unreachable');
+        });
+
+        it('should measure actual response time', async () => {
+            prisma.$queryRaw.mockImplementation(() => 
+                new Promise(resolve => setTimeout(() => resolve([{ '?column?': 1 }]), 30))
+            );
+
+            const responseTime = await repository.pingDatabase(2000);
+
+            expect(responseTime).toBeGreaterThanOrEqual(30);
+            expect(responseTime).toBeLessThan(150); // Allow some buffer
+        });
+    });
+});
+

--- a/packages/core/database/repositories/health-check-repository-postgres.test.js
+++ b/packages/core/database/repositories/health-check-repository-postgres.test.js
@@ -1,31 +1,22 @@
-/**
- * Tests for HealthCheckRepositoryPostgreSQL
- * 
- * Tests database connection state detection and ping functionality
- */
-
 const { HealthCheckRepositoryPostgreSQL } = require('./health-check-repository-postgres');
-
-// Mock the prisma module
-jest.mock('../prisma', () => ({
-    prisma: {
-        $queryRaw: jest.fn(),
-    },
-}));
-
-const { prisma } = require('../prisma');
 
 describe('HealthCheckRepositoryPostgreSQL', () => {
     let repository;
+    let mockPrismaClient;
 
     beforeEach(() => {
-        repository = new HealthCheckRepositoryPostgreSQL();
-        jest.clearAllMocks();
+        mockPrismaClient = {
+            $queryRaw: jest.fn(),
+        };
+        
+        repository = new HealthCheckRepositoryPostgreSQL({ 
+            prismaClient: mockPrismaClient 
+        });
     });
 
     describe('getDatabaseConnectionState()', () => {
         it('should return connected state when query succeeds', async () => {
-            prisma.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+            mockPrismaClient.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
 
             const result = await repository.getDatabaseConnectionState();
 
@@ -34,11 +25,11 @@ describe('HealthCheckRepositoryPostgreSQL', () => {
                 stateName: 'connected',
                 isConnected: true,
             });
-            expect(prisma.$queryRaw).toHaveBeenCalled();
+            expect(mockPrismaClient.$queryRaw).toHaveBeenCalled();
         });
 
         it('should return disconnected state when query fails', async () => {
-            prisma.$queryRaw.mockRejectedValue(new Error('Connection failed'));
+            mockPrismaClient.$queryRaw.mockRejectedValue(new Error('Connection failed'));
 
             const result = await repository.getDatabaseConnectionState();
 
@@ -50,7 +41,7 @@ describe('HealthCheckRepositoryPostgreSQL', () => {
         });
 
         it('should return disconnected state when database is unreachable', async () => {
-            prisma.$queryRaw.mockRejectedValue(new Error('ECONNREFUSED'));
+            mockPrismaClient.$queryRaw.mockRejectedValue(new Error('ECONNREFUSED'));
 
             const result = await repository.getDatabaseConnectionState();
 
@@ -59,7 +50,7 @@ describe('HealthCheckRepositoryPostgreSQL', () => {
         });
 
         it('should return disconnected state on authentication error', async () => {
-            prisma.$queryRaw.mockRejectedValue(new Error('Authentication failed'));
+            mockPrismaClient.$queryRaw.mockRejectedValue(new Error('Authentication failed'));
 
             const result = await repository.getDatabaseConnectionState();
 
@@ -73,24 +64,24 @@ describe('HealthCheckRepositoryPostgreSQL', () => {
 
     describe('pingDatabase()', () => {
         it('should return response time when ping succeeds', async () => {
-            prisma.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+            mockPrismaClient.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
 
             const responseTime = await repository.pingDatabase(2000);
 
             expect(typeof responseTime).toBe('number');
             expect(responseTime).toBeGreaterThanOrEqual(0);
-            expect(prisma.$queryRaw).toHaveBeenCalled();
+            expect(mockPrismaClient.$queryRaw).toHaveBeenCalled();
         });
 
         it('should throw error when ping fails', async () => {
             const error = new Error('Database unreachable');
-            prisma.$queryRaw.mockRejectedValue(error);
+            mockPrismaClient.$queryRaw.mockRejectedValue(error);
 
             await expect(repository.pingDatabase(2000)).rejects.toThrow('Database unreachable');
         });
 
         it('should measure actual response time', async () => {
-            prisma.$queryRaw.mockImplementation(() => 
+            mockPrismaClient.$queryRaw.mockImplementation(() => 
                 new Promise(resolve => setTimeout(() => resolve([{ '?column?': 1 }]), 30))
             );
 

--- a/packages/core/database/use-cases/check-database-health-use-case.js
+++ b/packages/core/database/use-cases/check-database-health-use-case.js
@@ -16,7 +16,7 @@ class CheckDatabaseHealthUseCase {
      * @returns {Promise<Object>} Health check result with status, state, and response time
      */
     async execute() {
-        const { stateName, isConnected } = this.repository.getDatabaseConnectionState();
+        const { stateName, isConnected } = await this.repository.getDatabaseConnectionState();
 
         const result = {
             status: isConnected ? 'healthy' : 'unhealthy',

--- a/packages/core/database/use-cases/check-database-health-use-case.js
+++ b/packages/core/database/use-cases/check-database-health-use-case.js
@@ -1,19 +1,14 @@
-/**
- * Use Case for checking database health.
- * Contains business logic for determining database connectivity and health status.
- */
 class CheckDatabaseHealthUseCase {
     /**
      * @param {Object} params
-     * @param {import('../health-check-repository-interface').HealthCheckRepositoryInterface} params.healthCheckRepository
+     * @param {import('../repositories/health-check-repository-interface').HealthCheckRepositoryInterface} params.healthCheckRepository
      */
     constructor({ healthCheckRepository }) {
         this.repository = healthCheckRepository;
     }
 
     /**
-     * Execute database health check
-     * @returns {Promise<Object>} Health check result with status, state, and response time
+     * @returns {Promise<{status: string, state: string, responseTime?: number}>}
      */
     async execute() {
         const { stateName, isConnected } = await this.repository.getDatabaseConnectionState();

--- a/packages/core/database/use-cases/check-database-health-use-case.test.js
+++ b/packages/core/database/use-cases/check-database-health-use-case.test.js
@@ -1,0 +1,138 @@
+/**
+ * Tests for CheckDatabaseHealthUseCase
+ * 
+ * Tests business logic for database health checking
+ */
+
+const { CheckDatabaseHealthUseCase } = require('./check-database-health-use-case');
+
+describe('CheckDatabaseHealthUseCase', () => {
+    let useCase;
+    let mockRepository;
+
+    beforeEach(() => {
+        mockRepository = {
+            getDatabaseConnectionState: jest.fn(),
+            pingDatabase: jest.fn(),
+        };
+        useCase = new CheckDatabaseHealthUseCase({ 
+            healthCheckRepository: mockRepository 
+        });
+    });
+
+    describe('execute()', () => {
+        it('should return healthy status when database is connected', async () => {
+            mockRepository.getDatabaseConnectionState.mockResolvedValue({
+                readyState: 1,
+                stateName: 'connected',
+                isConnected: true,
+            });
+            mockRepository.pingDatabase.mockResolvedValue(5);
+
+            const result = await useCase.execute();
+
+            expect(result).toEqual({
+                status: 'healthy',
+                state: 'connected',
+                responseTime: 5,
+            });
+            expect(mockRepository.getDatabaseConnectionState).toHaveBeenCalled();
+            expect(mockRepository.pingDatabase).toHaveBeenCalledWith(2000);
+        });
+
+        it('should return unhealthy status when database is disconnected', async () => {
+            mockRepository.getDatabaseConnectionState.mockResolvedValue({
+                readyState: 0,
+                stateName: 'disconnected',
+                isConnected: false,
+            });
+
+            const result = await useCase.execute();
+
+            expect(result).toEqual({
+                status: 'unhealthy',
+                state: 'disconnected',
+            });
+            expect(mockRepository.getDatabaseConnectionState).toHaveBeenCalled();
+            expect(mockRepository.pingDatabase).not.toHaveBeenCalled();
+        });
+
+        it('should return unhealthy status when database is connecting', async () => {
+            mockRepository.getDatabaseConnectionState.mockResolvedValue({
+                readyState: 2,
+                stateName: 'connecting',
+                isConnected: false,
+            });
+
+            const result = await useCase.execute();
+
+            expect(result).toEqual({
+                status: 'unhealthy',
+                state: 'connecting',
+            });
+            expect(mockRepository.pingDatabase).not.toHaveBeenCalled();
+        });
+
+        it('should return unhealthy status when database is disconnecting', async () => {
+            mockRepository.getDatabaseConnectionState.mockResolvedValue({
+                readyState: 3,
+                stateName: 'disconnecting',
+                isConnected: false,
+            });
+
+            const result = await useCase.execute();
+
+            expect(result).toEqual({
+                status: 'unhealthy',
+                state: 'disconnecting',
+            });
+        });
+
+        it('should not include responseTime when database is unhealthy', async () => {
+            mockRepository.getDatabaseConnectionState.mockResolvedValue({
+                readyState: 0,
+                stateName: 'disconnected',
+                isConnected: false,
+            });
+
+            const result = await useCase.execute();
+
+            expect(result.responseTime).toBeUndefined();
+        });
+
+        it('should handle connection state check errors gracefully', async () => {
+            mockRepository.getDatabaseConnectionState.mockRejectedValue(
+                new Error('Failed to check connection')
+            );
+
+            await expect(useCase.execute()).rejects.toThrow('Failed to check connection');
+        });
+
+        it('should handle ping errors when database appears connected', async () => {
+            mockRepository.getDatabaseConnectionState.mockResolvedValue({
+                readyState: 1,
+                stateName: 'connected',
+                isConnected: true,
+            });
+            mockRepository.pingDatabase.mockRejectedValue(
+                new Error('Ping timeout')
+            );
+
+            await expect(useCase.execute()).rejects.toThrow('Ping timeout');
+        });
+
+        it('should pass timeout parameter to pingDatabase', async () => {
+            mockRepository.getDatabaseConnectionState.mockResolvedValue({
+                readyState: 1,
+                stateName: 'connected',
+                isConnected: true,
+            });
+            mockRepository.pingDatabase.mockResolvedValue(10);
+
+            await useCase.execute();
+
+            expect(mockRepository.pingDatabase).toHaveBeenCalledWith(2000);
+        });
+    });
+});
+

--- a/packages/core/database/use-cases/check-database-health-use-case.test.js
+++ b/packages/core/database/use-cases/check-database-health-use-case.test.js
@@ -1,9 +1,3 @@
-/**
- * Tests for CheckDatabaseHealthUseCase
- * 
- * Tests business logic for database health checking
- */
-
 const { CheckDatabaseHealthUseCase } = require('./check-database-health-use-case');
 
 describe('CheckDatabaseHealthUseCase', () => {

--- a/packages/core/handlers/routers/health.js
+++ b/packages/core/handlers/routers/health.js
@@ -14,6 +14,7 @@ const {
 const {
     createHealthCheckRepository,
 } = require('../../database/repositories/health-check-repository-factory');
+const { prisma } = require('../../database/prisma');
 const {
     TestEncryptionUseCase,
 } = require('../../database/use-cases/test-encryption-use-case');
@@ -31,7 +32,7 @@ const {
 } = require('../use-cases/check-integrations-health-use-case');
 
 const router = Router();
-const healthCheckRepository = createHealthCheckRepository();
+const healthCheckRepository = createHealthCheckRepository({ prismaClient: prisma });
 
 // Load integrations and create factories just like auth router does
 // This verifies the system can properly load integrations


### PR DESCRIPTION
Added better health check for when we run /health/detailed

Now uses prisma and not mongoose.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.487.63ed8db.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.487.63ed8db.0
  npm install @friggframework/devtools@2.0.0--canary.487.63ed8db.0
  npm install @friggframework/eslint-config@2.0.0--canary.487.63ed8db.0
  npm install @friggframework/prettier-config@2.0.0--canary.487.63ed8db.0
  npm install @friggframework/schemas@2.0.0--canary.487.63ed8db.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.487.63ed8db.0
  npm install @friggframework/test@2.0.0--canary.487.63ed8db.0
  npm install @friggframework/ui@2.0.0--canary.487.63ed8db.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.487.63ed8db.0
  yarn add @friggframework/devtools@2.0.0--canary.487.63ed8db.0
  yarn add @friggframework/eslint-config@2.0.0--canary.487.63ed8db.0
  yarn add @friggframework/prettier-config@2.0.0--canary.487.63ed8db.0
  yarn add @friggframework/schemas@2.0.0--canary.487.63ed8db.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.487.63ed8db.0
  yarn add @friggframework/test@2.0.0--canary.487.63ed8db.0
  yarn add @friggframework/ui@2.0.0--canary.487.63ed8db.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
