### PR TITLE
Refactor integration mapping to use plain object for DTO conversion

### DIFF
--- a/packages/core/integrations/use-cases/get-integrations-for-user.js
+++ b/packages/core/integrations/use-cases/get-integrations-for-user.js
@@ -64,7 +64,7 @@ class GetIntegrationsForUser {
                 modules.push(moduleInstance);
             }
 
-            const integrationInstance = new integrationClass({
+            const integrationData = {
                 id: integrationRecord.id,
                 userId: integrationRecord.userId,
                 entities: entities,
@@ -73,10 +73,11 @@ class GetIntegrationsForUser {
                 version: integrationRecord.version,
                 messages: integrationRecord.messages,
                 modules,
-            });
+                options: integrationClass.getOptionDetails(),
+            };
 
             integrations.push(
-                mapIntegrationClassToIntegrationDTO(integrationInstance)
+                mapIntegrationClassToIntegrationDTO(integrationData)
             );
         }
 

--- a/packages/core/integrations/utils/map-integration-dto.js
+++ b/packages/core/integrations/utils/map-integration-dto.js
@@ -1,6 +1,7 @@
 /**
  * @param {import('../integration').Integration} integration
  * Convert an Integration domain instance to a plain DTO suitable for JSON responses.
+ * Can also accept a plain object with an 'options' property to avoid unnecessary instantiation.
  */
 function mapIntegrationClassToIntegrationDTO(integration) {
     if (!integration) return null;
@@ -14,7 +15,7 @@ function mapIntegrationClassToIntegrationDTO(integration) {
         version: integration.version,
         messages: integration.messages,
         userActions: integration.userActions,
-        options: integration.getOptionDetails(),
+        options: integration.options || (typeof integration.getOptionDetails === 'function' ? integration.getOptionDetails() : null),
     };
 }
 


### PR DESCRIPTION
- Updated `GetIntegrationsForUser` to create an integration data object instead of instantiating the integration class directly.
- Modified `mapIntegrationClassToIntegrationDTO` to accept a plain object with an 'options' property, allowing for more flexible integration handling without unnecessary instantiation.

This change enhances the efficiency of integration data processing and improves the overall code structure.