### PR TITLE
fix: make sure messages is not undefined

### DIFF
--- a/packages/core/integrations/use-cases/get-integrations-for-user.js
+++ b/packages/core/integrations/use-cases/get-integrations-for-user.js
@@ -71,7 +71,7 @@ class GetIntegrationsForUser {
                 config: integrationRecord.config,
                 status: integrationRecord.status,
                 version: integrationRecord.version,
-                messages: integrationRecord.messages,
+                messages: integrationRecord.messages || { errors: [], warnings: [] },
                 modules,
                 options: integrationClass.getOptionDetails(),
             };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.492.669f13d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.492.669f13d.0
  npm install @friggframework/devtools@2.0.0--canary.492.669f13d.0
  npm install @friggframework/eslint-config@2.0.0--canary.492.669f13d.0
  npm install @friggframework/prettier-config@2.0.0--canary.492.669f13d.0
  npm install @friggframework/schemas@2.0.0--canary.492.669f13d.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.492.669f13d.0
  npm install @friggframework/test@2.0.0--canary.492.669f13d.0
  npm install @friggframework/ui@2.0.0--canary.492.669f13d.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.492.669f13d.0
  yarn add @friggframework/devtools@2.0.0--canary.492.669f13d.0
  yarn add @friggframework/eslint-config@2.0.0--canary.492.669f13d.0
  yarn add @friggframework/prettier-config@2.0.0--canary.492.669f13d.0
  yarn add @friggframework/schemas@2.0.0--canary.492.669f13d.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.492.669f13d.0
  yarn add @friggframework/test@2.0.0--canary.492.669f13d.0
  yarn add @friggframework/ui@2.0.0--canary.492.669f13d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
