### PR TITLE
feat: add deleteUserById command for user cleanup

### DIFF
--- a/packages/core/application/commands/user-commands.js
+++ b/packages/core/application/commands/user-commands.js
@@ -235,6 +235,38 @@ function createUserCommands() {
                 return mapErrorToResponse(error);
             }
         },
+
+        /**
+         * Delete a user by ID
+         * Cascades to all related records (credentials, entities, integrations, etc.)
+         * @param {string} userId - User ID to delete
+         * @returns {Promise<Object>} Deletion result
+         */
+        async deleteUserById(userId) {
+            try {
+                if (!userId) {
+                    const error = new Error('userId is required');
+                    error.code = 'INVALID_USER_DATA';
+                    throw error;
+                }
+
+                const deleted = await userRepository.deleteUser(userId);
+
+                if (!deleted) {
+                    const error = new Error(`User ${userId} not found`);
+                    error.code = 'USER_NOT_FOUND';
+                    return mapErrorToResponse(error);
+                }
+
+                return {
+                    success: true,
+                    userId,
+                    message: 'User and all related data deleted successfully',
+                };
+            } catch (error) {
+                return mapErrorToResponse(error);
+            }
+        },
     };
 }
 


### PR DESCRIPTION
Add deleteUserById() command to support user disconnection/deletion. This command cascades to all related records (credentials, entities, integrations, etc.) via Prisma's onDelete: Cascade configuration.

Returns:
- success: true on successful deletion
- error: 404 if user not found
- error: 400 for invalid input