### PR TITLE
Fix/delete user cascading

### DIFF
--- a/packages/core/application/commands/credential-commands.js
+++ b/packages/core/application/commands/credential-commands.js
@@ -215,6 +215,27 @@ function createCredentialCommands() {
                 return mapErrorToResponse(error);
             }
         },
+
+        /**
+         * Delete a credential by ID (alias for deleteCredential)
+         * @param {string} credentialId - Credential ID to delete
+         * @returns {Promise<Object>} Result object with success flag
+         */
+        async deleteCredentialById(credentialId) {
+            try {
+                if (!credentialId) {
+                    const error = new Error('credentialId is required');
+                    error.code = 'INVALID_CREDENTIAL_DATA';
+                    throw error;
+                }
+
+                await credRepo.deleteCredentialById(credentialId);
+
+                return { success: true };
+            } catch (error) {
+                return mapErrorToResponse(error);
+            }
+        },
     };
 }
 

--- a/packages/core/application/commands/entity-commands.js
+++ b/packages/core/application/commands/entity-commands.js
@@ -287,6 +287,27 @@ function createEntityCommands() {
         },
 
         /**
+         * Delete an entity by ID (alias for deleteEntity)
+         * @param {string} entityId - Entity ID to delete
+         * @returns {Promise<Object>} Result object with success flag
+         */
+        async deleteEntityById(entityId) {
+            try {
+                if (!entityId) {
+                    const error = new Error('entityId is required');
+                    error.code = 'INVALID_ENTITY_DATA';
+                    throw error;
+                }
+
+                await moduleRepo.deleteEntity(entityId);
+
+                return { success: true };
+            } catch (error) {
+                return mapErrorToResponse(error);
+            }
+        },
+
+        /**
          * Remove credential reference from an entity
          * @param {string} entityId - Entity ID to update
          * @returns {Promise<Object>} Result object with success flag

--- a/packages/core/application/commands/integration-commands.js
+++ b/packages/core/application/commands/integration-commands.js
@@ -161,6 +161,37 @@ function createIntegrationCommands({ integrationClass }) {
                 return mapErrorToResponse(error);
             }
         },
+
+        /**
+         * Delete an integration by ID
+         * @param {string} integrationId - Integration ID to delete
+         * @returns {Promise<Object>} Deletion result
+         */
+        async deleteIntegrationById(integrationId) {
+            try {
+                if (!integrationId) {
+                    const error = new Error('integrationId is required');
+                    error.code = 'INVALID_INTEGRATION_DATA';
+                    throw error;
+                }
+
+                const deleted = await integrationRepository.deleteIntegrationById(integrationId);
+
+                if (!deleted) {
+                    const error = new Error(`Integration ${integrationId} not found`);
+                    error.code = 'INTEGRATION_NOT_FOUND';
+                    return mapErrorToResponse(error);
+                }
+
+                return {
+                    success: true,
+                    integrationId,
+                    message: 'Integration deleted successfully',
+                };
+            } catch (error) {
+                return mapErrorToResponse(error);
+            }
+        },
     };
 }
 

--- a/packages/core/application/commands/integration-commands.test.js
+++ b/packages/core/application/commands/integration-commands.test.js
@@ -120,4 +120,29 @@ describe('integration commands', () => {
         });
         expect(result).toEqual({ context: expectedContext });
     });
+
+    describe('deleteIntegrationById', () => {
+        it('returns error if integrationId is missing', async () => {
+            const commands = createIntegrationCommands({
+                integrationClass: DummyIntegration,
+            });
+
+            const result = await commands.deleteIntegrationById(null);
+
+            expect(result).toHaveProperty('error');
+            expect(result.reason).toContain('integrationId is required');
+        });
+
+        it('calls repository deleteIntegrationById', async () => {
+            const commands = createIntegrationCommands({
+                integrationClass: DummyIntegration,
+            });
+
+            // Will fail since no real database, but verifies the method exists and is wired up
+            const result = await commands.deleteIntegrationById('integration-123');
+
+            // Expect error since no real DB connection
+            expect(result).toHaveProperty('error');
+        });
+    });
 });

--- a/packages/core/application/commands/user-commands.js
+++ b/packages/core/application/commands/user-commands.js
@@ -238,7 +238,14 @@ function createUserCommands() {
 
         /**
          * Delete a user by ID
-         * Cascades to all related records (credentials, entities, integrations, etc.)
+         *
+         * IMPORTANT: This does NOT automatically cascade delete related records in MongoDB.
+         * Integration developers MUST manually delete related data first:
+         * 1. Delete integrations (via deleteIntegrationById)
+         * 2. Delete entities (via deleteEntityById)
+         * 3. Delete credentials (via deleteCredentialById)
+         * 4. Finally delete user (via deleteUserById)
+         *
          * @param {string} userId - User ID to delete
          * @returns {Promise<Object>} Deletion result
          */
@@ -261,7 +268,7 @@ function createUserCommands() {
                 return {
                     success: true,
                     userId,
-                    message: 'User and all related data deleted successfully',
+                    message: 'User deleted successfully',
                 };
             } catch (error) {
                 return mapErrorToResponse(error);

--- a/packages/core/user/repositories/user-repository-mongo.js
+++ b/packages/core/user/repositories/user-repository-mongo.js
@@ -259,6 +259,15 @@ class UserRepositoryMongo extends UserRepositoryInterface {
 
     /**
      * Delete user by ID
+     *
+     * NOTE: This only deletes the user record itself.
+     * Prisma's onDelete: Cascade does NOT work reliably with MongoDB (no database-level referential integrity).
+     * Integration developers MUST manually cascade delete related records before calling this method:
+     * 1. Delete integrations (via deleteIntegrationById)
+     * 2. Delete entities (via deleteEntityById)
+     * 3. Delete credentials (via deleteCredentialById)
+     * 4. Finally delete user (via deleteUserById)
+     *
      * @param {string} userId - User ID to delete
      * @returns {Promise<boolean>} True if deleted successfully
      */


### PR DESCRIPTION
## Summary
  - Added `deleteIntegrationById` command to integration-commands
  - Added `deleteCredentialById` and `deleteEntityById` aliases for consistency
  - Updated `deleteUserById` documentation to clarify manual cascade requirement
  - Documented that Prisma's `onDelete: Cascade` doesn't work reliably with MongoDB

  ## Problem
  When deleting a user, orphaned entities, credentials, and integrations remained in the database because Prisma's referential actions don't work with MongoDB (no database-level
  referential integrity).

  ## Solution
  Integration developers must now manually cascade delete in the correct order:
  1. Delete integrations (`deleteIntegrationById`)
  2. Delete entities (`deleteEntityById`)
  3. Delete credentials (`deleteCredentialById`)
  4. Delete user (`deleteUserById`)

  ## Testing
  Tested with Canva integration disconnect feature - all related records now properly deleted.

  ## Breaking Changes
  None - added new methods and improved documentation. Existing behavior unchanged.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.60`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/core`
    - Fix/delete user cascading [#509](https://github.com/friggframework/frigg/pull/509) ([@roboli](https://github.com/roboli))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - feat: add deleteUserById command for user cleanup [#508](https://github.com/friggframework/frigg/pull/508) ([@roboli](https://github.com/roboli))
  
  #### Authors: 1
  
  - Roberto Oliveros ([@roboli](https://github.com/roboli))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
