### PR TITLE
feat(cli): add frigg validate command with auto-detection

### DIFF
--- a/packages/devtools/frigg-cli/index.js
+++ b/packages/devtools/frigg-cli/index.js
@@ -85,6 +85,7 @@ const { uiCommand } = require('./ui-command');
 const { dbSetupCommand } = require('./db-setup-command');
 const { doctorCommand } = require('./doctor-command');
 const { repairCommand } = require('./repair-command');
+const { createValidateCommand } = require('./validate-command/adapters/cli/validate-command');
 
 const program = new Command();
 
@@ -168,9 +169,11 @@ program
     .option('-v, --verbose', 'enable verbose output')
     .action(repairCommand);
 
+createValidateCommand(program);
+
 // Only parse arguments when run directly, not when imported by tests
 if (require.main === module) {
     program.parse(process.argv);
 }
 
-module.exports = { initCommand, installCommand, startCommand, buildCommand, deployCommand, generateIamCommand, uiCommand, dbSetupCommand, doctorCommand, repairCommand, program };
+module.exports = { initCommand, installCommand, startCommand, buildCommand, deployCommand, generateIamCommand, uiCommand, dbSetupCommand, doctorCommand, repairCommand, createValidateCommand, program };

--- a/packages/devtools/frigg-cli/validate-command/__tests__/adapters/validate-command.test.js
+++ b/packages/devtools/frigg-cli/validate-command/__tests__/adapters/validate-command.test.js
@@ -1,0 +1,205 @@
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const {
+    createValidateCommand,
+    formatConsoleOutput,
+    autoDetectFriggApp,
+    findBackendPathInDir,
+    findBackendPath
+} = require('../../adapters/cli/validate-command');
+const { ValidationResult } = require('../../domain/entities/validation-result');
+const { ValidationError } = require('../../domain/value-objects/validation-error');
+const { FixSuggestion } = require('../../domain/value-objects/fix-suggestion');
+const { Command } = require('commander');
+
+describe('validateCommand', () => {
+    let mockOutput;
+
+    beforeEach(() => {
+        mockOutput = {
+            info: jest.fn(),
+            success: jest.fn(),
+            error: jest.fn(),
+            warn: jest.fn(),
+            log: jest.fn()
+        };
+    });
+
+    describe('createValidateCommand', () => {
+        it('registers validate command on program', () => {
+            const program = new Command();
+            createValidateCommand(program);
+            const validateCmd = program.commands.find(c => c.name() === 'validate');
+            expect(validateCmd).toBeDefined();
+        });
+
+        it('has required options', () => {
+            const program = new Command();
+            createValidateCommand(program);
+            const validateCmd = program.commands.find(c => c.name() === 'validate');
+            const options = validateCmd.options.map(o => o.long);
+            expect(options).toContain('--format');
+            expect(options).toContain('--verbose');
+        });
+    });
+
+    describe('formatConsoleOutput', () => {
+        it('outputs success for valid result', () => {
+            const result = ValidationResult.create();
+            formatConsoleOutput(result, {}, mockOutput);
+            expect(mockOutput.success).toHaveBeenCalled();
+        });
+
+        it('outputs errors for invalid result', () => {
+            const error = ValidationError.create({
+                path: 'integrations',
+                message: 'Missing integrations',
+                severity: 'error'
+            });
+            const result = ValidationResult.create({ errors: [error] });
+            formatConsoleOutput(result, {}, mockOutput);
+            const logCalls = mockOutput.log.mock.calls.flat().join(' ');
+            expect(logCalls).toContain('Missing integrations');
+        });
+
+        it('outputs warnings', () => {
+            const warning = ValidationError.create({
+                path: 'database',
+                message: 'No database configured',
+                severity: 'warning'
+            });
+            const result = ValidationResult.create({ errors: [warning] });
+            formatConsoleOutput(result, {}, mockOutput);
+            expect(mockOutput.warn).toHaveBeenCalled();
+        });
+
+        it('shows fix suggestions in verbose mode', () => {
+            const fix = FixSuggestion.create({ action: 'add', description: 'Add database configuration' });
+            const error = ValidationError.create({
+                path: 'database',
+                message: 'Missing config',
+                severity: 'error',
+                fix
+            });
+            const result = ValidationResult.create({ errors: [error] });
+            formatConsoleOutput(result, { verbose: true }, mockOutput);
+            const logCalls = mockOutput.log.mock.calls.flat().join(' ');
+            expect(logCalls).toContain('Add database configuration');
+        });
+    });
+
+    describe('findBackendPathInDir', () => {
+        let tmpDir;
+
+        beforeEach(() => {
+            tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'frigg-test-'));
+        });
+
+        afterEach(() => {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        });
+
+        it('finds backend/index.js', () => {
+            const backendDir = path.join(tmpDir, 'backend');
+            fs.mkdirSync(backendDir);
+            fs.writeFileSync(path.join(backendDir, 'index.js'), 'module.exports = {}');
+            expect(findBackendPathInDir(tmpDir)).toBe(backendDir);
+        });
+
+        it('finds index.js with integrations keyword', () => {
+            fs.writeFileSync(path.join(tmpDir, 'index.js'), 'module.exports = { integrations: [] }');
+            expect(findBackendPathInDir(tmpDir)).toBe(tmpDir);
+        });
+
+        it('finds index.js with Definition keyword', () => {
+            fs.writeFileSync(path.join(tmpDir, 'index.js'), 'module.exports = { Definition: {} }');
+            expect(findBackendPathInDir(tmpDir)).toBe(tmpDir);
+        });
+
+        it('returns null for non-frigg directory', () => {
+            fs.writeFileSync(path.join(tmpDir, 'index.js'), 'console.log("hello")');
+            expect(findBackendPathInDir(tmpDir)).toBeNull();
+        });
+
+        it('returns null for empty directory', () => {
+            expect(findBackendPathInDir(tmpDir)).toBeNull();
+        });
+    });
+
+    describe('findBackendPath', () => {
+        let tmpDir;
+
+        beforeEach(() => {
+            tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'frigg-test-'));
+        });
+
+        afterEach(() => {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        });
+
+        it('finds backend subdirectory with package.json', () => {
+            const backendDir = path.join(tmpDir, 'backend');
+            fs.mkdirSync(backendDir);
+            fs.writeFileSync(path.join(backendDir, 'package.json'), '{}');
+            expect(findBackendPath(tmpDir)).toBe(backendDir);
+        });
+
+        it('finds backend subdirectory with index.js', () => {
+            const backendDir = path.join(tmpDir, 'backend');
+            fs.mkdirSync(backendDir);
+            fs.writeFileSync(path.join(backendDir, 'index.js'), 'module.exports = {}');
+            expect(findBackendPath(tmpDir)).toBe(backendDir);
+        });
+
+        it('returns path itself if it has package.json', () => {
+            fs.writeFileSync(path.join(tmpDir, 'package.json'), '{}');
+            expect(findBackendPath(tmpDir)).toBe(tmpDir);
+        });
+
+        it('returns null for non-backend directory', () => {
+            expect(findBackendPath(tmpDir)).toBeNull();
+        });
+    });
+
+    describe('autoDetectFriggApp', () => {
+        let tmpDir;
+
+        beforeEach(() => {
+            tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'frigg-test-'));
+        });
+
+        afterEach(() => {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        });
+
+        it('detects frigg app in current directory', () => {
+            const backendDir = path.join(tmpDir, 'backend');
+            fs.mkdirSync(backendDir);
+            fs.writeFileSync(path.join(backendDir, 'index.js'), 'module.exports = {}');
+            const result = autoDetectFriggApp(tmpDir);
+            expect(result).toEqual({
+                appRoot: tmpDir,
+                backendPath: backendDir
+            });
+        });
+
+        it('detects frigg app in parent directory', () => {
+            const backendDir = path.join(tmpDir, 'backend');
+            const subDir = path.join(tmpDir, 'src', 'components');
+            fs.mkdirSync(backendDir);
+            fs.mkdirSync(subDir, { recursive: true });
+            fs.writeFileSync(path.join(backendDir, 'index.js'), 'module.exports = {}');
+            const result = autoDetectFriggApp(subDir);
+            expect(result).toEqual({
+                appRoot: tmpDir,
+                backendPath: backendDir
+            });
+        });
+
+        it('returns null when no frigg app found', () => {
+            const result = autoDetectFriggApp(tmpDir);
+            expect(result).toBeNull();
+        });
+    });
+});

--- a/packages/devtools/frigg-cli/validate-command/__tests__/application/validate-app-use-case.test.js
+++ b/packages/devtools/frigg-cli/validate-command/__tests__/application/validate-app-use-case.test.js
@@ -1,0 +1,104 @@
+const { ValidateAppUseCase } = require('../../application/use-cases/validate-app-use-case');
+
+describe('ValidateAppUseCase', () => {
+    let useCase;
+    let mockAppDefinitionValidator;
+    let mockIntegrationClassValidator;
+
+    beforeEach(() => {
+        mockAppDefinitionValidator = {
+            validate: jest.fn()
+        };
+        mockIntegrationClassValidator = {
+            validate: jest.fn()
+        };
+        useCase = new ValidateAppUseCase({
+            appDefinitionValidator: mockAppDefinitionValidator,
+            integrationClassValidator: mockIntegrationClassValidator
+        });
+    });
+
+    describe('execute', () => {
+        it('validates app definition structure', async () => {
+            const { ValidationResult } = require('../../domain/entities/validation-result');
+            mockAppDefinitionValidator.validate.mockReturnValue(ValidationResult.create());
+            mockIntegrationClassValidator.validate.mockReturnValue(ValidationResult.create());
+
+            const definition = { integrations: [] };
+            await useCase.execute({ definition });
+
+            expect(mockAppDefinitionValidator.validate).toHaveBeenCalledWith(definition);
+        });
+
+        it('validates each integration class', async () => {
+            const { ValidationResult } = require('../../domain/entities/validation-result');
+            mockAppDefinitionValidator.validate.mockReturnValue(ValidationResult.create());
+            mockIntegrationClassValidator.validate.mockReturnValue(ValidationResult.create());
+
+            class Int1 { static Definition = { name: 'int1' }; }
+            class Int2 { static Definition = { name: 'int2' }; }
+            const definition = { integrations: [Int1, Int2] };
+
+            await useCase.execute({ definition });
+
+            expect(mockIntegrationClassValidator.validate).toHaveBeenCalledWith(Int1, 0);
+            expect(mockIntegrationClassValidator.validate).toHaveBeenCalledWith(Int2, 1);
+        });
+
+        it('merges all validation results', async () => {
+            const { ValidationResult } = require('../../domain/entities/validation-result');
+            const { ValidationError } = require('../../domain/value-objects/validation-error');
+
+            const appError = ValidationError.create({ path: 'database', message: 'missing', severity: 'error' });
+            const intError = ValidationError.create({ path: 'integrations[0]', message: 'invalid', severity: 'error' });
+
+            mockAppDefinitionValidator.validate.mockReturnValue(
+                ValidationResult.create({ errors: [appError] })
+            );
+            mockIntegrationClassValidator.validate.mockReturnValue(
+                ValidationResult.create({ errors: [intError] })
+            );
+
+            class Int1 { static Definition = { name: 'int1' }; }
+            const definition = { integrations: [Int1] };
+
+            const result = await useCase.execute({ definition });
+
+            expect(result.getErrors()).toHaveLength(2);
+        });
+
+        it('returns valid result when no errors', async () => {
+            const { ValidationResult } = require('../../domain/entities/validation-result');
+            mockAppDefinitionValidator.validate.mockReturnValue(ValidationResult.create());
+            mockIntegrationClassValidator.validate.mockReturnValue(ValidationResult.create());
+
+            const definition = { integrations: [] };
+            const result = await useCase.execute({ definition });
+
+            expect(result.isValid()).toBe(true);
+        });
+
+        it('adds context with definition metadata', async () => {
+            const { ValidationResult } = require('../../domain/entities/validation-result');
+            mockAppDefinitionValidator.validate.mockReturnValue(ValidationResult.create());
+
+            const definition = { integrations: [] };
+            const result = await useCase.execute({ definition, appPath: '/app/backend' });
+
+            expect(result.getContext()).toMatchObject({ appPath: '/app/backend' });
+        });
+    });
+
+    describe('error handling', () => {
+        it('handles validator throwing error', async () => {
+            mockAppDefinitionValidator.validate.mockImplementation(() => {
+                throw new Error('Validator crashed');
+            });
+
+            const definition = { integrations: [] };
+
+            await expect(useCase.execute({ definition }))
+                .rejects.toThrow('Validator crashed');
+        });
+    });
+});

--- a/packages/devtools/frigg-cli/validate-command/__tests__/domain/fix-suggestion.test.js
+++ b/packages/devtools/frigg-cli/validate-command/__tests__/domain/fix-suggestion.test.js
@@ -1,0 +1,153 @@
+const { FixSuggestion } = require('../../domain/value-objects/fix-suggestion');
+
+describe('FixSuggestion', () => {
+    describe('creation', () => {
+        it('creates fix with action and description', () => {
+            const fix = FixSuggestion.create({
+                action: 'add',
+                description: 'Add the name field to the configuration'
+            });
+            expect(fix.action).toBe('add');
+            expect(fix.description).toBe('Add the name field to the configuration');
+        });
+
+        it('creates fix with template', () => {
+            const fix = FixSuggestion.create({
+                action: 'add',
+                description: 'Add database configuration',
+                template: { database: { mongoDB: { enable: true } } }
+            });
+            expect(fix.template).toEqual({ database: { mongoDB: { enable: true } } });
+        });
+
+        it('creates fix with code snippet', () => {
+            const fix = FixSuggestion.create({
+                action: 'replace',
+                description: 'Update the export',
+                codeSnippet: 'module.exports = { Definition };'
+            });
+            expect(fix.codeSnippet).toBe('module.exports = { Definition };');
+        });
+
+        it('throws for missing action', () => {
+            expect(() => FixSuggestion.create({ description: 'Fix it' }))
+                .toThrow('action is required');
+        });
+
+        it('throws for missing description', () => {
+            expect(() => FixSuggestion.create({ action: 'add' }))
+                .toThrow('description is required');
+        });
+
+        it('throws for invalid action', () => {
+            expect(() => FixSuggestion.create({ action: 'destroy', description: 'd' }))
+                .toThrow('Invalid action');
+        });
+    });
+
+    describe('actions', () => {
+        it('supports add action', () => {
+            const fix = FixSuggestion.create({ action: 'add', description: 'd' });
+            expect(fix.isAdd()).toBe(true);
+            expect(fix.isRemove()).toBe(false);
+        });
+
+        it('supports remove action', () => {
+            const fix = FixSuggestion.create({ action: 'remove', description: 'd' });
+            expect(fix.isRemove()).toBe(true);
+        });
+
+        it('supports replace action', () => {
+            const fix = FixSuggestion.create({ action: 'replace', description: 'd' });
+            expect(fix.isReplace()).toBe(true);
+        });
+
+        it('supports rename action', () => {
+            const fix = FixSuggestion.create({ action: 'rename', description: 'd' });
+            expect(fix.isRename()).toBe(true);
+        });
+
+        it('supports update action', () => {
+            const fix = FixSuggestion.create({ action: 'update', description: 'd' });
+            expect(fix.isUpdate()).toBe(true);
+        });
+    });
+
+    describe('applicability', () => {
+        it('is auto-applicable with template', () => {
+            const fix = FixSuggestion.create({
+                action: 'add',
+                description: 'd',
+                template: { key: 'value' }
+            });
+            expect(fix.isAutoApplicable()).toBe(true);
+        });
+
+        it('is auto-applicable with code snippet', () => {
+            const fix = FixSuggestion.create({
+                action: 'replace',
+                description: 'd',
+                codeSnippet: 'const x = 1;'
+            });
+            expect(fix.isAutoApplicable()).toBe(true);
+        });
+
+        it('is not auto-applicable without template or snippet', () => {
+            const fix = FixSuggestion.create({ action: 'add', description: 'd' });
+            expect(fix.isAutoApplicable()).toBe(false);
+        });
+    });
+
+    describe('target', () => {
+        it('sets target path', () => {
+            const fix = FixSuggestion.create({
+                action: 'add',
+                description: 'd',
+                targetPath: 'config.database'
+            });
+            expect(fix.targetPath).toBe('config.database');
+        });
+
+        it('sets target file', () => {
+            const fix = FixSuggestion.create({
+                action: 'update',
+                description: 'd',
+                targetFile: 'backend/index.js'
+            });
+            expect(fix.targetFile).toBe('backend/index.js');
+        });
+    });
+
+    describe('serialization', () => {
+        it('converts to JSON', () => {
+            const fix = FixSuggestion.create({
+                action: 'add',
+                description: 'Add config',
+                template: { key: 'value' },
+                targetPath: 'config'
+            });
+            const json = fix.toJSON();
+            expect(json).toEqual({
+                action: 'add',
+                description: 'Add config',
+                template: { key: 'value' },
+                codeSnippet: null,
+                targetPath: 'config',
+                targetFile: null
+            });
+        });
+    });
+
+    describe('formatting', () => {
+        it('formats for console display', () => {
+            const fix = FixSuggestion.create({
+                action: 'add',
+                description: 'Add the name field',
+                template: { name: 'my-app' }
+            });
+            const formatted = fix.format();
+            expect(formatted).toContain('add');
+            expect(formatted).toContain('Add the name field');
+        });
+    });
+});

--- a/packages/devtools/frigg-cli/validate-command/__tests__/domain/validation-error.test.js
+++ b/packages/devtools/frigg-cli/validate-command/__tests__/domain/validation-error.test.js
@@ -1,0 +1,162 @@
+const { ValidationError } = require('../../domain/value-objects/validation-error');
+const { FixSuggestion } = require('../../domain/value-objects/fix-suggestion');
+
+describe('ValidationError', () => {
+    describe('creation', () => {
+        it('creates error with required fields', () => {
+            const error = ValidationError.create({
+                path: 'integrations[0].name',
+                message: 'Integration name is required'
+            });
+            expect(error.path).toBe('integrations[0].name');
+            expect(error.message).toBe('Integration name is required');
+            expect(error.severity).toBe('error');
+        });
+
+        it('creates error with custom severity', () => {
+            const warning = ValidationError.create({
+                path: 'config.timeout',
+                message: 'Timeout value seems high',
+                severity: 'warning'
+            });
+            expect(warning.severity).toBe('warning');
+            expect(warning.isWarning()).toBe(true);
+            expect(warning.isError()).toBe(false);
+        });
+
+        it('creates error with fix suggestion', () => {
+            const fix = FixSuggestion.create({
+                action: 'add',
+                description: 'Add the name field to integration'
+            });
+            const error = ValidationError.create({
+                path: 'integrations[0].name',
+                message: 'Required field missing',
+                fix
+            });
+            expect(error.fix).toBe(fix);
+            expect(error.hasFix()).toBe(true);
+        });
+
+        it('throws for missing path', () => {
+            expect(() => ValidationError.create({ message: 'error' }))
+                .toThrow('path is required');
+        });
+
+        it('throws for missing message', () => {
+            expect(() => ValidationError.create({ path: 'a.b' }))
+                .toThrow('message is required');
+        });
+
+        it('throws for invalid severity', () => {
+            expect(() => ValidationError.create({
+                path: 'a',
+                message: 'b',
+                severity: 'critical'
+            })).toThrow('Invalid severity');
+        });
+    });
+
+    describe('path parsing', () => {
+        it('parses simple path', () => {
+            const error = ValidationError.create({ path: 'name', message: 'm' });
+            expect(error.getPathSegments()).toEqual(['name']);
+        });
+
+        it('parses nested path', () => {
+            const error = ValidationError.create({ path: 'config.database.uri', message: 'm' });
+            expect(error.getPathSegments()).toEqual(['config', 'database', 'uri']);
+        });
+
+        it('parses array path', () => {
+            const error = ValidationError.create({ path: 'integrations[0].modules[1].name', message: 'm' });
+            expect(error.getPathSegments()).toEqual(['integrations', '0', 'modules', '1', 'name']);
+        });
+
+        it('gets root path', () => {
+            const error = ValidationError.create({ path: 'integrations[0].config.timeout', message: 'm' });
+            expect(error.getRootPath()).toBe('integrations');
+        });
+    });
+
+    describe('severity helpers', () => {
+        it('identifies error severity', () => {
+            const error = ValidationError.create({ path: 'a', message: 'm', severity: 'error' });
+            expect(error.isError()).toBe(true);
+            expect(error.isWarning()).toBe(false);
+            expect(error.isInfo()).toBe(false);
+        });
+
+        it('identifies warning severity', () => {
+            const error = ValidationError.create({ path: 'a', message: 'm', severity: 'warning' });
+            expect(error.isError()).toBe(false);
+            expect(error.isWarning()).toBe(true);
+        });
+
+        it('identifies info severity', () => {
+            const error = ValidationError.create({ path: 'a', message: 'm', severity: 'info' });
+            expect(error.isError()).toBe(false);
+            expect(error.isInfo()).toBe(true);
+        });
+    });
+
+    describe('code', () => {
+        it('assigns error code', () => {
+            const error = ValidationError.create({
+                path: 'name',
+                message: 'Required',
+                code: 'REQUIRED_FIELD'
+            });
+            expect(error.code).toBe('REQUIRED_FIELD');
+        });
+
+        it('defaults to null code', () => {
+            const error = ValidationError.create({ path: 'a', message: 'm' });
+            expect(error.code).toBeNull();
+        });
+    });
+
+    describe('serialization', () => {
+        it('converts to JSON', () => {
+            const error = ValidationError.create({
+                path: 'config.name',
+                message: 'Name required',
+                severity: 'error',
+                code: 'REQUIRED'
+            });
+            const json = error.toJSON();
+            expect(json).toEqual({
+                path: 'config.name',
+                message: 'Name required',
+                severity: 'error',
+                code: 'REQUIRED',
+                fix: null
+            });
+        });
+
+        it('includes fix in JSON', () => {
+            const fix = FixSuggestion.create({ action: 'add', description: 'Add field' });
+            const error = ValidationError.create({
+                path: 'a',
+                message: 'm',
+                fix
+            });
+            const json = error.toJSON();
+            expect(json.fix).toMatchObject({ action: 'add', description: 'Add field' });
+        });
+    });
+
+    describe('equality', () => {
+        it('considers errors equal by path and message', () => {
+            const error1 = ValidationError.create({ path: 'a.b', message: 'Required' });
+            const error2 = ValidationError.create({ path: 'a.b', message: 'Required' });
+            expect(error1.equals(error2)).toBe(true);
+        });
+
+        it('considers errors different by path', () => {
+            const error1 = ValidationError.create({ path: 'a.b', message: 'Required' });
+            const error2 = ValidationError.create({ path: 'a.c', message: 'Required' });
+            expect(error1.equals(error2)).toBe(false);
+        });
+    });
+});

--- a/packages/devtools/frigg-cli/validate-command/__tests__/domain/validation-result.test.js
+++ b/packages/devtools/frigg-cli/validate-command/__tests__/domain/validation-result.test.js
@@ -1,0 +1,152 @@
+const { ValidationResult } = require('../../domain/entities/validation-result');
+const { ValidationError } = require('../../domain/value-objects/validation-error');
+const { FixSuggestion } = require('../../domain/value-objects/fix-suggestion');
+
+describe('ValidationResult', () => {
+    describe('creation', () => {
+        it('creates empty result with no errors', () => {
+            const result = ValidationResult.create();
+            expect(result.isValid()).toBe(true);
+            expect(result.getErrors()).toHaveLength(0);
+            expect(result.getWarnings()).toHaveLength(0);
+        });
+
+        it('creates result with errors', () => {
+            const error = ValidationError.create({
+                path: 'integrations[0].name',
+                message: 'Integration name is required',
+                severity: 'error'
+            });
+            const result = ValidationResult.create({ errors: [error] });
+            expect(result.isValid()).toBe(false);
+            expect(result.getErrors()).toHaveLength(1);
+        });
+
+        it('creates result with warnings', () => {
+            const warning = ValidationError.create({
+                path: 'config.timeout',
+                message: 'Timeout value is unusually high',
+                severity: 'warning'
+            });
+            const result = ValidationResult.create({ errors: [warning] });
+            expect(result.isValid()).toBe(true);
+            expect(result.getWarnings()).toHaveLength(1);
+        });
+    });
+
+    describe('addError', () => {
+        it('adds error to result', () => {
+            const result = ValidationResult.create();
+            const error = ValidationError.create({
+                path: 'name',
+                message: 'Name is required',
+                severity: 'error'
+            });
+            result.addError(error);
+            expect(result.isValid()).toBe(false);
+            expect(result.getErrors()).toContain(error);
+        });
+
+        it('adds warning without affecting validity', () => {
+            const result = ValidationResult.create();
+            const warning = ValidationError.create({
+                path: 'description',
+                message: 'Description is recommended',
+                severity: 'warning'
+            });
+            result.addError(warning);
+            expect(result.isValid()).toBe(true);
+            expect(result.getWarnings()).toContain(warning);
+        });
+    });
+
+    describe('merge', () => {
+        it('merges two valid results', () => {
+            const result1 = ValidationResult.create();
+            const result2 = ValidationResult.create();
+            const merged = result1.merge(result2);
+            expect(merged.isValid()).toBe(true);
+        });
+
+        it('merges results with errors', () => {
+            const error1 = ValidationError.create({
+                path: 'name',
+                message: 'Name required',
+                severity: 'error'
+            });
+            const error2 = ValidationError.create({
+                path: 'version',
+                message: 'Version required',
+                severity: 'error'
+            });
+            const result1 = ValidationResult.create({ errors: [error1] });
+            const result2 = ValidationResult.create({ errors: [error2] });
+            const merged = result1.merge(result2);
+            expect(merged.isValid()).toBe(false);
+            expect(merged.getErrors()).toHaveLength(2);
+        });
+
+        it('preserves context from both results', () => {
+            const result1 = ValidationResult.create({ context: { file: 'index.js' } });
+            const result2 = ValidationResult.create({ context: { integration: 'oauth' } });
+            const merged = result1.merge(result2);
+            expect(merged.getContext()).toMatchObject({ file: 'index.js', integration: 'oauth' });
+        });
+    });
+
+    describe('filtering', () => {
+        it('filters errors by path prefix', () => {
+            const errors = [
+                ValidationError.create({ path: 'integrations[0].name', message: 'a', severity: 'error' }),
+                ValidationError.create({ path: 'integrations[1].config', message: 'b', severity: 'error' }),
+                ValidationError.create({ path: 'database.uri', message: 'c', severity: 'error' })
+            ];
+            const result = ValidationResult.create({ errors });
+            const filtered = result.filterByPath('integrations');
+            expect(filtered.getErrors()).toHaveLength(2);
+        });
+
+        it('filters by severity', () => {
+            const errors = [
+                ValidationError.create({ path: 'a', message: 'error1', severity: 'error' }),
+                ValidationError.create({ path: 'b', message: 'warning1', severity: 'warning' }),
+                ValidationError.create({ path: 'c', message: 'info1', severity: 'info' })
+            ];
+            const result = ValidationResult.create({ errors });
+            expect(result.getBySeverity('error')).toHaveLength(1);
+            expect(result.getBySeverity('warning')).toHaveLength(1);
+            expect(result.getBySeverity('info')).toHaveLength(1);
+        });
+    });
+
+    describe('summary', () => {
+        it('generates summary statistics', () => {
+            const errors = [
+                ValidationError.create({ path: 'a', message: 'm1', severity: 'error' }),
+                ValidationError.create({ path: 'b', message: 'm2', severity: 'error' }),
+                ValidationError.create({ path: 'c', message: 'm3', severity: 'warning' })
+            ];
+            const result = ValidationResult.create({ errors });
+            const summary = result.getSummary();
+            expect(summary.errorCount).toBe(2);
+            expect(summary.warningCount).toBe(1);
+            expect(summary.isValid).toBe(false);
+        });
+    });
+
+    describe('serialization', () => {
+        it('converts to JSON', () => {
+            const error = ValidationError.create({
+                path: 'name',
+                message: 'Required',
+                severity: 'error',
+                fix: FixSuggestion.create({ action: 'add', description: 'Add name field' })
+            });
+            const result = ValidationResult.create({ errors: [error] });
+            const json = result.toJSON();
+            expect(json).toHaveProperty('valid', false);
+            expect(json).toHaveProperty('errors');
+            expect(json.errors[0]).toHaveProperty('path', 'name');
+        });
+    });
+});

--- a/packages/devtools/frigg-cli/validate-command/__tests__/infrastructure/app-definition-validator.test.js
+++ b/packages/devtools/frigg-cli/validate-command/__tests__/infrastructure/app-definition-validator.test.js
@@ -1,0 +1,160 @@
+const { AppDefinitionValidator } = require('../../infrastructure/validators/app-definition-validator');
+const { ValidationResult } = require('../../domain/entities/validation-result');
+
+describe('AppDefinitionValidator', () => {
+    let validator;
+
+    beforeEach(() => {
+        validator = new AppDefinitionValidator();
+    });
+
+    describe('valid definitions', () => {
+        it('validates minimal valid definition', () => {
+            const definition = {
+                integrations: []
+            };
+            const result = validator.validate(definition);
+            expect(result.isValid()).toBe(true);
+        });
+
+        it('validates definition with database config', () => {
+            const definition = {
+                integrations: [],
+                database: { mongoDB: { enable: true } }
+            };
+            const result = validator.validate(definition);
+            expect(result.isValid()).toBe(true);
+        });
+
+        it('validates definition with integration classes', () => {
+            const MockIntegration = class {
+                static Definition = { name: 'test-integration' };
+            };
+            const definition = {
+                integrations: [MockIntegration]
+            };
+            const result = validator.validate(definition);
+            expect(result.isValid()).toBe(true);
+        });
+    });
+
+    describe('integrations validation', () => {
+        it('errors when integrations is not an array', () => {
+            const definition = { integrations: 'not-an-array' };
+            const result = validator.validate(definition);
+            expect(result.isValid()).toBe(false);
+            expect(result.getErrors()[0].path).toBe('integrations');
+        });
+
+        it('errors when integrations is missing', () => {
+            const definition = {};
+            const result = validator.validate(definition);
+            expect(result.isValid()).toBe(false);
+            expect(result.getErrors().some(e => e.path === 'integrations')).toBe(true);
+        });
+
+        it('errors when integration lacks Definition property', () => {
+            const BadIntegration = class {};
+            const definition = { integrations: [BadIntegration] };
+            const result = validator.validate(definition);
+            expect(result.isValid()).toBe(false);
+            expect(result.getErrors()[0].path).toBe('integrations[0]');
+            expect(result.getErrors()[0].message).toContain('Definition');
+        });
+
+        it('errors when integration Definition lacks name', () => {
+            const BadIntegration = class {
+                static Definition = {};
+            };
+            const definition = { integrations: [BadIntegration] };
+            const result = validator.validate(definition);
+            expect(result.isValid()).toBe(false);
+            expect(result.getErrors()[0].path).toBe('integrations[0].Definition.name');
+        });
+
+        it('warns on duplicate integration names', () => {
+            const Int1 = class { static Definition = { name: 'same-name' }; };
+            const Int2 = class { static Definition = { name: 'same-name' }; };
+            const definition = { integrations: [Int1, Int2] };
+            const result = validator.validate(definition);
+            expect(result.getWarnings().some(w => w.message.includes('duplicate'))).toBe(true);
+        });
+    });
+
+    describe('database validation', () => {
+        it('warns when no database configured', () => {
+            const definition = { integrations: [] };
+            const result = validator.validate(definition);
+            expect(result.getWarnings().some(w => w.path === 'database')).toBe(true);
+        });
+
+        it('errors on invalid database type', () => {
+            const definition = {
+                integrations: [],
+                database: { mysql: { enable: true } }
+            };
+            const result = validator.validate(definition);
+            expect(result.isValid()).toBe(false);
+            expect(result.getErrors()[0].path).toBe('database');
+        });
+
+        it('validates mongoDB configuration', () => {
+            const definition = {
+                integrations: [],
+                database: { mongoDB: { enable: true } }
+            };
+            const result = validator.validate(definition);
+            const dbErrors = result.getErrors().filter(e => e.path.startsWith('database'));
+            expect(dbErrors).toHaveLength(0);
+        });
+
+        it('validates postgres configuration', () => {
+            const definition = {
+                integrations: [],
+                database: { postgres: { enable: true } }
+            };
+            const result = validator.validate(definition);
+            const dbErrors = result.getErrors().filter(e => e.path.startsWith('database'));
+            expect(dbErrors).toHaveLength(0);
+        });
+    });
+
+    describe('user configuration', () => {
+        it('validates mongoose user model', () => {
+            const definition = {
+                integrations: [],
+                user: { model: 'mongoose' }
+            };
+            const result = validator.validate(definition);
+            const userErrors = result.getErrors().filter(e => e.path.startsWith('user'));
+            expect(userErrors).toHaveLength(0);
+        });
+
+        it('validates prisma user model', () => {
+            const definition = {
+                integrations: [],
+                user: { model: 'prisma' }
+            };
+            const result = validator.validate(definition);
+            const userErrors = result.getErrors().filter(e => e.path.startsWith('user'));
+            expect(userErrors).toHaveLength(0);
+        });
+
+        it('errors on invalid user model', () => {
+            const definition = {
+                integrations: [],
+                user: { model: 'invalid' }
+            };
+            const result = validator.validate(definition);
+            expect(result.getErrors().some(e => e.path === 'user.model')).toBe(true);
+        });
+    });
+
+    describe('result type', () => {
+        it('returns ValidationResult instance', () => {
+            const definition = { integrations: [] };
+            const result = validator.validate(definition);
+            expect(result).toBeInstanceOf(ValidationResult);
+        });
+    });
+});

--- a/packages/devtools/frigg-cli/validate-command/__tests__/infrastructure/integration-class-validator.test.js
+++ b/packages/devtools/frigg-cli/validate-command/__tests__/infrastructure/integration-class-validator.test.js
@@ -1,0 +1,141 @@
+const { IntegrationClassValidator } = require('../../infrastructure/validators/integration-class-validator');
+
+describe('IntegrationClassValidator', () => {
+    let validator;
+
+    beforeEach(() => {
+        validator = new IntegrationClassValidator();
+    });
+
+    describe('valid integration classes', () => {
+        it('validates class with Definition static property', () => {
+            class ValidIntegration {
+                static Definition = {
+                    name: 'test-integration',
+                    version: '1.0.0',
+                    modules: {}
+                };
+            }
+            const result = validator.validate(ValidIntegration, 0);
+            expect(result.isValid()).toBe(true);
+        });
+
+        it('validates class with modules configuration', () => {
+            class ValidIntegration {
+                static Definition = {
+                    name: 'oauth-integration',
+                    version: '1.0.0',
+                    modules: {
+                        hubspot: {
+                            definition: { name: 'hubspot' },
+                            options: {}
+                        }
+                    }
+                };
+            }
+            const result = validator.validate(ValidIntegration, 0);
+            expect(result.isValid()).toBe(true);
+        });
+    });
+
+    describe('invalid integration classes', () => {
+        it('errors when not a function/class', () => {
+            const notAClass = { Definition: { name: 'test' } };
+            const result = validator.validate(notAClass, 0);
+            expect(result.isValid()).toBe(false);
+            expect(result.getErrors()[0].message).toContain('class');
+        });
+
+        it('errors when Definition is missing', () => {
+            class NoDefinition {}
+            const result = validator.validate(NoDefinition, 0);
+            expect(result.isValid()).toBe(false);
+            expect(result.getErrors()[0].path).toBe('integrations[0].Definition');
+        });
+
+        it('errors when Definition.name is missing', () => {
+            class MissingName {
+                static Definition = { version: '1.0.0' };
+            }
+            const result = validator.validate(MissingName, 0);
+            expect(result.isValid()).toBe(false);
+            expect(result.getErrors()[0].path).toBe('integrations[0].Definition.name');
+        });
+
+        it('errors when Definition.name is not a string', () => {
+            class BadName {
+                static Definition = { name: 123, version: '1.0.0' };
+            }
+            const result = validator.validate(BadName, 0);
+            expect(result.isValid()).toBe(false);
+            expect(result.getErrors()[0].path).toBe('integrations[0].Definition.name');
+        });
+    });
+
+    describe('modules validation', () => {
+        it('errors when module lacks definition', () => {
+            class BadModule {
+                static Definition = {
+                    name: 'test',
+                    modules: {
+                        hubspot: { options: {} }
+                    }
+                };
+            }
+            const result = validator.validate(BadModule, 0);
+            expect(result.isValid()).toBe(false);
+            expect(result.getErrors()[0].path).toBe('integrations[0].Definition.modules.hubspot.definition');
+        });
+
+        it('warns when module definition lacks name', () => {
+            class ModuleNoName {
+                static Definition = {
+                    name: 'test',
+                    modules: {
+                        hubspot: {
+                            definition: {},
+                            options: {}
+                        }
+                    }
+                };
+            }
+            const result = validator.validate(ModuleNoName, 0);
+            expect(result.getWarnings().length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('lifecycle methods', () => {
+        it('warns when onCreate is not implemented', () => {
+            class NoOnCreate {
+                static Definition = { name: 'test', version: '1.0.0' };
+            }
+            const result = validator.validate(NoOnCreate, 0);
+            expect(result.getWarnings().some(w => w.message.includes('onCreate'))).toBe(true);
+        });
+
+        it('passes when onCreate is implemented', () => {
+            class WithOnCreate {
+                static Definition = { name: 'test', version: '1.0.0' };
+                async onCreate() {}
+            }
+            const result = validator.validate(WithOnCreate, 0);
+            expect(result.getWarnings().filter(w => w.message.includes('onCreate'))).toHaveLength(0);
+        });
+
+        it('warns when getConfigOptions is not implemented', () => {
+            class NoConfigOptions {
+                static Definition = { name: 'test', version: '1.0.0' };
+            }
+            const result = validator.validate(NoConfigOptions, 0);
+            expect(result.getWarnings().some(w => w.message.includes('getConfigOptions'))).toBe(true);
+        });
+    });
+
+    describe('index parameter', () => {
+        it('includes correct index in error paths', () => {
+            class Invalid {}
+            const result = validator.validate(Invalid, 5);
+            expect(result.getErrors()[0].path).toContain('integrations[5]');
+        });
+    });
+});

--- a/packages/devtools/frigg-cli/validate-command/adapters/cli/validate-command.js
+++ b/packages/devtools/frigg-cli/validate-command/adapters/cli/validate-command.js
@@ -1,0 +1,196 @@
+const path = require('path');
+const fs = require('fs');
+const { ValidateAppUseCase } = require('../../application/use-cases/validate-app-use-case');
+const { AppDefinitionValidator } = require('../../infrastructure/validators/app-definition-validator');
+const { IntegrationClassValidator } = require('../../infrastructure/validators/integration-class-validator');
+
+function createValidateCommand(program) {
+    program
+        .command('validate [path]')
+        .description('Validate a Frigg application configuration (auto-detects local app if no path given)')
+        .option('-f, --format <format>', 'Output format (console, json)', 'console')
+        .option('-v, --verbose', 'Show detailed output including fix suggestions', false)
+        .action(async (appPath, options) => {
+            const output = require('../../../utils/output');
+            await validateCommand(appPath, options, { output });
+        });
+}
+
+function autoDetectFriggApp(startDir = process.cwd()) {
+    let currentDir = startDir;
+    const root = path.parse(currentDir).root;
+
+    while (currentDir !== root) {
+        const backendPath = findBackendPathInDir(currentDir);
+        if (backendPath) {
+            return { appRoot: currentDir, backendPath };
+        }
+        currentDir = path.dirname(currentDir);
+    }
+
+    return null;
+}
+
+function findBackendPathInDir(dir) {
+    const backendDir = path.join(dir, 'backend');
+    if (fs.existsSync(path.join(backendDir, 'index.js'))) {
+        return backendDir;
+    }
+
+    if (fs.existsSync(path.join(dir, 'index.js'))) {
+        const content = fs.readFileSync(path.join(dir, 'index.js'), 'utf-8');
+        if (content.includes('integrations') || content.includes('Definition')) {
+            return dir;
+        }
+    }
+
+    return null;
+}
+
+function findBackendPath(startPath) {
+    const absolutePath = path.isAbsolute(startPath) ? startPath : path.resolve(process.cwd(), startPath);
+
+    const backendDir = path.join(absolutePath, 'backend');
+    if (fs.existsSync(path.join(backendDir, 'package.json')) || fs.existsSync(path.join(backendDir, 'index.js'))) {
+        return backendDir;
+    }
+
+    if (fs.existsSync(path.join(absolutePath, 'package.json')) || fs.existsSync(path.join(absolutePath, 'index.js'))) {
+        return absolutePath;
+    }
+
+    return null;
+}
+
+function loadAppDefinition(backendPath) {
+    const indexPath = path.join(backendPath, 'index.js');
+    if (!fs.existsSync(indexPath)) {
+        throw new Error(`No index.js found at ${backendPath}`);
+    }
+
+    const originalCwd = process.cwd();
+    try {
+        process.chdir(backendPath);
+        delete require.cache[require.resolve(indexPath)];
+        const exported = require(indexPath);
+        return exported.Definition || exported.default || exported;
+    } finally {
+        process.chdir(originalCwd);
+    }
+}
+
+async function validateCommand(appPath, options, { output }) {
+    try {
+        let backendPath;
+        let definition;
+
+        if (!appPath) {
+            const detected = autoDetectFriggApp();
+            if (!detected) {
+                output.error('No Frigg app found. Run from within a Frigg app directory or specify a path.');
+                return;
+            }
+            backendPath = detected.backendPath;
+            output.info(`Auto-detected Frigg app at: ${detected.appRoot}`);
+        } else {
+            backendPath = findBackendPath(appPath);
+            if (!backendPath) {
+                output.error(`Could not find backend directory in ${appPath}`);
+                return;
+            }
+            output.info(`Validating Frigg app at: ${appPath}`);
+        }
+
+        try {
+            definition = loadAppDefinition(backendPath);
+        } catch (err) {
+            output.error(`Could not load app definition: ${err.message}`);
+            return;
+        }
+
+        const appDefinitionValidator = new AppDefinitionValidator();
+        const integrationClassValidator = new IntegrationClassValidator();
+        const useCase = new ValidateAppUseCase({
+            appDefinitionValidator,
+            integrationClassValidator
+        });
+
+        const result = await useCase.execute({ definition, appPath: backendPath });
+
+        if (options.format === 'json') {
+            output.log(JSON.stringify(result.toJSON(), null, 2));
+            return;
+        }
+
+        formatConsoleOutput(result, options, output);
+    } catch (err) {
+        output.error(`Validation failed: ${err.message}`);
+        if (options.verbose) {
+            output.error(err.stack);
+        }
+    }
+}
+
+function formatConsoleOutput(result, options, output) {
+    const summary = result.getSummary();
+
+    output.log('');
+    output.log('═'.repeat(60));
+    output.log('  FRIGG VALIDATE - App Configuration Report');
+    output.log('═'.repeat(60));
+    output.log('');
+
+    if (result.isValid()) {
+        output.success('App configuration is valid');
+    } else {
+        output.error(`App configuration has ${summary.errorCount} error(s)`);
+    }
+
+    if (summary.warningCount > 0) {
+        output.warn(`${summary.warningCount} warning(s) found`);
+    }
+
+    output.log('');
+
+    if (result.getErrors().length > 0) {
+        output.log('─'.repeat(60));
+        output.log('ERRORS:');
+        output.log('');
+        result.getErrors().forEach((error, idx) => {
+            output.log(`  ${idx + 1}. [${error.path}] ${error.message}`);
+            if (options.verbose && error.fix) {
+                output.log(`     Fix: ${error.fix.description}`);
+                if (error.fix.template) {
+                    output.log(`     Template: ${JSON.stringify(error.fix.template)}`);
+                }
+            }
+        });
+        output.log('');
+    }
+
+    if (result.getWarnings().length > 0) {
+        output.log('─'.repeat(60));
+        output.log('WARNINGS:');
+        output.log('');
+        result.getWarnings().forEach((warning, idx) => {
+            output.log(`  ${idx + 1}. [${warning.path}] ${warning.message}`);
+            if (options.verbose && warning.fix) {
+                output.log(`     Fix: ${warning.fix.description}`);
+            }
+        });
+        output.log('');
+    }
+
+    output.log('═'.repeat(60));
+    output.log('');
+}
+
+module.exports = {
+    validateCommand,
+    createValidateCommand,
+    formatConsoleOutput,
+    autoDetectFriggApp,
+    findBackendPathInDir,
+    findBackendPath,
+    loadAppDefinition
+};

--- a/packages/devtools/frigg-cli/validate-command/application/use-cases/validate-app-use-case.js
+++ b/packages/devtools/frigg-cli/validate-command/application/use-cases/validate-app-use-case.js
@@ -1,0 +1,28 @@
+const { ValidationResult } = require('../../domain/entities/validation-result');
+
+class ValidateAppUseCase {
+    constructor({ appDefinitionValidator, integrationClassValidator }) {
+        this.appDefinitionValidator = appDefinitionValidator;
+        this.integrationClassValidator = integrationClassValidator;
+    }
+
+    async execute({ definition, appPath }) {
+        let result = ValidationResult.create({
+            context: { appPath }
+        });
+
+        const appResult = this.appDefinitionValidator.validate(definition);
+        result = result.merge(appResult);
+
+        if (definition.integrations && Array.isArray(definition.integrations)) {
+            definition.integrations.forEach((integration, index) => {
+                const integrationResult = this.integrationClassValidator.validate(integration, index);
+                result = result.merge(integrationResult);
+            });
+        }
+
+        return result;
+    }
+}
+
+module.exports = { ValidateAppUseCase };

--- a/packages/devtools/frigg-cli/validate-command/domain/entities/validation-result.js
+++ b/packages/devtools/frigg-cli/validate-command/domain/entities/validation-result.js
@@ -1,0 +1,74 @@
+class ValidationResult {
+    constructor({ errors, context }) {
+        this.errors = errors || [];
+        this.context = context || {};
+    }
+
+    static create(props = {}) {
+        return new ValidationResult(props);
+    }
+
+    isValid() {
+        return !this.errors.some(e => e.isError());
+    }
+
+    getErrors() {
+        return this.errors.filter(e => e.isError());
+    }
+
+    getWarnings() {
+        return this.errors.filter(e => e.isWarning());
+    }
+
+    getInfos() {
+        return this.errors.filter(e => e.isInfo());
+    }
+
+    addError(error) {
+        this.errors.push(error);
+        return this;
+    }
+
+    merge(other) {
+        return ValidationResult.create({
+            errors: [...this.errors, ...other.errors],
+            context: { ...this.context, ...other.context }
+        });
+    }
+
+    getContext() {
+        return this.context;
+    }
+
+    filterByPath(pathPrefix) {
+        return ValidationResult.create({
+            errors: this.errors.filter(e => e.path.startsWith(pathPrefix)),
+            context: this.context
+        });
+    }
+
+    getBySeverity(severity) {
+        return this.errors.filter(e => e.severity === severity);
+    }
+
+    getSummary() {
+        return {
+            isValid: this.isValid(),
+            errorCount: this.getErrors().length,
+            warningCount: this.getWarnings().length,
+            infoCount: this.getInfos().length,
+            totalCount: this.errors.length
+        };
+    }
+
+    toJSON() {
+        return {
+            valid: this.isValid(),
+            errors: this.errors.map(e => e.toJSON()),
+            summary: this.getSummary(),
+            context: this.context
+        };
+    }
+}
+
+module.exports = { ValidationResult };

--- a/packages/devtools/frigg-cli/validate-command/domain/value-objects/fix-suggestion.js
+++ b/packages/devtools/frigg-cli/validate-command/domain/value-objects/fix-suggestion.js
@@ -1,0 +1,74 @@
+const VALID_ACTIONS = ['add', 'remove', 'replace', 'rename', 'update'];
+
+class FixSuggestion {
+    constructor({ action, description, template, codeSnippet, targetPath, targetFile }) {
+        if (!action) {
+            throw new Error('action is required');
+        }
+        if (!description) {
+            throw new Error('description is required');
+        }
+        if (!VALID_ACTIONS.includes(action)) {
+            throw new Error(`Invalid action: ${action}. Must be one of: ${VALID_ACTIONS.join(', ')}`);
+        }
+
+        this.action = action;
+        this.description = description;
+        this.template = template || null;
+        this.codeSnippet = codeSnippet || null;
+        this.targetPath = targetPath || null;
+        this.targetFile = targetFile || null;
+    }
+
+    static create(props) {
+        return new FixSuggestion(props);
+    }
+
+    isAdd() {
+        return this.action === 'add';
+    }
+
+    isRemove() {
+        return this.action === 'remove';
+    }
+
+    isReplace() {
+        return this.action === 'replace';
+    }
+
+    isRename() {
+        return this.action === 'rename';
+    }
+
+    isUpdate() {
+        return this.action === 'update';
+    }
+
+    isAutoApplicable() {
+        return this.template !== null || this.codeSnippet !== null;
+    }
+
+    toJSON() {
+        return {
+            action: this.action,
+            description: this.description,
+            template: this.template,
+            codeSnippet: this.codeSnippet,
+            targetPath: this.targetPath,
+            targetFile: this.targetFile
+        };
+    }
+
+    format() {
+        let output = `[${this.action}] ${this.description}`;
+        if (this.template) {
+            output += `\n  Template: ${JSON.stringify(this.template)}`;
+        }
+        if (this.codeSnippet) {
+            output += `\n  Code: ${this.codeSnippet}`;
+        }
+        return output;
+    }
+}
+
+module.exports = { FixSuggestion };

--- a/packages/devtools/frigg-cli/validate-command/domain/value-objects/validation-error.js
+++ b/packages/devtools/frigg-cli/validate-command/domain/value-objects/validation-error.js
@@ -1,0 +1,68 @@
+const VALID_SEVERITIES = ['error', 'warning', 'info'];
+
+class ValidationError {
+    constructor({ path, message, severity, code, fix }) {
+        if (!path) {
+            throw new Error('path is required');
+        }
+        if (!message) {
+            throw new Error('message is required');
+        }
+        if (severity && !VALID_SEVERITIES.includes(severity)) {
+            throw new Error(`Invalid severity: ${severity}. Must be one of: ${VALID_SEVERITIES.join(', ')}`);
+        }
+
+        this.path = path;
+        this.message = message;
+        this.severity = severity || 'error';
+        this.code = code || null;
+        this.fix = fix || null;
+    }
+
+    static create(props) {
+        return new ValidationError(props);
+    }
+
+    getPathSegments() {
+        return this.path
+            .replace(/\[(\d+)\]/g, '.$1')
+            .split('.')
+            .filter(Boolean);
+    }
+
+    getRootPath() {
+        return this.getPathSegments()[0];
+    }
+
+    isError() {
+        return this.severity === 'error';
+    }
+
+    isWarning() {
+        return this.severity === 'warning';
+    }
+
+    isInfo() {
+        return this.severity === 'info';
+    }
+
+    hasFix() {
+        return this.fix !== null;
+    }
+
+    equals(other) {
+        return this.path === other.path && this.message === other.message;
+    }
+
+    toJSON() {
+        return {
+            path: this.path,
+            message: this.message,
+            severity: this.severity,
+            code: this.code,
+            fix: this.fix ? this.fix.toJSON() : null
+        };
+    }
+}
+
+module.exports = { ValidationError };

--- a/packages/devtools/frigg-cli/validate-command/infrastructure/validators/app-definition-validator.js
+++ b/packages/devtools/frigg-cli/validate-command/infrastructure/validators/app-definition-validator.js
@@ -1,0 +1,125 @@
+const { ValidationResult } = require('../../domain/entities/validation-result');
+const { ValidationError } = require('../../domain/value-objects/validation-error');
+const { FixSuggestion } = require('../../domain/value-objects/fix-suggestion');
+
+const VALID_DB_TYPES = ['mongoDB', 'postgres'];
+const VALID_USER_MODELS = ['mongoose', 'prisma'];
+
+class AppDefinitionValidator {
+    validate(definition) {
+        const result = ValidationResult.create();
+
+        this._validateIntegrations(definition, result);
+        this._validateDatabase(definition, result);
+        this._validateUser(definition, result);
+
+        return result;
+    }
+
+    _validateIntegrations(definition, result) {
+        if (!definition.integrations) {
+            result.addError(ValidationError.create({
+                path: 'integrations',
+                message: 'integrations is required',
+                severity: 'error',
+                code: 'REQUIRED_FIELD',
+                fix: FixSuggestion.create({
+                    action: 'add',
+                    description: 'Add integrations array to definition',
+                    template: { integrations: [] }
+                })
+            }));
+            return;
+        }
+
+        if (!Array.isArray(definition.integrations)) {
+            result.addError(ValidationError.create({
+                path: 'integrations',
+                message: 'integrations must be an array',
+                severity: 'error',
+                code: 'INVALID_TYPE'
+            }));
+            return;
+        }
+
+        const names = [];
+        definition.integrations.forEach((integration, index) => {
+            if (!integration.Definition) {
+                result.addError(ValidationError.create({
+                    path: `integrations[${index}]`,
+                    message: 'Integration class must have a static Definition property',
+                    severity: 'error',
+                    code: 'MISSING_DEFINITION'
+                }));
+                return;
+            }
+
+            if (!integration.Definition.name) {
+                result.addError(ValidationError.create({
+                    path: `integrations[${index}].Definition.name`,
+                    message: 'Integration Definition must have a name',
+                    severity: 'error',
+                    code: 'REQUIRED_FIELD'
+                }));
+                return;
+            }
+
+            const name = integration.Definition.name;
+            if (names.includes(name)) {
+                result.addError(ValidationError.create({
+                    path: `integrations[${index}].Definition.name`,
+                    message: `duplicate integration name: ${name}`,
+                    severity: 'warning',
+                    code: 'DUPLICATE_NAME'
+                }));
+            }
+            names.push(name);
+        });
+    }
+
+    _validateDatabase(definition, result) {
+        if (!definition.database) {
+            result.addError(ValidationError.create({
+                path: 'database',
+                message: 'No database configuration found',
+                severity: 'warning',
+                code: 'MISSING_CONFIG',
+                fix: FixSuggestion.create({
+                    action: 'add',
+                    description: 'Add database configuration',
+                    template: { database: { mongoDB: { enable: true } } }
+                })
+            }));
+            return;
+        }
+
+        const dbKeys = Object.keys(definition.database);
+        const validKeys = dbKeys.filter(k => VALID_DB_TYPES.includes(k));
+
+        if (validKeys.length === 0) {
+            result.addError(ValidationError.create({
+                path: 'database',
+                message: `Invalid database type. Must be one of: ${VALID_DB_TYPES.join(', ')}`,
+                severity: 'error',
+                code: 'INVALID_DB_TYPE'
+            }));
+        }
+    }
+
+    _validateUser(definition, result) {
+        if (!definition.user) {
+            return;
+        }
+
+        if (definition.user.model && !VALID_USER_MODELS.includes(definition.user.model)) {
+            result.addError(ValidationError.create({
+                path: 'user.model',
+                message: `Invalid user model: ${definition.user.model}. Must be one of: ${VALID_USER_MODELS.join(', ')}`,
+                severity: 'error',
+                code: 'INVALID_USER_MODEL'
+            }));
+        }
+    }
+}
+
+module.exports = { AppDefinitionValidator };

--- a/packages/devtools/frigg-cli/validate-command/infrastructure/validators/integration-class-validator.js
+++ b/packages/devtools/frigg-cli/validate-command/infrastructure/validators/integration-class-validator.js
@@ -1,0 +1,110 @@
+const { ValidationResult } = require('../../domain/entities/validation-result');
+const { ValidationError } = require('../../domain/value-objects/validation-error');
+const { FixSuggestion } = require('../../domain/value-objects/fix-suggestion');
+
+const LIFECYCLE_METHODS = ['onCreate', 'getConfigOptions', 'testAuth'];
+
+class IntegrationClassValidator {
+    validate(integrationClass, index) {
+        const result = ValidationResult.create();
+        const prefix = `integrations[${index}]`;
+
+        if (typeof integrationClass !== 'function') {
+            result.addError(ValidationError.create({
+                path: prefix,
+                message: 'Integration must be a class (function)',
+                severity: 'error',
+                code: 'INVALID_TYPE'
+            }));
+            return result;
+        }
+
+        if (!integrationClass.Definition) {
+            result.addError(ValidationError.create({
+                path: `${prefix}.Definition`,
+                message: 'Integration class must have a static Definition property',
+                severity: 'error',
+                code: 'MISSING_DEFINITION',
+                fix: FixSuggestion.create({
+                    action: 'add',
+                    description: 'Add static Definition property to integration class',
+                    codeSnippet: `static Definition = {\n    name: 'my-integration',\n    version: '1.0.0',\n    modules: {}\n};`
+                })
+            }));
+            return result;
+        }
+
+        this._validateDefinition(integrationClass.Definition, prefix, result);
+        this._validateModules(integrationClass.Definition, prefix, result);
+        this._validateLifecycleMethods(integrationClass, prefix, result);
+
+        return result;
+    }
+
+    _validateDefinition(definition, prefix, result) {
+        if (!definition.name) {
+            result.addError(ValidationError.create({
+                path: `${prefix}.Definition.name`,
+                message: 'Definition must have a name property',
+                severity: 'error',
+                code: 'REQUIRED_FIELD'
+            }));
+            return;
+        }
+
+        if (typeof definition.name !== 'string') {
+            result.addError(ValidationError.create({
+                path: `${prefix}.Definition.name`,
+                message: 'Definition.name must be a string',
+                severity: 'error',
+                code: 'INVALID_TYPE'
+            }));
+        }
+    }
+
+    _validateModules(definition, prefix, result) {
+        if (!definition.modules) {
+            return;
+        }
+
+        Object.entries(definition.modules).forEach(([moduleName, moduleConfig]) => {
+            const modulePath = `${prefix}.Definition.modules.${moduleName}`;
+
+            if (!moduleConfig.definition) {
+                result.addError(ValidationError.create({
+                    path: `${modulePath}.definition`,
+                    message: `Module ${moduleName} must have a definition property`,
+                    severity: 'error',
+                    code: 'REQUIRED_FIELD'
+                }));
+                return;
+            }
+
+            if (!moduleConfig.definition.name) {
+                result.addError(ValidationError.create({
+                    path: `${modulePath}.definition.name`,
+                    message: `Module ${moduleName} definition should have a name`,
+                    severity: 'warning',
+                    code: 'MISSING_NAME'
+                }));
+            }
+        });
+    }
+
+    _validateLifecycleMethods(integrationClass, prefix, result) {
+        const proto = integrationClass.prototype;
+
+        LIFECYCLE_METHODS.forEach(method => {
+            if (typeof proto[method] !== 'function') {
+                result.addError(ValidationError.create({
+                    path: `${prefix}.${method}`,
+                    message: `Integration should implement ${method}() method`,
+                    severity: 'warning',
+                    code: 'MISSING_METHOD'
+                }));
+            }
+        });
+    }
+}
+
+module.exports = { IntegrationClassValidator };

--- a/packages/e2e/__tests__/edge-cases/error-scenarios.test.js
+++ b/packages/e2e/__tests__/edge-cases/error-scenarios.test.js
@@ -1,0 +1,204 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('Error Scenarios', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('Authentication Errors', () => {
+        it('should return 401 for missing authorization header', async () => {
+            const res = await request(app).get('/api/integrations');
+            expect(res.status).toBe(401);
+        });
+
+        it('should return 401 for invalid token format', async () => {
+            const res = await request(app)
+                .get('/api/integrations')
+                .set('Authorization', 'InvalidFormat');
+            expect(res.status).toBe(401);
+        });
+
+        it('should return 401 for nonexistent user token', async () => {
+            const res = await request(app)
+                .get('/api/integrations')
+                .set('Authorization', 'Bearer nonexistent-user-id');
+            expect(res.status).toBe(401);
+        });
+    });
+
+    describe('Authorization Errors', () => {
+        it('should reject unknown entity type', async () => {
+            const { userId, token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/authorize')
+                .query({ entityType: 'unknown-entity-type' })
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(400);
+        });
+
+        it('should reject authorization without entity type', async () => {
+            const { userId, token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('Integration Errors', () => {
+        it('should reject creating integration without entities', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entities: [],
+                    config: { type: 'oauth-integration' },
+                });
+
+            expect(res.status).toBe(400);
+        });
+
+        it('should reject creating integration with nonexistent entity', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entities: ['nonexistent-entity-id'],
+                    config: { type: 'oauth-integration' },
+                });
+
+            expect(res.status).toBe(400);
+        });
+
+        it('should reject creating integration without config type', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entities: [entityId],
+                    config: {},
+                });
+
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('Resource Not Found', () => {
+        it('should return 404 for nonexistent integration', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/integrations/507f1f77bcf86cd799439011')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+
+        it('should return 404 for nonexistent entity', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/entities/507f1f77bcf86cd799439011')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('Malformed Requests', () => {
+        it('should handle malformed JSON body gracefully', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${token}`)
+                .set('Content-Type', 'application/json')
+                .send('{invalid json}');
+
+            expect(res.status).toBe(400);
+        });
+
+        it('should handle empty body gracefully', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .patch(`/api/integrations/${entityId}`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({});
+
+            expect([200, 400]).toContain(res.status);
+        });
+    });
+
+    describe('Concurrent Operations', () => {
+        it('should handle concurrent entity creation', async () => {
+            const { userId, token } = await fixture.createUser();
+
+            const promises = Array(5).fill(null).map(() =>
+                request(app)
+                    .post('/api/authorize')
+                    .set('Authorization', `Bearer ${token}`)
+                    .send({
+                        entityType: 'oauth2-mock',
+                        data: { code: `code-${Date.now()}-${Math.random()}` },
+                    })
+            );
+
+            const results = await Promise.all(promises);
+            results.forEach((res) => {
+                expect(res.status).toBe(200);
+            });
+        });
+
+        it('should handle concurrent integration creation', async () => {
+            const { userId, token } = await fixture.createUser();
+
+            const entities = await Promise.all(
+                Array(3).fill(null).map(() => fixture.createOAuthEntity(userId))
+            );
+
+            const promises = entities.map(({ entityId }) =>
+                request(app)
+                    .post('/api/integrations')
+                    .set('Authorization', `Bearer ${token}`)
+                    .send({
+                        entities: [entityId],
+                        config: { type: 'oauth-integration' },
+                    })
+            );
+
+            const results = await Promise.all(promises);
+            results.forEach((res) => {
+                expect(res.status).toBe(201);
+            });
+        });
+    });
+});

--- a/packages/e2e/__tests__/edge-cases/user-scenarios.test.js
+++ b/packages/e2e/__tests__/edge-cases/user-scenarios.test.js
@@ -1,0 +1,143 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('User Scenarios', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('User Creation', () => {
+        it('should create a new user', async () => {
+            const res = await request(app)
+                .post('/user/create')
+                .send({
+                    username: `newuser-${Date.now()}@example.com`,
+                    password: 'securepass123',
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('user');
+            expect(res.body.user).toHaveProperty('id');
+        });
+
+        it('should reject duplicate username', async () => {
+            const username = `duplicate-${Date.now()}@example.com`;
+
+            await request(app)
+                .post('/user/create')
+                .send({ username, password: 'password123' });
+
+            const res = await request(app)
+                .post('/user/create')
+                .send({ username, password: 'password456' });
+
+            expect(res.status).toBe(400);
+        });
+
+        it('should reject missing username', async () => {
+            const res = await request(app)
+                .post('/user/create')
+                .send({ password: 'password123' });
+
+            expect(res.status).toBe(400);
+        });
+
+        it('should reject missing password', async () => {
+            const res = await request(app)
+                .post('/user/create')
+                .send({ username: 'test@example.com' });
+
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('User Login', () => {
+        it('should login with correct credentials', async () => {
+            const username = `login-${Date.now()}@example.com`;
+            const password = 'correctpassword';
+
+            await request(app)
+                .post('/user/create')
+                .send({ username, password });
+
+            const res = await request(app)
+                .post('/user/login')
+                .send({ username, password });
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('token');
+        });
+
+        it('should reject incorrect password', async () => {
+            const username = `wrongpass-${Date.now()}@example.com`;
+
+            await request(app)
+                .post('/user/create')
+                .send({ username, password: 'correctpassword' });
+
+            const res = await request(app)
+                .post('/user/login')
+                .send({ username, password: 'wrongpassword' });
+
+            expect(res.status).toBe(401);
+        });
+
+        it('should reject nonexistent user', async () => {
+            const res = await request(app)
+                .post('/user/login')
+                .send({
+                    username: 'nonexistent@example.com',
+                    password: 'anypassword',
+                });
+
+            expect(res.status).toBe(401);
+        });
+    });
+
+    describe('User Session', () => {
+        it('should maintain user context across requests', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const getEntitiesRes = await request(app)
+                .get('/api/entities')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(getEntitiesRes.status).toBe(200);
+            expect(getEntitiesRes.body.entities.some((e) => e.id === entityId)).toBe(true);
+        });
+
+        it('should isolate user data between users', async () => {
+            const { userId: user1Id, token: token1 } = await fixture.createUser();
+            const { token: token2 } = await fixture.createUser();
+
+            await fixture.createOAuthEntity(user1Id);
+
+            const user1Entities = await request(app)
+                .get('/api/entities')
+                .set('Authorization', `Bearer ${token1}`);
+
+            const user2Entities = await request(app)
+                .get('/api/entities')
+                .set('Authorization', `Bearer ${token2}`);
+
+            expect(user1Entities.body.entities.length).toBeGreaterThan(0);
+            expect(user2Entities.body.entities).toHaveLength(0);
+        });
+    });
+});

--- a/packages/e2e/__tests__/helpers/db-cleanup.js
+++ b/packages/e2e/__tests__/helpers/db-cleanup.js
@@ -1,0 +1,46 @@
+const mongoose = require('mongoose');
+
+async function cleanupDatabase() {
+    if (!mongoose.connection || mongoose.connection.readyState !== 1) {
+        return;
+    }
+
+    const collections = mongoose.connection.collections;
+    const promises = Object.values(collections).map((collection) =>
+        collection.deleteMany({})
+    );
+
+    await Promise.all(promises);
+}
+
+async function cleanupCollection(collectionName) {
+    if (!mongoose.connection || mongoose.connection.readyState !== 1) {
+        return;
+    }
+
+    const collection = mongoose.connection.collections[collectionName];
+    if (collection) {
+        await collection.deleteMany({});
+    }
+}
+
+async function getCollectionCounts() {
+    if (!mongoose.connection || mongoose.connection.readyState !== 1) {
+        return {};
+    }
+
+    const collections = mongoose.connection.collections;
+    const counts = {};
+
+    for (const [name, collection] of Object.entries(collections)) {
+        counts[name] = await collection.countDocuments();
+    }
+
+    return counts;
+}
+
+module.exports = {
+    cleanupDatabase,
+    cleanupCollection,
+    getCollectionCounts,
+};

--- a/packages/e2e/__tests__/helpers/fixtures.js
+++ b/packages/e2e/__tests__/helpers/fixtures.js
@@ -1,0 +1,161 @@
+const request = require('supertest');
+
+class TestFixture {
+    constructor(app) {
+        this.app = app;
+        this.createdUsers = [];
+        this.createdEntities = [];
+        this.createdIntegrations = [];
+    }
+
+    async createUser(overrides = {}) {
+        const timestamp = Date.now();
+        const defaults = {
+            username: `testuser-${timestamp}@example.com`,
+            password: 'testpass123',
+        };
+
+        const userData = { ...defaults, ...overrides };
+
+        const res = await request(this.app)
+            .post('/user/create')
+            .send(userData);
+
+        if (res.body.user?.id) {
+            this.createdUsers.push(res.body.user.id);
+        }
+
+        return {
+            userId: res.body.user?.id,
+            token: res.body.token,
+            response: res,
+        };
+    }
+
+    async authenticateEntity(userId, entityType, authData) {
+        const res = await request(this.app)
+            .post('/api/authorize')
+            .set('Authorization', `Bearer ${userId}`)
+            .send({ entityType, data: authData });
+
+        if (res.body.entity?.id) {
+            this.createdEntities.push(res.body.entity.id);
+        }
+
+        return {
+            entityId: res.body.entity?.id,
+            entity: res.body.entity,
+            response: res,
+        };
+    }
+
+    async createOAuthEntity(userId) {
+        return this.authenticateEntity(userId, 'oauth2-mock', {
+            code: `mock-code-${Date.now()}`,
+        });
+    }
+
+    async createFormBasedEntity(userId) {
+        const step1Res = await request(this.app)
+            .post('/api/authorize')
+            .set('Authorization', `Bearer ${userId}`)
+            .send({
+                entityType: 'form-based-mock',
+                data: { apiKey: `api-key-${Date.now()}` },
+                step: 1,
+            });
+
+        const sessionId = step1Res.body.sessionId;
+
+        const step2Res = await request(this.app)
+            .post('/api/authorize')
+            .set('Authorization', `Bearer ${userId}`)
+            .send({
+                entityType: 'form-based-mock',
+                data: { workspaceId: `workspace-${Date.now()}` },
+                step: 2,
+                sessionId,
+            });
+
+        if (step2Res.body.entity?.id) {
+            this.createdEntities.push(step2Res.body.entity.id);
+        }
+
+        return {
+            entityId: step2Res.body.entity?.id,
+            entity: step2Res.body.entity,
+            response: step2Res,
+        };
+    }
+
+    async createWebhookEntity(userId) {
+        return this.authenticateEntity(userId, 'webhook-mock', {
+            apiKey: `webhook-key-${Date.now()}`,
+        });
+    }
+
+    async createIntegration(userId, entityId, integrationType) {
+        const res = await request(this.app)
+            .post('/api/integrations')
+            .set('Authorization', `Bearer ${userId}`)
+            .send({
+                entities: [entityId],
+                config: { type: integrationType },
+            });
+
+        if (res.body.id) {
+            this.createdIntegrations.push(res.body.id);
+        }
+
+        return {
+            integrationId: res.body.id,
+            integration: res.body,
+            response: res,
+        };
+    }
+
+    async createOAuthIntegration(userId) {
+        const { entityId } = await this.createOAuthEntity(userId);
+        return this.createIntegration(userId, entityId, 'oauth-integration');
+    }
+
+    async createFormBasedIntegration(userId) {
+        const { entityId } = await this.createFormBasedEntity(userId);
+        return this.createIntegration(userId, entityId, 'form-based-integration');
+    }
+
+    async createWebhookIntegration(userId) {
+        const { entityId } = await this.createWebhookEntity(userId);
+        return this.createIntegration(userId, entityId, 'webhook-integration');
+    }
+
+    async createFullOAuthSetup() {
+        const { userId, token } = await this.createUser();
+        const { entityId } = await this.createOAuthEntity(userId);
+        const { integrationId } = await this.createIntegration(
+            userId,
+            entityId,
+            'oauth-integration'
+        );
+
+        return { userId, token, entityId, integrationId };
+    }
+
+    async createFullWebhookSetup() {
+        const { userId, token } = await this.createUser();
+        const { entityId } = await this.createWebhookEntity(userId);
+        const { integrationId } = await this.createIntegration(
+            userId,
+            entityId,
+            'webhook-integration'
+        );
+
+        return { userId, token, entityId, integrationId };
+    }
+}
+
+function createFixture(app) {
+    return new TestFixture(app);
+}
+
+module.exports = { TestFixture, createFixture };

--- a/packages/e2e/__tests__/helpers/setup.js
+++ b/packages/e2e/__tests__/helpers/setup.js
@@ -1,0 +1,21 @@
+const { TestMongo } = require('@friggframework/test');
+const { cleanupDatabase } = require('./db-cleanup');
+
+let mongoServer;
+
+beforeAll(async () => {
+    mongoServer = new TestMongo();
+    await mongoServer.start();
+    process.env.STAGE = 'test';
+    process.env.HEALTH_API_KEY = 'test-key';
+});
+
+afterEach(async () => {
+    await cleanupDatabase();
+});
+
+afterAll(async () => {
+    if (mongoServer) {
+        await mongoServer.stop();
+    }
+});

--- a/packages/e2e/__tests__/helpers/test-server.js
+++ b/packages/e2e/__tests__/helpers/test-server.js
@@ -1,0 +1,95 @@
+const path = require('path');
+
+class TestServer {
+    constructor() {
+        this.app = null;
+        this.server = null;
+        this.port = null;
+        this.originalCwd = null;
+        this.isStarted = false;
+    }
+
+    async start() {
+        if (this.isStarted) {
+            throw new Error('TestServer is already started');
+        }
+
+        this.originalCwd = process.cwd();
+        const testAppPath = path.resolve(__dirname, '../../test-app');
+        process.chdir(testAppPath);
+
+        const express = require('express');
+        const bodyParser = require('body-parser');
+        const cors = require('cors');
+        const Boom = require('@hapi/boom');
+
+        const { createIntegrationRouter } = require('@friggframework/core');
+        const loadUserManager = require('@friggframework/core/handlers/routers/middleware/loadUser');
+        const { router: healthRouter } = require('@friggframework/core/handlers/routers/health');
+        const { router: userRouter } = require('@friggframework/core/handlers/routers/user');
+
+        this.app = express();
+
+        this.app.use(bodyParser.json({ limit: '10mb' }));
+        this.app.use(bodyParser.urlencoded({ extended: true }));
+        this.app.use(cors({ origin: '*', credentials: true }));
+        this.app.use(loadUserManager);
+
+        this.app.use(healthRouter);
+        this.app.use(userRouter);
+        this.app.use('/api', createIntegrationRouter());
+
+        this.app.use((err, req, res, next) => {
+            const boomError = err.isBoom ? err : Boom.boomify(err);
+            const { output: { statusCode = 500 } } = boomError;
+            if (statusCode >= 500) {
+                console.error(err);
+                res.status(statusCode).json({ error: 'Internal Server Error' });
+            } else {
+                res.status(statusCode).json({ error: err.message });
+            }
+        });
+
+        return new Promise((resolve, reject) => {
+            this.server = this.app.listen(0, () => {
+                this.port = this.server.address().port;
+                this.isStarted = true;
+                resolve();
+            });
+
+            this.server.on('error', (err) => {
+                reject(err);
+            });
+        });
+    }
+
+    async stop() {
+        if (!this.isStarted) {
+            return;
+        }
+
+        if (this.server) {
+            await new Promise((resolve) => this.server.close(resolve));
+            this.server = null;
+        }
+
+        if (this.originalCwd) {
+            process.chdir(this.originalCwd);
+            this.originalCwd = null;
+        }
+
+        this.isStarted = false;
+        this.app = null;
+        this.port = null;
+    }
+
+    getBaseUrl() {
+        return `http://localhost:${this.port}`;
+    }
+
+    getApp() {
+        return this.app;
+    }
+}
+
+module.exports = { TestServer };

--- a/packages/e2e/__tests__/lifecycle/form-auth-flow.test.js
+++ b/packages/e2e/__tests__/lifecycle/form-auth-flow.test.js
@@ -1,0 +1,146 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('Form-Based Authentication Lifecycle', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('Step 1: API Key Form', () => {
+        it('should get form fields for step 1', async () => {
+            const { userId } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/authorize')
+                .query({ entityType: 'form-based-mock', step: 1 })
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('type', 'form');
+            expect(res.body).toHaveProperty('fields');
+            expect(res.body.fields).toContainEqual(
+                expect.objectContaining({ name: 'apiKey', type: 'password' })
+            );
+        });
+
+        it('should process step 1 and return next step info', async () => {
+            const { userId } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'form-based-mock',
+                    data: { apiKey: 'valid-api-key-123456' },
+                    step: 1,
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('nextStep', 2);
+        });
+
+        it('should reject invalid API key', async () => {
+            const { userId } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'form-based-mock',
+                    data: { apiKey: 'bad' },
+                    step: 1,
+                });
+
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('Step 2: Workspace Selection', () => {
+        it('should get form fields for step 2 after step 1 completes', async () => {
+            const { userId } = await fixture.createUser();
+
+            const step1Res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'form-based-mock',
+                    data: { apiKey: 'valid-api-key-123456' },
+                    step: 1,
+                });
+
+            const sessionId = step1Res.body.sessionId;
+
+            const step2FieldsRes = await request(app)
+                .get('/api/authorize')
+                .query({ entityType: 'form-based-mock', step: 2, sessionId })
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(step2FieldsRes.status).toBe(200);
+            expect(step2FieldsRes.body).toHaveProperty('fields');
+            expect(step2FieldsRes.body.fields).toContainEqual(
+                expect.objectContaining({ name: 'workspaceId' })
+            );
+        });
+    });
+
+    describe('Complete Multi-Step Flow', () => {
+        it('should complete full multi-step auth flow', async () => {
+            const { userId } = await fixture.createUser();
+
+            const step1Res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'form-based-mock',
+                    data: { apiKey: 'complete-flow-key' },
+                    step: 1,
+                });
+            expect(step1Res.status).toBe(200);
+            const sessionId = step1Res.body.sessionId;
+
+            const step2Res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'form-based-mock',
+                    data: { workspaceId: 'workspace-123' },
+                    step: 2,
+                    sessionId,
+                });
+            expect(step2Res.status).toBe(200);
+            expect(step2Res.body).toHaveProperty('entity');
+            expect(step2Res.body.entity).toHaveProperty('id');
+        });
+
+        it('should create integration after completing form auth', async () => {
+            const { userId } = await fixture.createUser();
+            const { entityId } = await fixture.createFormBasedEntity(userId);
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entities: [entityId],
+                    config: { type: 'form-based-integration' },
+                });
+
+            expect(res.status).toBe(201);
+            expect(res.body).toHaveProperty('id');
+        });
+    });
+});

--- a/packages/e2e/__tests__/lifecycle/oauth-flow.test.js
+++ b/packages/e2e/__tests__/lifecycle/oauth-flow.test.js
@@ -1,0 +1,149 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('OAuth Integration Lifecycle', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('Authorization Requirements', () => {
+        it('should get authorization requirements for oauth module', async () => {
+            const { userId } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/authorize')
+                .query({ entityType: 'oauth2-mock' })
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('type', 'oauth2');
+            expect(res.body).toHaveProperty('url');
+        });
+    });
+
+    describe('Entity Creation', () => {
+        it('should create entity after successful oauth callback', async () => {
+            const { userId } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'oauth2-mock',
+                    data: { code: 'mock-auth-code' },
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('entity');
+            expect(res.body.entity).toHaveProperty('id');
+        });
+    });
+
+    describe('Integration Creation', () => {
+        it('should create integration with valid entity', async () => {
+            const { userId } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entities: [entityId],
+                    config: { type: 'oauth-integration' },
+                });
+
+            expect(res.status).toBe(201);
+            expect(res.body).toHaveProperty('id');
+        });
+    });
+
+    describe('Integration Auth Test', () => {
+        it('should test integration auth successfully', async () => {
+            const { userId, integrationId } = await fixture.createFullOAuthSetup();
+
+            const res = await request(app)
+                .get(`/api/integrations/${integrationId}/test-auth`)
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('status', 'ok');
+        });
+    });
+
+    describe('Integration Deletion', () => {
+        it('should delete integration', async () => {
+            const { userId, integrationId } = await fixture.createFullOAuthSetup();
+
+            const res = await request(app)
+                .delete(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(204);
+        });
+
+        it('should return 404 after deletion', async () => {
+            const { userId, integrationId } = await fixture.createFullOAuthSetup();
+
+            await request(app)
+                .delete(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${userId}`);
+
+            const res = await request(app)
+                .get(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('Complete OAuth Flow', () => {
+        it('should complete full lifecycle: authorize -> create -> test -> delete', async () => {
+            const { userId } = await fixture.createUser();
+
+            const authRes = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'oauth2-mock',
+                    data: { code: 'full-flow-code' },
+                });
+            expect(authRes.status).toBe(200);
+            const entityId = authRes.body.entity.id;
+
+            const createRes = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entities: [entityId],
+                    config: { type: 'oauth-integration' },
+                });
+            expect(createRes.status).toBe(201);
+            const integrationId = createRes.body.id;
+
+            const testRes = await request(app)
+                .get(`/api/integrations/${integrationId}/test-auth`)
+                .set('Authorization', `Bearer ${userId}`);
+            expect(testRes.status).toBe(200);
+
+            const deleteRes = await request(app)
+                .delete(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${userId}`);
+            expect(deleteRes.status).toBe(204);
+        });
+    });
+});

--- a/packages/e2e/__tests__/lifecycle/webhook-flow.test.js
+++ b/packages/e2e/__tests__/lifecycle/webhook-flow.test.js
@@ -1,0 +1,169 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('Webhook Integration Lifecycle', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('Webhook Entity Creation', () => {
+        it('should create webhook entity with API key', async () => {
+            const { userId } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'webhook-mock',
+                    data: { apiKey: 'webhook-api-key' },
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('entity');
+            expect(res.body.entity).toHaveProperty('id');
+        });
+    });
+
+    describe('Webhook Integration Creation', () => {
+        it('should create webhook integration', async () => {
+            const { userId } = await fixture.createUser();
+            const { entityId } = await fixture.createWebhookEntity(userId);
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entities: [entityId],
+                    config: { type: 'webhook-integration' },
+                });
+
+            expect(res.status).toBe(201);
+            expect(res.body).toHaveProperty('id');
+        });
+    });
+
+    describe('Webhook Signature Validation', () => {
+        it('should receive webhook and validate signature', async () => {
+            const { userId, integrationId } = await fixture.createFullWebhookSetup();
+            const payload = {
+                event: 'item.created',
+                data: { id: '123', name: 'Test Item' },
+            };
+
+            const res = await request(app)
+                .post(`/api/webhook-integration/webhooks/${integrationId}`)
+                .set('X-Webhook-Signature', 'valid-signature')
+                .send(payload);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('received', true);
+        });
+
+        it('should reject webhook with invalid signature', async () => {
+            const { integrationId } = await fixture.createFullWebhookSetup();
+            const payload = {
+                event: 'item.created',
+                data: { id: '123' },
+            };
+
+            const res = await request(app)
+                .post(`/api/webhook-integration/webhooks/${integrationId}`)
+                .set('X-Webhook-Signature', 'invalid-signature')
+                .send(payload);
+
+            expect(res.status).toBe(401);
+        });
+
+        it('should reject webhook with missing signature', async () => {
+            const { integrationId } = await fixture.createFullWebhookSetup();
+            const payload = {
+                event: 'item.created',
+                data: { id: '123' },
+            };
+
+            const res = await request(app)
+                .post(`/api/webhook-integration/webhooks/${integrationId}`)
+                .send(payload);
+
+            expect(res.status).toBe(401);
+        });
+    });
+
+    describe('Webhook Event Processing', () => {
+        it('should process item.created event', async () => {
+            const { integrationId } = await fixture.createFullWebhookSetup();
+            const payload = {
+                event: 'item.created',
+                data: { id: '456', name: 'New Item' },
+            };
+
+            const res = await request(app)
+                .post(`/api/webhook-integration/webhooks/${integrationId}`)
+                .set('X-Webhook-Signature', 'valid-signature')
+                .send(payload);
+
+            expect(res.status).toBe(200);
+        });
+
+        it('should process item.updated event', async () => {
+            const { integrationId } = await fixture.createFullWebhookSetup();
+            const payload = {
+                event: 'item.updated',
+                data: { id: '456', name: 'Updated Item' },
+            };
+
+            const res = await request(app)
+                .post(`/api/webhook-integration/webhooks/${integrationId}`)
+                .set('X-Webhook-Signature', 'valid-signature')
+                .send(payload);
+
+            expect(res.status).toBe(200);
+        });
+
+        it('should process item.deleted event', async () => {
+            const { integrationId } = await fixture.createFullWebhookSetup();
+            const payload = {
+                event: 'item.deleted',
+                data: { id: '456' },
+            };
+
+            const res = await request(app)
+                .post(`/api/webhook-integration/webhooks/${integrationId}`)
+                .set('X-Webhook-Signature', 'valid-signature')
+                .send(payload);
+
+            expect(res.status).toBe(200);
+        });
+    });
+
+    describe('Invalid Integration Webhook', () => {
+        it('should return 404 for nonexistent integration', async () => {
+            const payload = {
+                event: 'item.created',
+                data: { id: '123' },
+            };
+
+            const res = await request(app)
+                .post('/api/webhook-integration/webhooks/nonexistent-id')
+                .set('X-Webhook-Signature', 'valid-signature')
+                .send(payload);
+
+            expect(res.status).toBe(404);
+        });
+    });
+});

--- a/packages/e2e/__tests__/management-api/entities.test.js
+++ b/packages/e2e/__tests__/management-api/entities.test.js
@@ -1,0 +1,182 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('Management API - Entities', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('GET /api/entities', () => {
+        it('should require authentication', async () => {
+            const res = await request(app).get('/api/entities');
+            expect(res.status).toBe(401);
+        });
+
+        it('should return empty list for new user', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/entities')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('entities');
+            expect(res.body.entities).toHaveLength(0);
+        });
+
+        it('should return entities for user with existing entities', async () => {
+            const { userId, token } = await fixture.createUser();
+            await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .get('/api/entities')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body.entities.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('GET /api/entities/:id', () => {
+        it('should return entity details', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .get(`/api/entities/${entityId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('id', entityId);
+        });
+
+        it('should return 404 for nonexistent entity', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/entities/nonexistent-id')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+
+        it('should not allow access to other user entities', async () => {
+            const { userId: user1Id } = await fixture.createUser();
+            const { token: user2Token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(user1Id);
+
+            const res = await request(app)
+                .get(`/api/entities/${entityId}`)
+                .set('Authorization', `Bearer ${user2Token}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('GET /api/entities/:id/test-auth', () => {
+        it('should test entity authentication', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .get(`/api/entities/${entityId}/test-auth`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('status', 'ok');
+        });
+
+        it('should return 404 for nonexistent entity', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/entities/nonexistent-id/test-auth')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('DELETE /api/entities/:id', () => {
+        it('should delete entity', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .delete(`/api/entities/${entityId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(204);
+        });
+
+        it('should return 404 after deletion', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            await request(app)
+                .delete(`/api/entities/${entityId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            const res = await request(app)
+                .get(`/api/entities/${entityId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('Entity Types', () => {
+        it('should support oauth2-mock entity type', async () => {
+            const { userId, token } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entityType: 'oauth2-mock',
+                    data: { code: 'test-code' },
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body.entity).toHaveProperty('type', 'oauth2-mock');
+        });
+
+        it('should support form-based-mock entity type', async () => {
+            const { userId } = await fixture.createUser();
+            const { entity, response } = await fixture.createFormBasedEntity(userId);
+
+            expect(response.status).toBe(200);
+            expect(entity).toHaveProperty('type', 'form-based-mock');
+        });
+
+        it('should support webhook-mock entity type', async () => {
+            const { userId, token } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entityType: 'webhook-mock',
+                    data: { apiKey: 'test-key' },
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body.entity).toHaveProperty('type', 'webhook-mock');
+        });
+    });
+});

--- a/packages/e2e/__tests__/management-api/health.test.js
+++ b/packages/e2e/__tests__/management-api/health.test.js
@@ -1,0 +1,78 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+
+describe('Management API - Health Checks', () => {
+    let server;
+    let app;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    describe('GET /health', () => {
+        it('should return basic health status', async () => {
+            const res = await request(app).get('/health');
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('status', 'ok');
+            expect(res.body).toHaveProperty('timestamp');
+        });
+    });
+
+    describe('GET /health/live', () => {
+        it('should require API key for liveness check', async () => {
+            const res = await request(app).get('/health/live');
+            expect(res.status).toBe(401);
+        });
+
+        it('should return liveness status with valid API key', async () => {
+            const res = await request(app)
+                .get('/health/live')
+                .set('x-frigg-health-api-key', process.env.HEALTH_API_KEY || 'test-key');
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('status', 'alive');
+        });
+    });
+
+    describe('GET /health/ready', () => {
+        it('should return readiness response with checks', async () => {
+            const res = await request(app)
+                .get('/health/ready')
+                .set('x-frigg-health-api-key', process.env.HEALTH_API_KEY || 'test-key');
+
+            expect([200, 503]).toContain(res.status);
+            expect(res.body).toHaveProperty('ready');
+            expect(res.body).toHaveProperty('checks');
+        });
+
+        it('should require API key', async () => {
+            const res = await request(app).get('/health/ready');
+            expect(res.status).toBe(401);
+        });
+    });
+
+    describe('GET /health/detailed', () => {
+        it('should return detailed health information', async () => {
+            const res = await request(app)
+                .get('/health/detailed')
+                .set('x-frigg-health-api-key', process.env.HEALTH_API_KEY || 'test-key');
+
+            expect([200, 503]).toContain(res.status);
+            expect(res.body).toHaveProperty('status');
+            expect(res.body).toHaveProperty('checks');
+            expect(res.body.checks).toHaveProperty('database');
+        });
+
+        it('should require API key', async () => {
+            const res = await request(app).get('/health/detailed');
+            expect(res.status).toBe(401);
+        });
+    });
+});

--- a/packages/e2e/__tests__/management-api/integrations.test.js
+++ b/packages/e2e/__tests__/management-api/integrations.test.js
@@ -1,0 +1,227 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('Management API - Integrations', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('GET /api/integrations/options', () => {
+        it('should return available integration types', async () => {
+            const res = await request(app).get('/api/integrations/options');
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('integrations');
+            expect(Array.isArray(res.body.integrations)).toBe(true);
+        });
+
+        it('should include oauth, form-based, and webhook integrations', async () => {
+            const res = await request(app).get('/api/integrations/options');
+
+            const names = res.body.integrations.map((i) => i.name);
+            expect(names).toContain('oauth-integration');
+            expect(names).toContain('form-based-integration');
+            expect(names).toContain('webhook-integration');
+        });
+    });
+
+    describe('GET /api/integrations', () => {
+        it('should require authentication', async () => {
+            const res = await request(app).get('/api/integrations');
+            expect(res.status).toBe(401);
+        });
+
+        it('should return empty list for new user', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/integrations')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('integrations');
+            expect(res.body.integrations).toHaveLength(0);
+        });
+
+        it('should return integrations for user with existing integrations', async () => {
+            const { userId, token } = await fixture.createUser();
+            await fixture.createOAuthIntegration(userId);
+
+            const res = await request(app)
+                .get('/api/integrations')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body.integrations.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('POST /api/integrations', () => {
+        it('should require authentication', async () => {
+            const res = await request(app)
+                .post('/api/integrations')
+                .send({ entities: ['some-id'], config: { type: 'oauth-integration' } });
+
+            expect(res.status).toBe(401);
+        });
+
+        it('should create integration with valid entity', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entities: [entityId],
+                    config: { type: 'oauth-integration' },
+                });
+
+            expect(res.status).toBe(201);
+            expect(res.body).toHaveProperty('id');
+            expect(res.body).toHaveProperty('status');
+        });
+
+        it('should reject invalid integration type', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entities: [entityId],
+                    config: { type: 'nonexistent-integration' },
+                });
+
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('GET /api/integrations/:id', () => {
+        it('should return integration details', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { integrationId } = await fixture.createOAuthIntegration(userId);
+
+            const res = await request(app)
+                .get(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('id', integrationId);
+            expect(res.body).toHaveProperty('config');
+            expect(res.body).toHaveProperty('entities');
+        });
+
+        it('should return 404 for nonexistent integration', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/integrations/nonexistent-id')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+
+        it('should not allow access to other user integrations', async () => {
+            const { userId: user1Id } = await fixture.createUser();
+            const { token: user2Token } = await fixture.createUser();
+            const { integrationId } = await fixture.createOAuthIntegration(user1Id);
+
+            const res = await request(app)
+                .get(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${user2Token}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('PATCH /api/integrations/:id', () => {
+        it('should update integration config', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { integrationId } = await fixture.createOAuthIntegration(userId);
+
+            const res = await request(app)
+                .patch(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    config: { customSetting: 'value' },
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body.config).toHaveProperty('customSetting', 'value');
+        });
+
+        it('should preserve existing config when updating', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { integrationId } = await fixture.createOAuthIntegration(userId);
+
+            await request(app)
+                .patch(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({ config: { setting1: 'value1' } });
+
+            const res = await request(app)
+                .patch(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({ config: { setting2: 'value2' } });
+
+            expect(res.status).toBe(200);
+            expect(res.body.config).toHaveProperty('setting1', 'value1');
+            expect(res.body.config).toHaveProperty('setting2', 'value2');
+        });
+    });
+
+    describe('DELETE /api/integrations/:id', () => {
+        it('should delete integration', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { integrationId } = await fixture.createOAuthIntegration(userId);
+
+            const res = await request(app)
+                .delete(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(204);
+        });
+
+        it('should return 404 after deletion', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { integrationId } = await fixture.createOAuthIntegration(userId);
+
+            await request(app)
+                .delete(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            const res = await request(app)
+                .get(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+
+        it('should return 404 for nonexistent integration', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .delete('/api/integrations/nonexistent-id')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+});

--- a/packages/e2e/jest.config.js
+++ b/packages/e2e/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+    displayName: 'e2e',
+    testEnvironment: 'node',
+    testMatch: ['**/__tests__/**/*.test.js'],
+    testTimeout: 30000,
+    setupFilesAfterEnv: ['<rootDir>/__tests__/helpers/setup.js'],
+    collectCoverageFrom: [
+        'test-app/**/*.js',
+        '!**/__tests__/**',
+    ],
+};

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@friggframework/e2e",
+  "version": "1.0.0",
+  "private": true,
+  "description": "End-to-end test suite for Frigg Framework",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:ci": "jest --ci --coverage",
+    "test:management-api": "jest --testPathPattern=management-api",
+    "test:cli": "jest --testPathPattern=cli",
+    "test:lifecycle": "jest --testPathPattern=lifecycle"
+  },
+  "dependencies": {
+    "@friggframework/core": "*"
+  },
+  "devDependencies": {
+    "@friggframework/test": "*",
+    "jest": "^29.7.0",
+    "mongodb-memory-server": "^8.9.0",
+    "supertest": "^6.3.3"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/packages/e2e/test-app/backend/api-modules/formBasedMockModule.js
+++ b/packages/e2e/test-app/backend/api-modules/formBasedMockModule.js
@@ -1,0 +1,97 @@
+const { ApiKeyRequester } = require('@friggframework/core');
+
+class FormBasedMockApi extends ApiKeyRequester {
+    constructor(params = {}) {
+        super(params);
+        this.baseUrl = 'https://mock-form-api.example.com';
+        this.workspaceId = params.workspaceId || null;
+    }
+
+    getAuthorizationRequirements(step = 1) {
+        if (step === 1) {
+            return {
+                type: 'form',
+                fields: [
+                    { name: 'apiKey', label: 'API Key', type: 'password', required: true },
+                ],
+            };
+        }
+        return {
+            type: 'form',
+            fields: [
+                { name: 'workspaceId', label: 'Workspace ID', type: 'text', required: true },
+            ],
+        };
+    }
+
+    async validateApiKey(apiKey) {
+        return apiKey && apiKey.length > 5;
+    }
+
+    async getWorkspaces() {
+        return [
+            { id: 'ws-1', name: 'Workspace 1' },
+            { id: 'ws-2', name: 'Workspace 2' },
+        ];
+    }
+
+    async getUserDetails() {
+        return {
+            id: 'form-user-123',
+            email: 'formuser@example.com',
+            workspaceId: this.workspaceId,
+        };
+    }
+}
+
+const Definition = {
+    API: FormBasedMockApi,
+    getName: () => 'form-based-mock',
+    moduleName: 'form-based-mock',
+    modelName: 'FormBasedMock',
+    authType: 'form',
+    isMultiStep: true,
+    requiredAuthMethods: {
+        getAuthorizationRequirements: (api, step) => {
+            return api.getAuthorizationRequirements(step);
+        },
+        processStep: async (api, step, data) => {
+            if (step === 1) {
+                const isValid = await api.validateApiKey(data.apiKey);
+                if (!isValid) {
+                    throw new Error('Invalid API key');
+                }
+                api.setApiKey(data.apiKey);
+                return { nextStep: 2 };
+            }
+            if (step === 2) {
+                api.workspaceId = data.workspaceId;
+                return { complete: true };
+            }
+        },
+        getEntityDetails: async (api, callbackParams, tokenResponse, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: { externalId: userDetails.id, user: userId },
+                details: { workspaceId: userDetails.workspaceId },
+            };
+        },
+        apiPropertiesToPersist: {
+            credential: ['api_key'],
+            entity: ['workspaceId'],
+        },
+        getCredentialDetails: async (api, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: { externalId: userDetails.id, user: userId },
+                details: {},
+            };
+        },
+        testAuthRequest: async (api) => {
+            return api.getUserDetails();
+        },
+    },
+    env: {},
+};
+
+module.exports = { Definition, FormBasedMockApi };

--- a/packages/e2e/test-app/backend/api-modules/oauth2MockModule.js
+++ b/packages/e2e/test-app/backend/api-modules/oauth2MockModule.js
@@ -1,0 +1,75 @@
+const { OAuth2Requester } = require('@friggframework/core');
+
+class OAuth2MockApi extends OAuth2Requester {
+    constructor(params = {}) {
+        super(params);
+        this.baseUrl = 'https://mock-oauth-api.example.com';
+        this.tokenUri = 'https://mock-oauth-api.example.com/oauth/token';
+        this.authorizationUri = `https://mock-oauth-api.example.com/oauth/authorize?client_id=${this.client_id}&redirect_uri=${this.redirect_uri}`;
+    }
+
+    getAuthorizationRequirements() {
+        return {
+            url: this.authorizationUri,
+            type: 'oauth2',
+        };
+    }
+
+    async getTokenFromCode(code) {
+        return {
+            access_token: `mock-access-token-${Date.now()}`,
+            refresh_token: `mock-refresh-token-${Date.now()}`,
+            expires_in: 3600,
+        };
+    }
+
+    async getUserDetails() {
+        return {
+            id: 'mock-user-123',
+            email: 'mockuser@example.com',
+            name: 'Mock User',
+        };
+    }
+}
+
+const Definition = {
+    API: OAuth2MockApi,
+    getName: () => 'oauth2-mock',
+    moduleName: 'oauth2-mock',
+    modelName: 'OAuth2Mock',
+    requiredAuthMethods: {
+        getToken: async (api, params) => {
+            const code = params.data?.code;
+            return api.getTokenFromCode(code);
+        },
+        getEntityDetails: async (api, callbackParams, tokenResponse, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: { externalId: userDetails.id, user: userId },
+                details: { name: userDetails.name, email: userDetails.email },
+            };
+        },
+        apiPropertiesToPersist: {
+            credential: ['access_token', 'refresh_token'],
+            entity: [],
+        },
+        getCredentialDetails: async (api, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: { externalId: userDetails.id, user: userId },
+                details: {},
+            };
+        },
+        testAuthRequest: async (api) => {
+            return api.getUserDetails();
+        },
+    },
+    env: {
+        client_id: 'mock-client-id',
+        client_secret: 'mock-client-secret',
+        redirect_uri: 'http://localhost:3000/redirect/oauth2-mock',
+        scope: 'read write',
+    },
+};
+
+module.exports = { Definition, OAuth2MockApi };

--- a/packages/e2e/test-app/backend/api-modules/webhookMockModule.js
+++ b/packages/e2e/test-app/backend/api-modules/webhookMockModule.js
@@ -1,0 +1,81 @@
+const { ApiKeyRequester } = require('@friggframework/core');
+const crypto = require('crypto');
+
+class WebhookMockApi extends ApiKeyRequester {
+    constructor(params = {}) {
+        super(params);
+        this.baseUrl = 'https://mock-webhook-api.example.com';
+        this.webhookSecret = params.webhookSecret || 'default-webhook-secret';
+    }
+
+    getAuthorizationRequirements() {
+        return {
+            type: 'form',
+            fields: [
+                { name: 'apiKey', label: 'API Key', type: 'password', required: true },
+            ],
+        };
+    }
+
+    async getUserDetails() {
+        return {
+            id: 'webhook-user-123',
+            email: 'webhookuser@example.com',
+        };
+    }
+
+    async registerWebhook(url, events) {
+        return {
+            id: `webhook-${Date.now()}`,
+            url,
+            events,
+            active: true,
+        };
+    }
+
+    validateWebhookSignature(payload, signature) {
+        if (signature === 'valid-signature') return true;
+        const expectedSignature = crypto
+            .createHmac('sha256', this.webhookSecret)
+            .update(JSON.stringify(payload))
+            .digest('hex');
+        return signature === expectedSignature;
+    }
+}
+
+const Definition = {
+    API: WebhookMockApi,
+    getName: () => 'webhook-mock',
+    moduleName: 'webhook-mock',
+    modelName: 'WebhookMock',
+    requiredAuthMethods: {
+        getToken: async (api, params) => {
+            api.setApiKey(params.data?.apiKey);
+            return { api_key: params.data?.apiKey };
+        },
+        getEntityDetails: async (api, callbackParams, tokenResponse, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: { externalId: userDetails.id, user: userId },
+                details: { email: userDetails.email },
+            };
+        },
+        apiPropertiesToPersist: {
+            credential: ['api_key'],
+            entity: [],
+        },
+        getCredentialDetails: async (api, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: { externalId: userDetails.id, user: userId },
+                details: {},
+            };
+        },
+        testAuthRequest: async (api) => {
+            return api.getUserDetails();
+        },
+    },
+    env: {},
+};
+
+module.exports = { Definition, WebhookMockApi };

--- a/packages/e2e/test-app/backend/index.js
+++ b/packages/e2e/test-app/backend/index.js
@@ -1,0 +1,21 @@
+const { OAuthIntegration } = require('./integrations/oauthIntegration');
+const { FormBasedIntegration } = require('./integrations/formBasedIntegration');
+const { WebhookIntegration } = require('./integrations/webhookIntegration');
+
+const Definition = {
+    integrations: [
+        OAuthIntegration,
+        FormBasedIntegration,
+        WebhookIntegration,
+    ],
+    database: {
+        mongoDB: {
+            enable: true,
+        },
+    },
+    user: {
+        model: 'mongoose',
+    },
+};
+
+module.exports = { Definition };

--- a/packages/e2e/test-app/backend/integrations/formBasedIntegration.js
+++ b/packages/e2e/test-app/backend/integrations/formBasedIntegration.js
@@ -1,0 +1,52 @@
+const { IntegrationBase } = require('@friggframework/core');
+const { Definition: FormBasedMockDefinition } = require('../api-modules/formBasedMockModule');
+
+class FormBasedIntegration extends IntegrationBase {
+    static Definition = {
+        name: 'form-based-integration',
+        version: '1.0.0',
+        supportedVersions: ['>=1.0.0'],
+        modules: {
+            formBasedMock: {
+                definition: FormBasedMockDefinition,
+                options: {},
+            },
+        },
+        display: {
+            name: 'Form-Based Integration',
+            description: 'Test integration using form-based multi-step authentication',
+            icon: 'form-icon',
+        },
+    };
+
+    async onCreate({ integrationId }) {
+        await this.updateIntegrationStatus.execute(integrationId, 'NEEDS_CONFIG');
+    }
+
+    async getConfigOptions() {
+        return {
+            jsonSchema: {
+                type: 'object',
+                properties: {
+                    defaultWorkspace: { type: 'string', title: 'Default Workspace' },
+                },
+                required: ['defaultWorkspace'],
+            },
+            uiSchema: {},
+        };
+    }
+
+    async testAuth() {
+        let success = true;
+        if (this.formBasedMock) {
+            try {
+                await this.formBasedMock.testAuth();
+            } catch {
+                success = false;
+            }
+        }
+        return success;
+    }
+}
+
+module.exports = { FormBasedIntegration };

--- a/packages/e2e/test-app/backend/integrations/oauthIntegration.js
+++ b/packages/e2e/test-app/backend/integrations/oauthIntegration.js
@@ -1,0 +1,52 @@
+const { IntegrationBase } = require('@friggframework/core');
+const { Definition: OAuth2MockDefinition } = require('../api-modules/oauth2MockModule');
+
+class OAuthIntegration extends IntegrationBase {
+    static Definition = {
+        name: 'oauth-integration',
+        version: '1.0.0',
+        supportedVersions: ['>=1.0.0'],
+        modules: {
+            oauth2Mock: {
+                definition: OAuth2MockDefinition,
+                options: {},
+            },
+        },
+        display: {
+            name: 'OAuth Integration',
+            description: 'Test integration using OAuth2 authentication',
+            icon: 'oauth-icon',
+        },
+    };
+
+    async onCreate({ integrationId }) {
+        await this.updateIntegrationStatus.execute(integrationId, 'ENABLED');
+    }
+
+    async getConfigOptions() {
+        return {
+            jsonSchema: {
+                type: 'object',
+                properties: {
+                    syncEnabled: { type: 'boolean', title: 'Enable Sync' },
+                    syncInterval: { type: 'number', title: 'Sync Interval (minutes)' },
+                },
+            },
+            uiSchema: {},
+        };
+    }
+
+    async testAuth() {
+        let success = true;
+        if (this.oauth2Mock) {
+            try {
+                await this.oauth2Mock.testAuth();
+            } catch {
+                success = false;
+            }
+        }
+        return success;
+    }
+}
+
+module.exports = { OAuthIntegration };

--- a/packages/e2e/test-app/backend/integrations/webhookIntegration.js
+++ b/packages/e2e/test-app/backend/integrations/webhookIntegration.js
@@ -1,0 +1,75 @@
+const { IntegrationBase } = require('@friggframework/core');
+const { Definition: WebhookMockDefinition } = require('../api-modules/webhookMockModule');
+
+class WebhookIntegration extends IntegrationBase {
+    static Definition = {
+        name: 'webhook-integration',
+        version: '1.0.0',
+        supportedVersions: ['>=1.0.0'],
+        modules: {
+            webhookMock: {
+                definition: WebhookMockDefinition,
+                options: {},
+            },
+        },
+        display: {
+            name: 'Webhook Integration',
+            description: 'Test integration with webhook support',
+            icon: 'webhook-icon',
+        },
+    };
+
+    async onCreate({ integrationId }) {
+        await this.updateIntegrationStatus.execute(integrationId, 'ENABLED');
+    }
+
+    async getConfigOptions() {
+        return {
+            jsonSchema: {
+                type: 'object',
+                properties: {
+                    webhookEvents: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        title: 'Webhook Events to Subscribe',
+                    },
+                },
+            },
+            uiSchema: {},
+        };
+    }
+
+    async onWebhookReceived({ req, res }) {
+        const signature = req.headers['x-webhook-signature'];
+        const payload = req.body;
+
+        if (!this.webhookMock) {
+            return res.status(500).json({ error: 'Module not loaded' });
+        }
+
+        const isValid = this.webhookMock.api.validateWebhookSignature(payload, signature);
+        if (!isValid) {
+            return res.status(401).json({ error: 'Invalid signature' });
+        }
+
+        res.status(200).json({ received: true });
+    }
+
+    async onWebhook({ data }) {
+        return { processed: true, event: data.body?.event };
+    }
+
+    async testAuth() {
+        let success = true;
+        if (this.webhookMock) {
+            try {
+                await this.webhookMock.testAuth();
+            } catch {
+                success = false;
+            }
+        }
+        return success;
+    }
+}
+
+module.exports = { WebhookIntegration };

--- a/packages/e2e/test-app/backend/package.json
+++ b/packages/e2e/test-app/backend/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@friggframework/e2e-test-app",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js"
+}


### PR DESCRIPTION
## Summary
- Add new `frigg validate` CLI command that validates Frigg app configurations
- Auto-detects nearest Frigg app when no path given (traverses up directories)
- Follows DDD/hexagonal architecture with 101 passing tests (TDD approach)
- Add E2E test package with mock API modules for integration testing

## Features
- `frigg validate` - auto-detects local Frigg app
- `frigg validate ./path` - explicit path
- `--format json` - JSON output
- `--verbose` - shows fix suggestions

## Architecture
```
validate-command/
├── domain/
│   ├── entities/validation-result.js
│   └── value-objects/{validation-error,fix-suggestion}.js
├── application/use-cases/validate-app-use-case.js
├── infrastructure/validators/{app-definition,integration-class}-validator.js
├── adapters/cli/validate-command.js
└── __tests__/ (7 test suites, 101 tests)
```

## Test plan
- [x] All 101 validate-command tests pass
- [x] Auto-detection works from app root directory
- [x] Auto-detection works from subdirectories
- [x] Shows helpful error when no Frigg app found
- [x] Explicit path still works
- [x] JSON output format works
- [x] Verbose mode shows fix suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)