### PR TITLE
fix: pass existing config to integration constructor in UpdateIntegration

### DIFF
--- a/packages/core/integrations/tests/doubles/config-capturing-integration.js
+++ b/packages/core/integrations/tests/doubles/config-capturing-integration.js
@@ -1,76 +1,60 @@
 const { IntegrationBase } = require('../../integration-base');
 
-class DummyModule {
+class ConfigCapturingModule {
     static definition = {
-        getName: () => 'dummy'
+        getName: () => 'config-capturing-module'
     };
 }
 
-class DummyIntegration extends IntegrationBase {
+class ConfigCapturingIntegration extends IntegrationBase {
     static Definition = {
-        name: 'dummy',
+        name: 'config-capturing',
         version: '1.0.0',
         modules: {
-            dummy: DummyModule
+            primary: ConfigCapturingModule
         },
         display: {
-            label: 'Dummy Integration',
-            description: 'A dummy integration for testing',
+            label: 'Config Capturing Integration',
+            description: 'Test double for capturing config state during updates',
             detailsUrl: 'https://example.com',
-            icon: 'dummy-icon'
+            icon: 'test-icon'
         }
     };
 
-    static getOptionDetails() {
-        return {
-            name: this.Definition.name,
-            version: this.Definition.version,
-            display: this.Definition.display
-        };
+    static _capturedOnUpdateState = null;
+
+    static resetCaptures() {
+        this._capturedOnUpdateState = null;
+    }
+
+    static getCapturedOnUpdateState() {
+        return this._capturedOnUpdateState;
     }
 
     constructor(params) {
         super(params);
-        this.sendSpy = jest.fn();
-        this.eventCallHistory = [];
-        this.events = {};
-
         this.integrationRepository = {
             updateIntegrationById: jest.fn().mockResolvedValue({}),
             findIntegrationById: jest.fn().mockResolvedValue({}),
         };
-
         this.updateIntegrationStatus = {
             execute: jest.fn().mockResolvedValue({})
         };
-
         this.updateIntegrationMessages = {
             execute: jest.fn().mockResolvedValue({})
         };
     }
 
-    async loadDynamicUserActions() {
-        return {};
-    }
-
-    async send(event, data) {
-        this.sendSpy(event, data);
-        this.eventCallHistory.push({ event, data, timestamp: Date.now() });
-        if (event === 'ON_UPDATE') {
-            await this.onUpdate(data);
-        }
-        return { event, data };
-    }
-
     async initialize() {
-        return;
-    }
-
-    async onCreate({ integrationId }) {
-        return;
+        this.registerEventHandlers();
     }
 
     async onUpdate(params) {
+        ConfigCapturingIntegration._capturedOnUpdateState = {
+            thisConfig: JSON.parse(JSON.stringify(this.config)),
+            paramsConfig: params.config
+        };
+
         this.config = this._deepMerge(this.config, params.config);
     }
 
@@ -92,14 +76,6 @@ class DummyIntegration extends IntegrationBase {
         }
         return result;
     }
-
-    async onDelete(params) {
-        return;
-    }
-
-    getConfig() {
-        return this.config || {};
-    }
 }
 
-module.exports = { DummyIntegration }; 
+module.exports = { ConfigCapturingIntegration };

--- a/packages/core/integrations/tests/use-cases/update-integration.test.js
+++ b/packages/core/integrations/tests/use-cases/update-integration.test.js
@@ -9,6 +9,7 @@ const { UpdateIntegration } = require('../../use-cases/update-integration');
 const { TestIntegrationRepository } = require('../doubles/test-integration-repository');
 const { TestModuleFactory } = require('../../../modules/tests/doubles/test-module-factory');
 const { DummyIntegration } = require('../doubles/dummy-integration-class');
+const { ConfigCapturingIntegration } = require('../doubles/config-capturing-integration');
 
 describe('UpdateIntegration Use-Case', () => {
     let integrationRepository;
@@ -121,7 +122,7 @@ describe('UpdateIntegration Use-Case', () => {
             expect(dto.config.bar).toBeUndefined();
         });
 
-        it('handles deeply nested config updates', async () => {
+        it('handles deeply nested config updates with merge semantics', async () => {
             const record = await integrationRepository.createIntegration(['e1'], 'user-1', { type: 'dummy', nested: { old: 'value' } });
 
             const newConfig = {
@@ -135,7 +136,73 @@ describe('UpdateIntegration Use-Case', () => {
 
             expect(dto.config.nested.new).toBe('value');
             expect(dto.config.nested.deep.level).toBe('test');
-            expect(dto.config.nested.old).toBeUndefined();
+            expect(dto.config.nested.old).toBe('value');
+        });
+    });
+
+    describe('partial config update semantics (issue #514)', () => {
+        let configCapturingUseCase;
+
+        beforeEach(() => {
+            ConfigCapturingIntegration.resetCaptures();
+            configCapturingUseCase = new UpdateIntegration({
+                integrationRepository,
+                integrationClasses: [ConfigCapturingIntegration],
+                moduleFactory,
+            });
+        });
+
+        it('passes existing database config to integration constructor', async () => {
+            const existingConfig = { type: 'config-capturing', a: 1, b: 2, c: 3 };
+            const record = await integrationRepository.createIntegration(
+                ['e1'],
+                'user-1',
+                existingConfig
+            );
+
+            const partialUpdateConfig = { type: 'config-capturing', a: 10 };
+            await configCapturingUseCase.execute(record.id, 'user-1', partialUpdateConfig);
+
+            const captured = ConfigCapturingIntegration.getCapturedOnUpdateState();
+            expect(captured.thisConfig).toEqual(existingConfig);
+            expect(captured.paramsConfig).toEqual(partialUpdateConfig);
+        });
+
+        it('allows onUpdate to merge partial config with existing config', async () => {
+            const existingConfig = { type: 'config-capturing', a: 1, b: 2, c: 3 };
+            const record = await integrationRepository.createIntegration(
+                ['e1'],
+                'user-1',
+                existingConfig
+            );
+
+            const partialUpdateConfig = { type: 'config-capturing', a: 10 };
+            const dto = await configCapturingUseCase.execute(record.id, 'user-1', partialUpdateConfig);
+
+            expect(dto.config).toEqual({ type: 'config-capturing', a: 10, b: 2, c: 3 });
+        });
+
+        it('preserves nested existing values during partial update', async () => {
+            const existingConfig = {
+                type: 'config-capturing',
+                settings: { theme: 'dark', notifications: true },
+                credentials: { apiKey: 'secret123' }
+            };
+            const record = await integrationRepository.createIntegration(
+                ['e1'],
+                'user-1',
+                existingConfig
+            );
+
+            const partialUpdateConfig = {
+                type: 'config-capturing',
+                settings: { theme: 'light' }
+            };
+            const dto = await configCapturingUseCase.execute(record.id, 'user-1', partialUpdateConfig);
+
+            expect(dto.config.settings.theme).toBe('light');
+            expect(dto.config.settings.notifications).toBe(true);
+            expect(dto.config.credentials.apiKey).toBe('secret123');
         });
     });
 }); 

--- a/packages/core/integrations/use-cases/update-integration.js
+++ b/packages/core/integrations/use-cases/update-integration.js
@@ -70,12 +70,12 @@ class UpdateIntegration {
             modules.push(moduleInstance);
         }
 
-        // 4. Create the Integration domain entity with modules and updated config
+        // 4. Create the Integration domain entity with modules and existing config
         const integrationInstance = new integrationClass({
             id: integrationRecord.id,
             userId: integrationRecord.userId,
             entities: integrationRecord.entitiesIds,
-            config: config,
+            config: integrationRecord.config,
             status: integrationRecord.status,
             version: integrationRecord.version,
             messages: integrationRecord.messages,


### PR DESCRIPTION
## Summary

Fixes #514 - `UpdateIntegration` was passing the new config instead of the existing database config to the integration constructor, breaking partial update semantics.

- Pass `integrationRecord.config` (existing) instead of `config` (new) to constructor
- Integration's `onUpdate` handler now correctly receives existing config in `this.config` and new config in `params.config`
- Partial updates now preserve unspecified fields as expected

## Test plan

- [x] Added TDD tests verifying `this.config` contains existing database values when `onUpdate` is called
- [x] Added tests verifying partial config updates preserve unspecified fields
- [x] Added tests verifying nested values are preserved during partial updates
- [x] All 95 integration use-case tests pass
