### PR TITLE
fix: Exclude .env files from serverless package deployment 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,12 @@
 
 # misc
 .DS_Store
+
+# environment files - catch all variations
+.env
+.env.*
 .env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env.*.local
 
 npm-debug.log*
 yarn-debug.log*
@@ -35,7 +37,6 @@ claude-flow.log
 .frigg-infrastructure-cache.json
 .frigg-infrastructure-lock
 
-.env
 .npmrc
 .autorc
 /.nx/

--- a/packages/devtools/.npmignore
+++ b/packages/devtools/.npmignore
@@ -1,0 +1,15 @@
+# Test files
+test/
+
+# Dev config
+.eslintrc.json
+
+# Environment files - never publish these
+.env
+.env.*
+.env.local
+.env.*.local
+*.env
+
+# Changelog (optional, can be included if desired)
+CHANGELOG.md

--- a/packages/devtools/infrastructure/domains/shared/utilities/base-definition-factory.js
+++ b/packages/devtools/infrastructure/domains/shared/utilities/base-definition-factory.js
@@ -81,7 +81,13 @@ function createBaseDefinition(
             'node_modules/serverless-kms-grants/**',
             // Note: DO NOT exclude serverless-http - it's a runtime dependency!
 
-            // Exclude local dev files
+            // Exclude local dev files and environment files (NEVER deploy .env files!)
+            '.env',
+            '.env.*',
+            '.env.local',
+            '.env.*.local',
+            '**/.env',
+            '**/.env.*',
             'deploy.log',
             '.env.backup',
             'docker-compose.yml',
@@ -123,6 +129,14 @@ function createBaseDefinition(
             // Exclude nested node_modules from symlinked frigg packages (for npm link development)
             'node_modules/@friggframework/core/node_modules/**',
             'node_modules/@friggframework/devtools/node_modules/**',
+
+            // Exclude environment files (NEVER deploy .env files!)
+            '.env',
+            '.env.*',
+            '.env.local',
+            '.env.*.local',
+            '**/.env',
+            '**/.env.*',
 
             // Exclude development/test files from backend project
             'coverage/**',

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -5,6 +5,13 @@
   "bin": {
     "frigg": "./frigg-cli/index.js"
   },
+  "files": [
+    "frigg-cli/",
+    "migrations/",
+    "management-ui/dist/",
+    "index.js",
+    "README.md"
+  ],
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.705.0",
     "@aws-sdk/client-ec2": "^3.835.0",


### PR DESCRIPTION
## Summary
- Fix `.env` files being included in Lambda deployment packages during `frigg deploy`
- Add proper file exclusions to prevent accidental secret exposure

## Changes

### Root Cause Fix
**`packages/devtools/infrastructure/domains/shared/utilities/base-definition-factory.js`**

Added `.env*` exclusion patterns to both `skipEsbuildPackageConfig` and `functionPackageConfig`:
```javascript
'.env',
'.env.*',
'.env.local',
'.env.*.local',
'**/.env',
'**/.env.*',

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.62`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/devtools`
    - fix: Exclude .env files from serverless package deployment [#518](https://github.com/friggframework/frigg/pull/518) ([@claude](https://github.com/claude) [@seanspeaks](https://github.com/seanspeaks))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - chore: remove stale comment and fix step numbering [#516](https://github.com/friggframework/frigg/pull/516) ([@claude](https://github.com/claude) [@seanspeaks](https://github.com/seanspeaks))
  
  #### Authors: 2
  
  - Claude ([@claude](https://github.com/claude))
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
