### PR TITLE
fix(devtools): include infrastructure/ in npm package files

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -7,6 +7,7 @@
   },
   "files": [
     "frigg-cli/",
+    "infrastructure/",
     "migrations/",
     "management-ui/dist/",
     "index.js",


### PR DESCRIPTION
## Summary
- Add `infrastructure/` to the `files` array in devtools `package.json`

## Problem
The `doctor-command` requires files from `infrastructure/domains/health/` but the `infrastructure/` directory was not included in the npm package. This caused deployments to fail with:

```
Error: Cannot find module '../../infrastructure/domains/health/domain/value-objects/stack-identifier'
Require stack:
- /home/runner/work/frigg-integrations/frigg-integrations/backend/node_modules/@friggframework/devtools/frigg-cli/doctor-command/index.js
```

## Solution
Add `infrastructure/` to the `files` array in `packages/devtools/package.json` to ensure it's published to npm.


<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.63`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/devtools`
    - fix(devtools): include infrastructure/ in npm package files [#519](https://github.com/friggframework/frigg/pull/519) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - fix: Exclude .env files from serverless package deployment [#518](https://github.com/friggframework/frigg/pull/518) ([@claude](https://github.com/claude) [@seanspeaks](https://github.com/seanspeaks))
  
  #### Authors: 3
  
  - Claude ([@claude](https://github.com/claude))
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
