### PR TITLE
fix(devtools): include test/ in npm package files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,66 @@ lerna publish                 # Publish all packages
 npm run test:api-module-managers  # Test API module managers with watch mode
 ```
 
+## Pull Request Guidelines
+
+When contributing to the Frigg Framework, follow these guidelines for creating pull requests:
+
+### Target Branch
+
+- **Always create PRs targeting the `next` branch** - Never PR directly to `main`
+- The `next` branch is used for pre-release versions and testing before stable releases
+
+### Required Labels
+
+Always add **both** of these labels to your PR:
+
+- `release` - Triggers a new release version
+- `prerelease` - Creates a pre-release version (e.g., `2.0.0-next.63`)
+
+These labels ensure automated versioning and npm publishing via GitHub Actions.
+
+### Pre-PR Checklist
+
+Before creating a pull request, ensure:
+
+1. **Project compiles successfully**:
+   ```bash
+   npm install
+   npm run test:all
+   ```
+
+2. **No linting errors**:
+   ```bash
+   npm run lint:fix
+   ```
+
+3. **Changes are tested** - Add or update tests for your changes
+
+### PR Workflow Example
+
+```bash
+# 1. Create feature branch from next
+git checkout next
+git pull origin next
+git checkout -b fix/your-fix-description
+
+# 2. Make changes and verify compilation
+npm install
+npm run test:all
+
+# 3. Commit and push
+git add .
+git commit -m "fix(package): description of the fix"
+git push -u origin fix/your-fix-description
+
+# 4. Create PR targeting next branch with required labels
+gh pr create --base next \
+  --title "fix(package): description" \
+  --body "## Summary\n- Your changes\n\n## Test plan\n- [ ] Tests pass" \
+  --label "release" \
+  --label "prerelease"
+```
+
 ## Core Package Architecture (@friggframework/core)
 
 ### Integration Base Class Pattern

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -10,6 +10,7 @@
     "infrastructure/",
     "migrations/",
     "management-ui/dist/",
+    "test/",
     "index.js",
     "README.md"
   ],


### PR DESCRIPTION
## Summary
- Add `test/` to the `files` array in devtools `package.json`
- Add PR guidelines documentation to CLAUDE.md

## Problem
The `devtools/index.js` exports the test module:
```javascript
const test = require('./test');
module.exports = { createFriggInfrastructure, ...test };
```

But the `test/` directory was not included in the npm package. This caused builds to fail with:
```
Error: Cannot find module './test'
Require stack:
- .../node_modules/@friggframework/devtools/index.js
```

## Solution
Add `test/` to the `files` array in `packages/devtools/package.json` to ensure it's published to npm.

## Test plan
- [x] Verified `npm run frigg:local:build` works after fix
- [ ] Publish new version of `@friggframework/devtools`
- [ ] Install new version in a project
- [ ] Verify `frigg build` works without module not found errors
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.520.6641121.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.520.6641121.0
  npm install @friggframework/devtools@2.0.0--canary.520.6641121.0
  npm install @friggframework/eslint-config@2.0.0--canary.520.6641121.0
  npm install @friggframework/prettier-config@2.0.0--canary.520.6641121.0
  npm install @friggframework/schemas@2.0.0--canary.520.6641121.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.520.6641121.0
  npm install @friggframework/test@2.0.0--canary.520.6641121.0
  npm install @friggframework/ui@2.0.0--canary.520.6641121.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.520.6641121.0
  yarn add @friggframework/devtools@2.0.0--canary.520.6641121.0
  yarn add @friggframework/eslint-config@2.0.0--canary.520.6641121.0
  yarn add @friggframework/prettier-config@2.0.0--canary.520.6641121.0
  yarn add @friggframework/schemas@2.0.0--canary.520.6641121.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.520.6641121.0
  yarn add @friggframework/test@2.0.0--canary.520.6641121.0
  yarn add @friggframework/ui@2.0.0--canary.520.6641121.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.64`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/devtools`
    - fix(devtools): include test/ in npm package files [#520](https://github.com/friggframework/frigg/pull/520) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - fix(devtools): include infrastructure/ in npm package files [#519](https://github.com/friggframework/frigg/pull/519) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
