### PR TITLE
feat(devtools): add Frigg Authenticator CLI tool

### DIFF
--- a/.claude/skills/frigg/SKILL.md
+++ b/.claude/skills/frigg/SKILL.md
@@ -349,9 +349,9 @@ npm test                     # Run framework tests
 frigg ui                     # Start Frigg Management UI (localhost:3002)
 
 # API Module Authentication Testing
-frigg auth test .            # Test OAuth2 auth for current directory module
+frigg auth test .            # Test OAuth2 or API-Key auth (interactive form)
 frigg auth test attio        # Test by module name
-frigg auth test . --api-key sk_xxx  # Test API-Key authentication
+frigg auth test . --api-key sk_xxx  # Test API-Key (explicit, skips form)
 frigg auth list              # List saved credentials
 frigg auth get attio --json  # Get credentials as JSON
 frigg auth delete attio      # Delete saved credentials
@@ -368,11 +368,34 @@ CLI tool for testing API module authentication flows without deploying infrastru
 - `frigg auth delete [module]` - Remove credentials (supports `--all`)
 
 **Options for `frigg auth test`:**
-- `--api-key <key>` - Use API-Key authentication instead of OAuth2
+- `--api-key <key>` - Use explicit API key (skips interactive form)
 - `--port <port>` - Callback server port (default: 3333)
 - `--no-browser` - Print authorization URL instead of opening browser
 - `--timeout <seconds>` - OAuth callback timeout (default: 300)
 - `-v, --verbose` - Enable verbose output
+
+**API-Key Modules with Interactive Forms:**
+
+API-Key modules with `getAuthorizationRequirements` render interactive CLI forms:
+
+```bash
+$ frigg auth test .
+
+📝 Quo API Authorization
+
+  (Your Quo API key)
+  API Key: ********************************
+
+🔑 API-Key Authentication Flow
+Module: quo
+✓ API key configured
+```
+
+Features:
+- Password masking for `ui:widget: 'password'` fields
+- Help text from `ui:help` displayed before prompts
+- Validation for required fields
+- Multi-field support (e.g., company ID, public key, private key)
 
 **What it tests:**
 - `testAuthRequest` - Verify authentication works

--- a/.claude/skills/frigg/SKILL.md
+++ b/.claude/skills/frigg/SKILL.md
@@ -347,6 +347,57 @@ npm test                     # Run framework tests
 
 # Management UI
 frigg ui                     # Start Frigg Management UI (localhost:3002)
+
+# API Module Authentication Testing
+frigg auth test .            # Test OAuth2 auth for current directory module
+frigg auth test attio        # Test by module name
+frigg auth test . --api-key sk_xxx  # Test API-Key authentication
+frigg auth list              # List saved credentials
+frigg auth get attio --json  # Get credentials as JSON
+frigg auth delete attio      # Delete saved credentials
+```
+
+### Frigg Authenticator
+
+CLI tool for testing API module authentication flows without deploying infrastructure.
+
+**Commands:**
+- `frigg auth test <module>` - Test OAuth2 or API-Key authentication
+- `frigg auth list` - List all saved credentials
+- `frigg auth get <module>` - Retrieve credentials (supports `--json`, `--export`)
+- `frigg auth delete [module]` - Remove credentials (supports `--all`)
+
+**Options for `frigg auth test`:**
+- `--api-key <key>` - Use API-Key authentication instead of OAuth2
+- `--port <port>` - Callback server port (default: 3333)
+- `--no-browser` - Print authorization URL instead of opening browser
+- `--timeout <seconds>` - OAuth callback timeout (default: 300)
+- `-v, --verbose` - Enable verbose output
+
+**What it tests:**
+- `testAuthRequest` - Verify authentication works
+- `getEntityDetails` - Validate entity consistency post-auth
+- `getCredentialDetails` - Verify credential structure post-auth
+- Token refresh - Test refresh mechanism if supported
+- `apiPropertiesToPersist` - Verify credential and entity properties
+
+**Example workflow:**
+```bash
+# Navigate to API module directory
+cd packages/api-module-attio
+
+# Set up environment variables
+cat .env
+# ATTIO_CLIENT_ID=xxx
+# ATTIO_CLIENT_SECRET=xxx
+# ATTIO_SCOPE=read:objects
+# REDIRECT_URI=http://localhost:3333
+
+# Run authentication test
+frigg auth test . --verbose
+
+# Use saved credentials in tests
+frigg auth get . --json
 ```
 
 ### Infrastructure Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,36 @@ frigg deploy                  # Infrastructure deployment
 frigg search <term>           # Search available API modules
 ```
 
+### Frigg Authenticator
+
+CLI tool for testing API module authentication flows without deploying infrastructure:
+
+```bash
+# Test OAuth2 authentication (opens browser, captures tokens)
+frigg auth test .                    # Current directory module
+frigg auth test attio                # By module name
+frigg auth test . --port 8080        # Custom callback port
+frigg auth test . --no-browser       # Print URL instead of opening browser
+
+# Test API-Key authentication
+frigg auth test . --api-key sk_xxx
+
+# Manage saved credentials
+frigg auth list                      # List all saved credentials
+frigg auth get attio --json          # Get as JSON for scripts
+frigg auth get attio --export        # Export as environment variables
+frigg auth delete attio              # Delete credentials
+```
+
+Credentials are saved to `.frigg-credentials.json` and auto-added to `.gitignore`.
+
+The authenticator tests all `requiredAuthMethods`:
+- `testAuthRequest` - Verify authentication works
+- `getEntityDetails` - Validate entity consistency
+- `getCredentialDetails` - Verify credential structure
+- Token refresh (if module supports it)
+- `apiPropertiesToPersist` verification
+
 ### Development Tools
 
 - **Mock API**: `nock`-based HTTP request mocking for tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,8 +322,9 @@ frigg auth test attio                # By module name
 frigg auth test . --port 8080        # Custom callback port
 frigg auth test . --no-browser       # Print URL instead of opening browser
 
-# Test API-Key authentication
-frigg auth test . --api-key sk_xxx
+# Test API-Key authentication (interactive form if getAuthorizationRequirements exists)
+frigg auth test .                    # Renders JSON Schema form
+frigg auth test . --api-key sk_xxx   # Explicit key (skips form)
 
 # Manage saved credentials
 frigg auth list                      # List all saved credentials
@@ -333,6 +334,29 @@ frigg auth delete attio              # Delete credentials
 ```
 
 Credentials are saved to `.frigg-credentials.json` and auto-added to `.gitignore`.
+
+**API-Key Modules with Interactive Forms:**
+
+Modules with `getAuthorizationRequirements` render interactive CLI forms using JSON Schema:
+
+```bash
+$ frigg auth test .
+
+📝 Quo API Authorization
+
+  (Your Quo API key)
+  API Key: ********************************
+
+🔑 API-Key Authentication Flow
+Module: quo
+✓ API key configured
+```
+
+Form features:
+- Password masking for `ui:widget: 'password'` fields
+- Help text from `ui:help`
+- Multi-field support (e.g., company ID, public key, private key)
+- Validation for required fields
 
 The authenticator tests all `requiredAuthMethods`:
 - `testAuthRequest` - Verify authentication works

--- a/packages/devtools/frigg-cli/auth-command/CLAUDE.md
+++ b/packages/devtools/frigg-cli/auth-command/CLAUDE.md
@@ -1,0 +1,268 @@
+# CLAUDE.md - Frigg Authenticator
+
+This file provides guidance to Claude Code when working with the Frigg Authenticator tool.
+
+## Overview
+
+The Frigg Authenticator is a CLI tool for testing API module authentication flows. It's part of `@friggframework/devtools` and enables developers to validate OAuth2 and API-Key authentication without deploying full Frigg infrastructure.
+
+## Directory Structure
+
+```
+auth-command/
+├── index.js                 # Main CLI command handler (test, list, get, delete)
+├── module-loader.js         # Dynamic module loading & validation
+├── credential-storage.js    # .frigg-credentials.json persistence
+├── oauth-callback-server.js # Local HTTP server for OAuth callbacks
+├── oauth-flow.js            # OAuth2 flow orchestration
+├── api-key-flow.js          # API-Key authentication flow
+├── auth-tester.js           # Run testAuthRequest & sample API calls
+├── utils/
+│   └── browser.js           # Cross-platform browser opening
+├── README.md                # User documentation
+└── CLAUDE.md                # This file - AI assistant guidance
+```
+
+## Key Files and Their Purpose
+
+### `index.js` - Command Handler
+Main entry point that exports `authCommand` object with methods:
+- `test(moduleName, options)` - Test authentication for a module
+- `list(options)` - List saved credentials
+- `get(moduleName, options)` - Retrieve credentials
+- `delete(moduleName, options)` - Remove credentials
+
+**When to modify:** Adding new subcommands or changing command behavior.
+
+### `module-loader.js` - Module Loading
+Handles dynamic loading of API modules from various sources:
+- Current directory (`.`)
+- Relative/absolute paths (`./path/to/module`)
+- Short names (`attio` → `@friggframework/api-module-attio`)
+- Full package names (`@friggframework/api-module-attio`)
+
+**Key functions:**
+- `loadModule(moduleIdentifier)` - Load and return `{definition, Api, modulePath}`
+- `validateModule(definition)` - Ensure module has required fields
+- `getAuthType(Api)` - Detect auth type (oauth2 or apiKey)
+
+**When to modify:** Supporting new module locations or validation rules.
+
+### `credential-storage.js` - Persistence
+Manages `.frigg-credentials.json` file:
+- Stores credentials per module
+- Supports global (`~/.frigg-credentials.json`) and local storage
+- Auto-adds to `.gitignore`
+
+**Key class:** `CredentialStorage`
+- `save(moduleName, credentials, authType)`
+- `get(moduleName)`
+- `list()`
+- `delete(moduleName)`
+- `deleteAll()`
+
+**When to modify:** Changing storage format or location logic.
+
+### `oauth-callback-server.js` - OAuth Server
+Local HTTP server that captures OAuth callbacks:
+- Listens on configurable port (default: 3333)
+- Handles `?code=` and `?error=` query params
+- Returns success/error HTML pages
+- Implements timeout handling
+
+**Key class:** `OAuthCallbackServer`
+- `start()` - Start the server
+- `waitForCode()` - Promise that resolves with `{code, state}`
+- `stop()` - Shutdown the server
+
+**When to modify:** Changing callback behavior or HTML responses.
+
+### `oauth-flow.js` - OAuth2 Orchestration
+Orchestrates the complete OAuth2 flow:
+1. Generate CSRF state token
+2. Create API instance with env params
+3. Get authorization URL
+4. Start callback server
+5. Open browser or print URL
+6. Wait for callback
+7. Verify state (CSRF protection)
+8. Exchange code for tokens via `getToken()`
+9. Fetch entity details via `getEntityDetails()`
+10. Return credentials object
+
+**Key function:** `runOAuthFlow(definition, ApiClass, options)`
+
+**When to modify:** Changing OAuth flow steps or adding features.
+
+### `api-key-flow.js` - API-Key Flow
+Handles API-Key authentication:
+1. Create API instance
+2. Set API key via `setApiKey()` or similar
+3. Fetch entity details
+4. Return credentials object
+
+**Key function:** `runApiKeyFlow(definition, ApiClass, apiKey, options)`
+
+**When to modify:** Supporting different API key mechanisms.
+
+### `auth-tester.js` - Verification
+Runs verification tests after authentication:
+1. Create fresh API instance with credentials
+2. Run `testAuthRequest` from module definition
+3. Try common sample API methods
+4. Verify credential properties are set
+
+**Key function:** `runAuthTests(definition, ApiClass, credentials, options)`
+
+**When to modify:** Adding verification steps or sample methods.
+
+### `utils/browser.js` - Browser Opening
+Cross-platform browser opening utility:
+- macOS: `open`
+- Windows: `start`
+- Linux: `xdg-open`
+
+**Key function:** `openBrowser(url)`
+
+## Integration with Frigg CLI
+
+The authenticator is registered in `frigg-cli/index.js`:
+
+```javascript
+const { authCommand } = require('./auth-command');
+
+const authProgram = program
+    .command('auth')
+    .description('Test API module authentication');
+
+authProgram
+    .command('test <module>')
+    .action(authCommand.test);
+// ... more subcommands
+```
+
+## Common Development Tasks
+
+### Adding a New Subcommand
+
+1. Add handler method in `auth-command/index.js`
+2. Register in `frigg-cli/index.js` under `authProgram`
+3. Update README.md with usage docs
+
+### Supporting a New Auth Type
+
+1. Create new flow file (e.g., `basic-auth-flow.js`)
+2. Update `getAuthType()` in `module-loader.js`
+3. Add case in `test()` handler in `index.js`
+
+### Changing Credential Format
+
+1. Update `save()` and `get()` in `credential-storage.js`
+2. Consider migration for existing credentials
+3. Update `_meta.version` for format versioning
+
+### Adding Verification Steps
+
+1. Modify `runAuthTests()` in `auth-tester.js`
+2. Add new sample methods to check
+3. Update verbose output
+
+## Testing
+
+### Manual Testing
+
+```bash
+# Test with a real module
+cd /path/to/api-module-attio
+export ATTIO_CLIENT_ID=xxx
+export ATTIO_CLIENT_SECRET=xxx
+export ATTIO_SCOPE="read:objects"
+export REDIRECT_URI="http://localhost:3333"
+node /path/to/frigg-cli/index.js auth test . --verbose
+```
+
+### Unit Testing
+
+Tests should be added to `frigg-cli/test/auth-command.test.js`:
+- Test module loading with various paths
+- Test credential storage operations
+- Mock OAuth callback server responses
+- Test error handling
+
+## Error Handling Patterns
+
+### User-Friendly Errors
+
+```javascript
+throw new Error(
+    `Port ${port} is already in use.\n` +
+    `Try using a different port: frigg auth test <module> --port <different-port>`
+);
+```
+
+### Validation Errors
+
+```javascript
+const errors = [];
+if (!definition.moduleName) {
+    errors.push('Missing required field: moduleName');
+}
+if (errors.length > 0) {
+    throw new Error(`Module validation failed:\n${errors.map(e => `  - ${e}`).join('\n')}`);
+}
+```
+
+## Dependencies
+
+External packages used:
+- `chalk` - Terminal colors
+- `commander` - CLI framework (via parent)
+
+Node.js built-ins:
+- `http` - Callback server
+- `url` - URL parsing
+- `fs` - File system
+- `path` - Path utilities
+- `os` - OS info
+- `crypto` - State token generation
+- `child_process` - Browser opening
+- `readline` - User confirmation
+
+## Security Considerations
+
+1. **State Parameter**: CSRF protection via random state token
+2. **Local Only**: Callback server only binds to localhost
+3. **No Credential Logging**: Sensitive values are masked in output
+4. **Gitignore Integration**: Auto-adds credentials file to .gitignore
+5. **Sanitization**: Client secrets removed from stored apiParams
+
+## Common Issues
+
+### Module Not Loading
+
+Check:
+- Module exports `{Definition}` or `{definition}`
+- Definition has `API` class
+- `require('dotenv').config()` is called in definition.js
+
+### OAuth Flow Failing
+
+Check:
+- Environment variables are set correctly
+- Redirect URI matches callback server port
+- OAuth credentials are valid
+- Scopes are correct
+
+### Credentials Not Persisting
+
+Check:
+- Write permissions on target directory
+- File isn't gitignored in a way that prevents reading
+- Storage path detection is correct
+
+## Related Documentation
+
+- [Frigg Framework CLAUDE.md](../../CLAUDE.md)
+- [API Module Library](https://github.com/friggframework/api-module-library)
+- [OAuth2Requester](../../../core/modules/requester/oauth-2.js)
+- [ApiKeyRequester](../../../core/modules/requester/ApiKeyRequester.js)

--- a/packages/devtools/frigg-cli/auth-command/CLAUDE.md
+++ b/packages/devtools/frigg-cli/auth-command/CLAUDE.md
@@ -16,6 +16,7 @@ auth-command/
 ├── oauth-callback-server.js # Local HTTP server for OAuth callbacks
 ├── oauth-flow.js            # OAuth2 flow orchestration
 ├── api-key-flow.js          # API-Key authentication flow
+├── json-schema-form.js      # Interactive JSON Schema form renderer (CLI prompts)
 ├── auth-tester.js           # Run testAuthRequest & sample API calls
 ├── utils/
 │   └── browser.js           # Cross-platform browser opening
@@ -96,14 +97,37 @@ Orchestrates the complete OAuth2 flow:
 
 ### `api-key-flow.js` - API-Key Flow
 Handles API-Key authentication:
-1. Create API instance
-2. Set API key via `setApiKey()` or similar
-3. Fetch entity details
-4. Return credentials object
+1. Check for `getAuthorizationRequirements` in module definition
+2. If no API key provided and `getAuthorizationRequirements` exists, render JSON Schema form
+3. Create API instance
+4. Set API key via `setApiKey()` or similar
+5. Fetch entity details
+6. Return credentials object
 
 **Key function:** `runApiKeyFlow(definition, ApiClass, apiKey, options)`
 
-**When to modify:** Supporting different API key mechanisms.
+**When to modify:** Supporting different API key mechanisms or form rendering.
+
+### `json-schema-form.js` - Interactive Form Renderer
+Renders JSON Schema as interactive CLI prompts using `@inquirer/prompts`:
+1. Display form title from `jsonSchema.title`
+2. Iterate through `jsonSchema.properties`
+3. Show help text from `uiSchema[field]['ui:help']`
+4. Use password prompt for `ui:widget: 'password'` fields
+5. Validate required fields
+6. Return collected form data
+
+**Key function:** `renderJsonSchemaForm(jsonSchema, uiSchema)`
+
+**When to modify:** Adding new field types or UI schema options.
+
+**Example output:**
+```
+📝 Quo API Authorization
+
+  (Your Quo API key)
+  API Key: ********************************
+```
 
 ### `auth-tester.js` - Verification
 Runs verification tests after authentication:
@@ -217,6 +241,7 @@ if (errors.length > 0) {
 External packages used:
 - `chalk` - Terminal colors
 - `commander` - CLI framework (via parent)
+- `@inquirer/prompts` - Interactive CLI prompts (input, password)
 
 Node.js built-ins:
 - `http` - Callback server

--- a/packages/devtools/frigg-cli/auth-command/README.md
+++ b/packages/devtools/frigg-cli/auth-command/README.md
@@ -48,6 +48,39 @@ This will:
 
 ### Testing API-Key Modules
 
+API-Key modules with `getAuthorizationRequirements` will render an interactive JSON Schema form:
+
+```bash
+# Navigate to API module directory
+cd packages/api-module-quo
+
+# Run auth test - renders interactive form
+frigg auth test .
+```
+
+**Interactive Form Example:**
+```
+📝 Quo API Authorization
+
+  (Your Quo API key)
+  API Key: ********************************
+
+🔑 API-Key Authentication Flow
+
+Module: quo
+✓ API key configured
+Fetching entity details...
+✓ Entity details retrieved
+  Entity: Quo Workspace (API Key Hash)
+```
+
+The form:
+- Displays title from `jsonSchema.title`
+- Shows help text from `ui:help` before each field
+- Masks password fields (`ui:widget: 'password'`) with `*`
+- Validates required fields
+
+**Using `--api-key` flag (bypasses interactive form):**
 ```bash
 frigg auth test ./my-api-key-module --api-key YOUR_API_KEY
 ```
@@ -69,7 +102,7 @@ Test authentication for an API module.
 **Options:**
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--api-key <key>` | - | API key for API-Key authentication |
+| `--api-key <key>` | - | API key (bypasses interactive form) |
 | `--port <port>` | `3333` | Callback server port |
 | `--no-browser` | `false` | Don't auto-open browser (print URL instead) |
 | `--timeout <seconds>` | `300` | OAuth callback timeout |
@@ -281,8 +314,71 @@ MY_MODULE_CLIENT_SECRET=your_client_secret
 MY_MODULE_SCOPE=read write
 REDIRECT_URI=http://localhost:3333
 
-# API-Key modules (pass via --api-key flag)
+# API-Key modules - use interactive form or --api-key flag
 ```
+
+### JSON Schema Form for API-Key Modules
+
+API-Key modules can define `getAuthorizationRequirements` to enable interactive CLI forms:
+
+```javascript
+// definition.js
+const Definition = {
+    // ...
+    requiredAuthMethods: {
+        getAuthorizationRequirements: (api) => ({
+            type: 'apiKey',
+            data: {
+                jsonSchema: {
+                    title: 'My API Authorization',
+                    type: 'object',
+                    required: ['apiKey'],
+                    properties: {
+                        apiKey: { type: 'string', title: 'API Key' }
+                    }
+                },
+                uiSchema: {
+                    apiKey: {
+                        'ui:widget': 'password',  // Masks input with *
+                        'ui:help': 'Your API key from the dashboard'
+                    }
+                }
+            }
+        }),
+        // ... other methods
+    }
+};
+```
+
+**Multi-Field Example (e.g., ConnectWise):**
+```javascript
+getAuthorizationRequirements: (api) => ({
+    type: 'apiKey',
+    data: {
+        jsonSchema: {
+            title: 'ConnectWise Authentication',
+            type: 'object',
+            required: ['companyId', 'publicKey', 'privateKey'],
+            properties: {
+                companyId: { type: 'string', title: 'Company ID' },
+                publicKey: { type: 'string', title: 'Public Key' },
+                privateKey: { type: 'string', title: 'Private Key' },
+                siteUrl: { type: 'string', title: 'Site URL' }
+            }
+        },
+        uiSchema: {
+            companyId: { 'ui:help': 'The Company ID you use to login' },
+            publicKey: { 'ui:help': 'From My Account > API Keys' },
+            privateKey: { 'ui:widget': 'password', 'ui:help': 'Your private key' },
+            siteUrl: { 'ui:help': 'e.g., https://na.myconnectwise.net' }
+        }
+    }
+})
+```
+
+**Supported UI Schema Options:**
+- `ui:widget: 'password'` - Masks input with `*` characters
+- `ui:help` - Displays help text before the field prompt
 
 ## Troubleshooting
 
@@ -336,6 +432,7 @@ auth-command/
 ├── oauth-callback-server.js # Local HTTP server for OAuth callbacks
 ├── oauth-flow.js            # OAuth2 flow orchestration
 ├── api-key-flow.js          # API-Key authentication flow
+├── json-schema-form.js      # Interactive JSON Schema form renderer
 ├── auth-tester.js           # Run testAuthRequest & sample API calls
 └── utils/
     └── browser.js           # Cross-platform browser opening

--- a/packages/devtools/frigg-cli/auth-command/README.md
+++ b/packages/devtools/frigg-cli/auth-command/README.md
@@ -1,0 +1,353 @@
+# Frigg Authenticator
+
+A CLI tool for testing OAuth2 and API-Key authentication flows in Frigg API modules without deploying full infrastructure.
+
+## Overview
+
+The Frigg Authenticator allows API module developers to:
+- Test OAuth2 authentication flows end-to-end
+- Test API-Key authentication
+- Verify `requiredAuthMethods` work correctly
+- Save credentials for reuse in tests
+- Debug authentication issues quickly
+
+## Installation
+
+The authenticator is included in `@friggframework/devtools` and available via the Frigg CLI:
+
+```bash
+npm install @friggframework/devtools
+```
+
+## Quick Start
+
+### Testing OAuth2 Modules
+
+```bash
+# Navigate to your API module directory
+cd packages/api-module-attio
+
+# Ensure .env has required OAuth credentials
+cat .env
+# ATTIO_CLIENT_ID=your_client_id
+# ATTIO_CLIENT_SECRET=your_client_secret
+# ATTIO_SCOPE=read:objects write:objects
+# REDIRECT_URI=http://localhost:3333
+
+# Run the auth test
+frigg auth test .
+```
+
+This will:
+1. Load your module and validate its definition
+2. Start a local callback server on port 3333
+3. Open your browser to the OAuth authorization page
+4. Capture the callback and exchange code for tokens
+5. Run `testAuthRequest` to verify authentication works
+6. Save credentials to `.frigg-credentials.json`
+
+### Testing API-Key Modules
+
+```bash
+frigg auth test ./my-api-key-module --api-key YOUR_API_KEY
+```
+
+## Commands
+
+### `frigg auth test <module>`
+
+Test authentication for an API module.
+
+**Arguments:**
+- `<module>` - Module path or name. Can be:
+  - `.` - Current directory
+  - `./path/to/module` - Relative path
+  - `/absolute/path/to/module` - Absolute path
+  - `attio` - Short name (resolves to `@friggframework/api-module-attio`)
+  - `@friggframework/api-module-attio` - Full package name
+
+**Options:**
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--api-key <key>` | - | API key for API-Key authentication |
+| `--port <port>` | `3333` | Callback server port |
+| `--no-browser` | `false` | Don't auto-open browser (print URL instead) |
+| `--timeout <seconds>` | `300` | OAuth callback timeout |
+| `-v, --verbose` | `false` | Enable verbose output |
+
+**Examples:**
+```bash
+# Test current directory module
+frigg auth test .
+
+# Test with custom port
+frigg auth test . --port 8080
+
+# Test without opening browser
+frigg auth test . --no-browser
+
+# Test API-Key module
+frigg auth test . --api-key sk_live_xxxxx
+
+# Verbose output for debugging
+frigg auth test . --verbose
+```
+
+### `frigg auth list`
+
+List all saved credentials.
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--json` | Output as JSON |
+
+**Example:**
+```bash
+frigg auth list
+```
+
+Output:
+```
+┌─────────┬───────────┬──────────────────────┬──────────────────┬───────────────────┬─────────────────────┐
+│ Module  │ Auth Type │ Entity               │ Has Access Token │ Has Refresh Token │ Saved At            │
+├─────────┼───────────┼──────────────────────┼──────────────────┼───────────────────┼─────────────────────┤
+│ attio   │ oauth2    │ Left Hook Dev        │ ✓                │ -                 │ 12/23/2025, 7:34 PM │
+│ quo     │ apiKey    │ Quo Workspace        │ ✓                │ -                 │ 12/23/2025, 8:00 PM │
+└─────────┴───────────┴──────────────────────┴──────────────────┴───────────────────┴─────────────────────┘
+```
+
+### `frigg auth get <module>`
+
+Get credentials for a specific module.
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--json` | Output as JSON (for scripts) |
+| `--export` | Output as environment variables |
+
+**Examples:**
+```bash
+# Display formatted credentials
+frigg auth get attio
+
+# Get as JSON for scripts
+frigg auth get attio --json
+
+# Export as environment variables
+eval $(frigg auth get attio --export)
+```
+
+### `frigg auth delete [module]`
+
+Delete saved credentials.
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--all` | Delete all credentials |
+| `-y, --yes` | Skip confirmation |
+
+**Examples:**
+```bash
+# Delete specific module credentials
+frigg auth delete attio
+
+# Delete all credentials
+frigg auth delete --all
+
+# Skip confirmation
+frigg auth delete attio -y
+```
+
+## Credential Storage
+
+Credentials are saved to `.frigg-credentials.json`:
+- **Project-local**: If run in a Frigg project, saves to project root
+- **Global**: Otherwise saves to `~/.frigg-credentials.json`
+
+The file is automatically added to `.gitignore` when saving locally.
+
+### Credential Format
+
+```json
+{
+  "_meta": {
+    "version": 1,
+    "warning": "DO NOT COMMIT THIS FILE - contains sensitive credentials"
+  },
+  "modules": {
+    "attio": {
+      "authType": "oauth2",
+      "tokens": {
+        "access_token": "xxx...",
+        "refresh_token": null,
+        "accessTokenExpire": "2025-12-24T19:34:50.468Z"
+      },
+      "entity": {
+        "identifiers": {
+          "externalId": "workspace-id",
+          "user": "cli-test-user"
+        },
+        "details": {
+          "name": "My Workspace"
+        }
+      },
+      "obtainedAt": "2025-12-23T19:34:51.097Z",
+      "savedAt": "2025-12-23T19:34:51.713Z"
+    }
+  }
+}
+```
+
+## Using Credentials in Tests
+
+### Direct Import
+
+```javascript
+const { CredentialStorage } = require('@friggframework/devtools/frigg-cli/auth-command/credential-storage');
+
+describe('Attio Integration', () => {
+    let api;
+
+    beforeAll(async () => {
+        const storage = new CredentialStorage();
+        const credentials = await storage.get('attio');
+
+        if (!credentials) {
+            throw new Error('Run "frigg auth test attio" first');
+        }
+
+        const { Api } = require('@friggframework/api-module-attio');
+        api = new Api({
+            ...credentials.tokens,
+            ...credentials.apiParams,
+        });
+    });
+
+    it('should list objects', async () => {
+        const result = await api.listObjects();
+        expect(result.data).toBeDefined();
+    });
+});
+```
+
+### Environment Variables
+
+```bash
+# Export credentials as env vars
+eval $(frigg auth get attio --export)
+
+# Now available as:
+# ATTIO_ACCESS_TOKEN=xxx
+# ATTIO_EXTERNAL_ID=workspace-id
+```
+
+## Module Requirements
+
+For the authenticator to work, your module must have:
+
+### Required Definition Fields
+
+```javascript
+const Definition = {
+    API: Api,                    // API class (extends OAuth2Requester or ApiKeyRequester)
+    moduleName: 'my-module',     // Unique module name
+    requiredAuthMethods: {
+        getToken,                // Exchange auth code for tokens (OAuth2)
+        getEntityDetails,        // Get entity info after auth
+        getCredentialDetails,    // Get credential info
+        testAuthRequest,         // Verify auth works
+        apiPropertiesToPersist,  // Fields to persist
+    },
+    env: {
+        client_id: process.env.MY_MODULE_CLIENT_ID,
+        client_secret: process.env.MY_MODULE_CLIENT_SECRET,
+        scope: process.env.MY_MODULE_SCOPE,
+        redirect_uri: process.env.REDIRECT_URI,
+    }
+};
+```
+
+### Required Environment Variables
+
+Create a `.env` file in your module directory:
+
+```bash
+# OAuth2 modules
+MY_MODULE_CLIENT_ID=your_client_id
+MY_MODULE_CLIENT_SECRET=your_client_secret
+MY_MODULE_SCOPE=read write
+REDIRECT_URI=http://localhost:3333
+
+# API-Key modules (pass via --api-key flag)
+```
+
+## Troubleshooting
+
+### Port Already in Use
+
+```
+Error: Port 3333 is already in use.
+Try using a different port: frigg auth test <module> --port <different-port>
+```
+
+**Solution:** Use a different port with `--port 8080`
+
+### Module Not Found
+
+```
+Error: Could not find module: my-module
+```
+
+**Solution:**
+- Use `.` for current directory
+- Use absolute path
+- Ensure module exports `Definition`
+
+### OAuth Callback Timeout
+
+```
+Error: OAuth callback timeout after 300 seconds.
+```
+
+**Solution:**
+- Complete authorization in browser faster
+- Increase timeout with `--timeout 600`
+- Check redirect URI matches callback server
+
+### Invalid Module Definition
+
+```
+Error: Module validation failed:
+  - Missing required auth method: testAuthRequest
+```
+
+**Solution:** Ensure your module's `requiredAuthMethods` has all required methods.
+
+## Architecture
+
+```
+auth-command/
+├── index.js                 # Main command handler
+├── module-loader.js         # Dynamic module loading & validation
+├── credential-storage.js    # .frigg-credentials.json persistence
+├── oauth-callback-server.js # Local HTTP server for OAuth callbacks
+├── oauth-flow.js            # OAuth2 flow orchestration
+├── api-key-flow.js          # API-Key authentication flow
+├── auth-tester.js           # Run testAuthRequest & sample API calls
+└── utils/
+    └── browser.js           # Cross-platform browser opening
+```
+
+## Security Considerations
+
+1. **Credentials are stored in plain text** - Only use for development/testing
+2. **Auto-adds to .gitignore** - Prevents accidental commits
+3. **CSRF protection** - OAuth state parameter prevents attacks
+4. **Local callback only** - Server only listens on localhost
+
+## Contributing
+
+See the main [Frigg Contributing Guide](https://github.com/friggframework/frigg/blob/main/CONTRIBUTING.md).

--- a/packages/devtools/frigg-cli/auth-command/api-key-flow.js
+++ b/packages/devtools/frigg-cli/auth-command/api-key-flow.js
@@ -1,0 +1,112 @@
+const chalk = require('chalk');
+
+async function runApiKeyFlow(definition, ApiClass, apiKey, options) {
+    const moduleName = definition.moduleName || definition.getName?.() || 'unknown';
+
+    console.log(chalk.blue('\n🔑 API-Key Authentication Flow\n'));
+    console.log(chalk.gray(`Module: ${moduleName}`));
+
+    // 1. Create API instance with environment params
+    const apiParams = {
+        ...definition.env,
+    };
+    const api = new ApiClass(apiParams);
+
+    // 2. Set API key using available methods
+    let apiKeySet = false;
+
+    // Try different methods to set the API key
+    if (definition.requiredAuthMethods?.setAuthParams) {
+        // Some modules have setAuthParams in definition
+        await definition.requiredAuthMethods.setAuthParams(api, {
+            apiKey,
+            data: { apiKey, api_key: apiKey, access_token: apiKey }
+        });
+        apiKeySet = true;
+    } else if (typeof api.setApiKey === 'function') {
+        // Standard ApiKeyRequester method
+        api.setApiKey(apiKey);
+        apiKeySet = true;
+    } else if (typeof api.setAuthParams === 'function') {
+        // Alternative method name
+        await api.setAuthParams({ apiKey, api_key: apiKey, access_token: apiKey });
+        apiKeySet = true;
+    } else {
+        // Direct property assignment as fallback
+        api.api_key = apiKey;
+        api.access_token = apiKey;
+        apiKeySet = true;
+    }
+
+    if (!apiKeySet) {
+        throw new Error(
+            `Could not set API key for module ${moduleName}.\n` +
+            `Module does not have setApiKey(), setAuthParams(), or setAuthParams in requiredAuthMethods.`
+        );
+    }
+
+    console.log(chalk.green('✓ API key configured'));
+
+    // 3. Get entity details
+    console.log(chalk.gray('Fetching entity details...'));
+
+    let entityDetails;
+    if (definition.requiredAuthMethods?.getEntityDetails) {
+        try {
+            entityDetails = await definition.requiredAuthMethods.getEntityDetails(
+                api,
+                {},
+                { api_key: apiKey },
+                'cli-test-user'
+            );
+        } catch (err) {
+            console.log(chalk.yellow(`  Warning: getEntityDetails failed: ${err.message}`));
+            entityDetails = {
+                identifiers: { externalId: 'unknown', user: 'cli-test-user' },
+                details: { name: 'API Key Authentication' }
+            };
+        }
+    } else {
+        entityDetails = {
+            identifiers: { externalId: 'unknown', user: 'cli-test-user' },
+            details: { name: 'API Key Authentication' }
+        };
+    }
+
+    console.log(chalk.green('✓ Entity details retrieved'));
+
+    if (entityDetails?.details?.name) {
+        console.log(chalk.gray(`  Entity: ${entityDetails.details.name}`));
+    }
+
+    // 4. Get credential details
+    let credentialDetails = {};
+    if (definition.requiredAuthMethods?.getCredentialDetails) {
+        try {
+            credentialDetails = await definition.requiredAuthMethods.getCredentialDetails(
+                api,
+                'cli-test-user'
+            );
+        } catch (err) {
+            console.log(chalk.yellow(`  Warning: Could not get credential details: ${err.message}`));
+        }
+    }
+
+    // 5. Return credentials object
+    return {
+        apiKey,
+        entity: entityDetails,
+        credential: credentialDetails,
+        apiParams: sanitizeApiParams(apiParams),
+        obtainedAt: new Date().toISOString(),
+    };
+}
+
+function sanitizeApiParams(params) {
+    // Remove sensitive data that shouldn't be stored in readable form
+    const sanitized = { ...params };
+    delete sanitized.client_secret;
+    return sanitized;
+}
+
+module.exports = { runApiKeyFlow };

--- a/packages/devtools/frigg-cli/auth-command/api-key-flow.js
+++ b/packages/devtools/frigg-cli/auth-command/api-key-flow.js
@@ -1,7 +1,48 @@
 const chalk = require('chalk');
+const { renderJsonSchemaForm } = require('./json-schema-form');
 
-async function runApiKeyFlow(definition, ApiClass, apiKey, options) {
+async function runApiKeyFlow(definition, ApiClass, providedApiKey, options) {
     const moduleName = definition.moduleName || definition.getName?.() || 'unknown';
+
+    let apiKey = providedApiKey;
+    let formData = null;
+
+    // If no API key provided, check for getAuthorizationRequirements to render form
+    if (!apiKey) {
+        if (definition.requiredAuthMethods?.getAuthorizationRequirements) {
+            // Create temporary API instance to call getAuthorizationRequirements
+            const tempApi = new ApiClass({ ...definition.env });
+            const authReqs = definition.requiredAuthMethods.getAuthorizationRequirements(tempApi);
+
+            if (authReqs?.data?.jsonSchema) {
+                // Render the JSON schema form
+                formData = await renderJsonSchemaForm(
+                    authReqs.data.jsonSchema,
+                    authReqs.data.uiSchema
+                );
+
+                // Extract API key from form data - try common field names
+                apiKey = formData.apiKey || formData.api_key ||
+                         formData.access_token || formData.token;
+
+                // If still no API key found, use the first value from the form
+                if (!apiKey && Object.keys(formData).length > 0) {
+                    apiKey = Object.values(formData)[0];
+                }
+
+                if (!apiKey) {
+                    throw new Error('No API key provided in form');
+                }
+            }
+        }
+
+        if (!apiKey) {
+            throw new Error(
+                `--api-key is required for API-Key modules without getAuthorizationRequirements.\n` +
+                `Usage: frigg auth test ${moduleName} --api-key YOUR_API_KEY`
+            );
+        }
+    }
 
     console.log(chalk.blue('\n🔑 API-Key Authentication Flow\n'));
     console.log(chalk.gray(`Module: ${moduleName}`));

--- a/packages/devtools/frigg-cli/auth-command/auth-tester.js
+++ b/packages/devtools/frigg-cli/auth-command/auth-tester.js
@@ -9,7 +9,6 @@ async function runAuthTests(definition, ApiClass, credentials, options) {
         getEntityDetails: { status: 'pending' },
         getCredentialDetails: { status: 'pending' },
         tokenRefresh: { status: 'pending' },
-        sampleApiCall: { status: 'pending' },
         credentialProps: { set: 0, total: 0 },
         entityProps: { set: 0, total: 0 },
     };
@@ -115,17 +114,8 @@ async function runAuthTests(definition, ApiClass, credentials, options) {
         results.tokenRefresh = { status: 'passed', tokenChanged: refreshResult.tokenChanged };
     }
 
-    // 6. Run a sample API call if available
-    console.log(chalk.gray('\n5. Running sample API call...'));
-    const sampleResult = await runSampleApiCall(api, ApiClass, options);
-    if (sampleResult.success) {
-        results.sampleApiCall = { status: 'passed', method: sampleResult.method };
-    } else {
-        results.sampleApiCall = { status: 'skipped', reason: 'no methods available' };
-    }
-
-    // 7. Verify credential persistence properties
-    console.log(chalk.gray('\n6. Verifying credential properties (apiPropertiesToPersist.credential)...'));
+    // 6. Verify credential persistence properties
+    console.log(chalk.gray('\n5. Verifying credential properties (apiPropertiesToPersist.credential)...'));
     const credProps = definition.requiredAuthMethods?.apiPropertiesToPersist?.credential || [];
     results.credentialProps.total = credProps.length;
 
@@ -143,8 +133,8 @@ async function runAuthTests(definition, ApiClass, credentials, options) {
         }
     }
 
-    // 8. Verify entity persistence properties
-    console.log(chalk.gray('\n7. Verifying entity properties (apiPropertiesToPersist.entity)...'));
+    // 7. Verify entity persistence properties
+    console.log(chalk.gray('\n6. Verifying entity properties (apiPropertiesToPersist.entity)...'));
     const entityProps = definition.requiredAuthMethods?.apiPropertiesToPersist?.entity || [];
     results.entityProps.total = entityProps.length;
 
@@ -162,7 +152,7 @@ async function runAuthTests(definition, ApiClass, credentials, options) {
         }
     }
 
-    // 9. Summary
+    // 8. Summary
     console.log(chalk.blue('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'));
     console.log(chalk.blue('Summary'));
     console.log(chalk.blue('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'));
@@ -171,7 +161,6 @@ async function runAuthTests(definition, ApiClass, credentials, options) {
     printSummaryLine('getEntityDetails', results.getEntityDetails);
     printSummaryLine('getCredentialDetails', results.getCredentialDetails);
     printSummaryLine('tokenRefresh', results.tokenRefresh);
-    printSummaryLine('sampleApiCall', results.sampleApiCall);
 
     const credPropsStatus = results.credentialProps.total === 0
         ? chalk.gray('n/a')
@@ -202,8 +191,6 @@ async function runAuthTests(definition, ApiClass, credentials, options) {
         getEntityDetailsPassed: results.getEntityDetails.status === 'passed',
         getCredentialDetailsPassed: results.getCredentialDetails.status === 'passed',
         tokenRefreshPassed: results.tokenRefresh.status === 'passed',
-        sampleApiCallPassed: results.sampleApiCall.status === 'passed',
-        sampleMethod: results.sampleApiCall.method,
         credentialPropertiesValid: results.credentialProps.set === results.credentialProps.total,
         entityPropertiesValid: results.entityProps.set === results.entityProps.total,
     };
@@ -322,44 +309,6 @@ async function tryCommonTestMethods(api) {
     }
 
     throw new Error('No testAuthRequest method defined and no common test methods available');
-}
-
-async function runSampleApiCall(api, ApiClass, options) {
-    const sampleMethods = [
-        { name: 'getUserDetails', description: 'Get user details' },
-        { name: 'getUser', description: 'Get user' },
-        { name: 'getCurrentUser', description: 'Get current user' },
-        { name: 'listObjects', description: 'List objects' },
-        { name: 'listContacts', description: 'List contacts' },
-        { name: 'listDeals', description: 'List deals' },
-        { name: 'listUsers', description: 'List users' },
-        { name: 'getWorkspace', description: 'Get workspace' },
-        { name: 'getOrganization', description: 'Get organization' },
-    ];
-
-    for (const { name, description } of sampleMethods) {
-        if (typeof api[name] === 'function') {
-            console.log(chalk.gray(`   Trying ${name}()...`));
-            try {
-                const result = await api[name]();
-                console.log(chalk.green(`   ✓ Sample API call (${name}) succeeded`));
-
-                if (options.verbose && result) {
-                    console.log(chalk.gray('   Response preview:'));
-                    const preview = JSON.stringify(result, null, 2);
-                    const truncated = preview.length > 300 ? preview.slice(0, 300) + '\n   ...' : preview;
-                    console.log(chalk.gray('   ' + truncated.split('\n').join('\n   ')));
-                }
-
-                return { success: true, method: name };
-            } catch (error) {
-                console.log(chalk.yellow(`   ⚠ ${name}() failed: ${error.message}`));
-            }
-        }
-    }
-
-    console.log(chalk.gray('   No additional sample API calls available for this module'));
-    return { success: false, method: null };
 }
 
 function maskSensitive(prop, value) {

--- a/packages/devtools/frigg-cli/auth-command/auth-tester.js
+++ b/packages/devtools/frigg-cli/auth-command/auth-tester.js
@@ -1,0 +1,395 @@
+const chalk = require('chalk');
+
+async function runAuthTests(definition, ApiClass, credentials, options) {
+    console.log(chalk.blue('\n🧪 Running Authentication Tests\n'));
+
+    const moduleName = definition.moduleName || definition.getName?.() || 'unknown';
+    const results = {
+        testAuthRequest: { status: 'pending' },
+        getEntityDetails: { status: 'pending' },
+        getCredentialDetails: { status: 'pending' },
+        tokenRefresh: { status: 'pending' },
+        sampleApiCall: { status: 'pending' },
+        credentialProps: { set: 0, total: 0 },
+        entityProps: { set: 0, total: 0 },
+    };
+
+    // 1. Create fresh API instance with credentials
+    const apiParams = {
+        ...definition.env,
+        ...credentials.tokens,
+        ...credentials.apiParams,
+    };
+
+    const api = new ApiClass(apiParams);
+
+    // If API key, set it
+    if (credentials.apiKey) {
+        if (typeof api.setApiKey === 'function') {
+            api.setApiKey(credentials.apiKey);
+        } else {
+            api.api_key = credentials.apiKey;
+            api.access_token = credentials.apiKey;
+        }
+    }
+
+    // 2. Run testAuthRequest
+    console.log(chalk.gray('1. Running testAuthRequest...'));
+    try {
+        let testResult;
+        if (definition.requiredAuthMethods?.testAuthRequest) {
+            testResult = await definition.requiredAuthMethods.testAuthRequest(api);
+        } else {
+            testResult = await tryCommonTestMethods(api);
+        }
+
+        console.log(chalk.green('   ✓ testAuthRequest passed'));
+        results.testAuthRequest = { status: 'passed' };
+
+        if (options.verbose && testResult) {
+            console.log(chalk.gray('   Response preview:'));
+            const preview = JSON.stringify(testResult, null, 2);
+            const truncated = preview.length > 500 ? preview.slice(0, 500) + '\n   ...' : preview;
+            console.log(chalk.gray('   ' + truncated.split('\n').join('\n   ')));
+        }
+    } catch (error) {
+        console.log(chalk.red('   ✗ testAuthRequest failed'));
+        console.log(chalk.red(`   Error: ${error.message}`));
+        results.testAuthRequest = { status: 'failed', error: error.message };
+        if (options.verbose && error.stack) {
+            console.log(chalk.gray(`   Stack: ${error.stack.split('\n').slice(1, 4).join('\n   ')}`));
+        }
+        throw new Error(`Authentication test failed: ${error.message}`);
+    }
+
+    // 3. Test getEntityDetails
+    console.log(chalk.gray('\n2. Testing getEntityDetails...'));
+    const entityResult = await testGetEntityDetails(definition, api, credentials, options);
+    if (entityResult.skipped) {
+        console.log(chalk.yellow(`   ⚠ Skipped (${entityResult.reason})`));
+        results.getEntityDetails = { status: 'skipped', reason: entityResult.reason };
+    } else if (entityResult.error) {
+        console.log(chalk.red(`   ✗ Failed: ${entityResult.error}`));
+        results.getEntityDetails = { status: 'failed', error: entityResult.error };
+    } else if (!entityResult.consistent) {
+        console.log(chalk.yellow(`   ⚠ Entity mismatch (saved: ${entityResult.savedId}, fresh: ${entityResult.freshId})`));
+        results.getEntityDetails = { status: 'warning', message: 'entity mismatch' };
+    } else {
+        console.log(chalk.green(`   ✓ getEntityDetails returned consistent entity${entityResult.freshId ? ` (externalId: ${entityResult.freshId})` : ''}`));
+        results.getEntityDetails = { status: 'passed' };
+    }
+
+    // 4. Test getCredentialDetails
+    console.log(chalk.gray('\n3. Testing getCredentialDetails...'));
+    const credResult = await testGetCredentialDetails(definition, api, options);
+    if (credResult.skipped) {
+        console.log(chalk.yellow(`   ⚠ Skipped (${credResult.reason})`));
+        results.getCredentialDetails = { status: 'skipped', reason: credResult.reason };
+    } else if (credResult.error) {
+        console.log(chalk.red(`   ✗ Failed: ${credResult.error}`));
+        results.getCredentialDetails = { status: 'failed', error: credResult.error };
+    } else if (!credResult.valid) {
+        console.log(chalk.yellow('   ⚠ getCredentialDetails did not return valid identifiers'));
+        results.getCredentialDetails = { status: 'warning', message: 'invalid structure' };
+    } else {
+        console.log(chalk.green('   ✓ getCredentialDetails returned valid identifiers'));
+        results.getCredentialDetails = { status: 'passed' };
+        if (options.verbose && credResult.credentials?.identifiers) {
+            const ids = credResult.credentials.identifiers;
+            console.log(chalk.gray(`   Identifiers: ${JSON.stringify(ids)}`));
+        }
+    }
+
+    // 5. Test token refresh
+    console.log(chalk.gray('\n4. Testing token refresh...'));
+    const refreshResult = await testTokenRefresh(api, credentials, options);
+    if (refreshResult.skipped) {
+        console.log(chalk.yellow(`   ⚠ Skipped (${refreshResult.reason})`));
+        results.tokenRefresh = { status: 'skipped', reason: refreshResult.reason };
+    } else if (refreshResult.error) {
+        console.log(chalk.red(`   ✗ Failed: ${refreshResult.error}`));
+        results.tokenRefresh = { status: 'failed', error: refreshResult.error };
+    } else {
+        const tokenMsg = refreshResult.tokenChanged ? 'token refreshed successfully' : 'refresh called but token unchanged';
+        console.log(chalk.green(`   ✓ ${tokenMsg}`));
+        results.tokenRefresh = { status: 'passed', tokenChanged: refreshResult.tokenChanged };
+    }
+
+    // 6. Run a sample API call if available
+    console.log(chalk.gray('\n5. Running sample API call...'));
+    const sampleResult = await runSampleApiCall(api, ApiClass, options);
+    if (sampleResult.success) {
+        results.sampleApiCall = { status: 'passed', method: sampleResult.method };
+    } else {
+        results.sampleApiCall = { status: 'skipped', reason: 'no methods available' };
+    }
+
+    // 7. Verify credential persistence properties
+    console.log(chalk.gray('\n6. Verifying credential properties (apiPropertiesToPersist.credential)...'));
+    const credProps = definition.requiredAuthMethods?.apiPropertiesToPersist?.credential || [];
+    results.credentialProps.total = credProps.length;
+
+    if (credProps.length === 0) {
+        console.log(chalk.gray('   (no credential properties defined)'));
+    } else {
+        for (const prop of credProps) {
+            const value = api[prop];
+            if (value !== undefined && value !== null && value !== '') {
+                console.log(chalk.green(`   ✓ ${prop}: ${maskSensitive(prop, value)}`));
+                results.credentialProps.set++;
+            } else {
+                console.log(chalk.yellow(`   ⚠ ${prop}: not set or empty`));
+            }
+        }
+    }
+
+    // 8. Verify entity persistence properties
+    console.log(chalk.gray('\n7. Verifying entity properties (apiPropertiesToPersist.entity)...'));
+    const entityProps = definition.requiredAuthMethods?.apiPropertiesToPersist?.entity || [];
+    results.entityProps.total = entityProps.length;
+
+    if (entityProps.length === 0) {
+        console.log(chalk.gray('   (no entity properties defined)'));
+    } else {
+        for (const prop of entityProps) {
+            const value = api[prop];
+            if (value !== undefined && value !== null && value !== '') {
+                console.log(chalk.green(`   ✓ ${prop}: ${maskSensitive(prop, value)}`));
+                results.entityProps.set++;
+            } else {
+                console.log(chalk.yellow(`   ⚠ ${prop}: not set or empty`));
+            }
+        }
+    }
+
+    // 9. Summary
+    console.log(chalk.blue('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'));
+    console.log(chalk.blue('Summary'));
+    console.log(chalk.blue('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'));
+
+    printSummaryLine('testAuthRequest', results.testAuthRequest);
+    printSummaryLine('getEntityDetails', results.getEntityDetails);
+    printSummaryLine('getCredentialDetails', results.getCredentialDetails);
+    printSummaryLine('tokenRefresh', results.tokenRefresh);
+    printSummaryLine('sampleApiCall', results.sampleApiCall);
+
+    const credPropsStatus = results.credentialProps.total === 0
+        ? chalk.gray('n/a')
+        : (results.credentialProps.set === results.credentialProps.total
+            ? chalk.green(`${results.credentialProps.set}/${results.credentialProps.total} set`)
+            : chalk.yellow(`${results.credentialProps.set}/${results.credentialProps.total} set`));
+    console.log(`  credentialProps:      ${credPropsStatus}`);
+
+    const entityPropsStatus = results.entityProps.total === 0
+        ? chalk.gray('n/a')
+        : (results.entityProps.set === results.entityProps.total
+            ? chalk.green(`${results.entityProps.set}/${results.entityProps.total} set`)
+            : chalk.yellow(`${results.entityProps.set}/${results.entityProps.total} set`));
+    console.log(`  entityProps:          ${entityPropsStatus}`);
+
+    console.log('');
+
+    // Check if any critical tests failed
+    const criticalFailed = results.testAuthRequest.status === 'failed';
+    if (criticalFailed) {
+        throw new Error('Critical authentication tests failed');
+    }
+
+    console.log(chalk.green('✓ All authentication tests passed'));
+
+    return {
+        testAuthRequestPassed: results.testAuthRequest.status === 'passed',
+        getEntityDetailsPassed: results.getEntityDetails.status === 'passed',
+        getCredentialDetailsPassed: results.getCredentialDetails.status === 'passed',
+        tokenRefreshPassed: results.tokenRefresh.status === 'passed',
+        sampleApiCallPassed: results.sampleApiCall.status === 'passed',
+        sampleMethod: results.sampleApiCall.method,
+        credentialPropertiesValid: results.credentialProps.set === results.credentialProps.total,
+        entityPropertiesValid: results.entityProps.set === results.entityProps.total,
+    };
+}
+
+function printSummaryLine(name, result) {
+    const paddedName = (name + ':').padEnd(22);
+    let statusText;
+
+    switch (result.status) {
+        case 'passed':
+            statusText = chalk.green('✓ passed');
+            break;
+        case 'failed':
+            statusText = chalk.red('✗ failed');
+            break;
+        case 'skipped':
+            statusText = chalk.yellow(`⚠ skipped${result.reason ? ` (${result.reason})` : ''}`);
+            break;
+        case 'warning':
+            statusText = chalk.yellow(`⚠ ${result.message || 'warning'}`);
+            break;
+        default:
+            statusText = chalk.gray('pending');
+    }
+
+    console.log(`  ${paddedName}${statusText}`);
+}
+
+async function testGetEntityDetails(definition, api, savedCredentials, options) {
+    if (!definition.requiredAuthMethods?.getEntityDetails) {
+        return { skipped: true, reason: 'not defined' };
+    }
+
+    try {
+        const freshEntity = await definition.requiredAuthMethods.getEntityDetails(
+            api,
+            {},  // callbackParams
+            {},  // tokenResponse
+            'cli-test-user'
+        );
+
+        const savedId = savedCredentials.entity?.identifiers?.externalId;
+        const freshId = freshEntity?.identifiers?.externalId;
+        const consistent = !savedId || !freshId || savedId === freshId;
+
+        return {
+            success: true,
+            consistent,
+            freshId,
+            savedId,
+            freshEntity
+        };
+    } catch (error) {
+        return { error: error.message };
+    }
+}
+
+async function testGetCredentialDetails(definition, api, options) {
+    if (!definition.requiredAuthMethods?.getCredentialDetails) {
+        return { skipped: true, reason: 'not defined' };
+    }
+
+    try {
+        const credentials = await definition.requiredAuthMethods.getCredentialDetails(
+            api,
+            'cli-test-user'
+        );
+
+        const valid = credentials && typeof credentials.identifiers === 'object';
+        return { success: true, valid, credentials };
+    } catch (error) {
+        return { error: error.message };
+    }
+}
+
+async function testTokenRefresh(api, savedCredentials, options) {
+    // Check if refresh token exists
+    if (!savedCredentials.tokens?.refresh_token) {
+        return { skipped: true, reason: 'no refresh token' };
+    }
+
+    // Check if API supports refresh
+    if (typeof api.refreshAccessToken !== 'function') {
+        return { skipped: true, reason: 'refreshAccessToken not implemented' };
+    }
+
+    try {
+        const oldToken = api.access_token;
+        await api.refreshAccessToken();
+        const newToken = api.access_token;
+
+        return {
+            success: true,
+            tokenChanged: newToken !== oldToken
+        };
+    } catch (error) {
+        return { error: error.message };
+    }
+}
+
+async function tryCommonTestMethods(api) {
+    const methodsToTry = [
+        'getUserDetails',
+        'getUser',
+        'getCurrentUser',
+        'getMe',
+        'getAccount',
+        'getProfile',
+    ];
+
+    for (const method of methodsToTry) {
+        if (typeof api[method] === 'function') {
+            return await api[method]();
+        }
+    }
+
+    throw new Error('No testAuthRequest method defined and no common test methods available');
+}
+
+async function runSampleApiCall(api, ApiClass, options) {
+    const sampleMethods = [
+        { name: 'getUserDetails', description: 'Get user details' },
+        { name: 'getUser', description: 'Get user' },
+        { name: 'getCurrentUser', description: 'Get current user' },
+        { name: 'listObjects', description: 'List objects' },
+        { name: 'listContacts', description: 'List contacts' },
+        { name: 'listDeals', description: 'List deals' },
+        { name: 'listUsers', description: 'List users' },
+        { name: 'getWorkspace', description: 'Get workspace' },
+        { name: 'getOrganization', description: 'Get organization' },
+    ];
+
+    for (const { name, description } of sampleMethods) {
+        if (typeof api[name] === 'function') {
+            console.log(chalk.gray(`   Trying ${name}()...`));
+            try {
+                const result = await api[name]();
+                console.log(chalk.green(`   ✓ Sample API call (${name}) succeeded`));
+
+                if (options.verbose && result) {
+                    console.log(chalk.gray('   Response preview:'));
+                    const preview = JSON.stringify(result, null, 2);
+                    const truncated = preview.length > 300 ? preview.slice(0, 300) + '\n   ...' : preview;
+                    console.log(chalk.gray('   ' + truncated.split('\n').join('\n   ')));
+                }
+
+                return { success: true, method: name };
+            } catch (error) {
+                console.log(chalk.yellow(`   ⚠ ${name}() failed: ${error.message}`));
+            }
+        }
+    }
+
+    console.log(chalk.gray('   No additional sample API calls available for this module'));
+    return { success: false, method: null };
+}
+
+function maskSensitive(prop, value) {
+    const sensitiveProps = [
+        'access_token',
+        'refresh_token',
+        'api_key',
+        'apiKey',
+        'client_secret',
+        'password',
+        'secret',
+        'token',
+    ];
+
+    const propLower = prop.toLowerCase();
+    const isSensitive = sensitiveProps.some(sp => propLower.includes(sp.toLowerCase()));
+
+    if (isSensitive && typeof value === 'string') {
+        if (value.length <= 8) {
+            return '***';
+        }
+        return value.slice(0, 4) + '...' + value.slice(-4);
+    }
+
+    const strValue = String(value);
+    if (strValue.length > 50) {
+        return strValue.slice(0, 47) + '...';
+    }
+
+    return strValue;
+}
+
+module.exports = { runAuthTests };

--- a/packages/devtools/frigg-cli/auth-command/credential-storage.js
+++ b/packages/devtools/frigg-cli/auth-command/credential-storage.js
@@ -1,0 +1,182 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+class CredentialStorage {
+    constructor(options = {}) {
+        // Global storage in user home directory
+        this.globalPath = path.join(os.homedir(), '.frigg-credentials.json');
+        // Project-local storage (if in a Frigg project)
+        this.localPath = path.join(process.cwd(), '.frigg-credentials.json');
+        // Allow override via options
+        this.customPath = options.path || null;
+    }
+
+    getStoragePath() {
+        // Priority: custom > local (if exists) > global
+        if (this.customPath) {
+            return this.customPath;
+        }
+        if (fs.existsSync(this.localPath)) {
+            return this.localPath;
+        }
+        return this.globalPath;
+    }
+
+    getWritePath() {
+        // Priority: custom > local (if in project) > global
+        if (this.customPath) {
+            return this.customPath;
+        }
+        if (this.isInProject()) {
+            return this.localPath;
+        }
+        return this.globalPath;
+    }
+
+    async load() {
+        const filePath = this.getStoragePath();
+
+        if (!fs.existsSync(filePath)) {
+            return {
+                _meta: {
+                    version: 1,
+                    warning: 'DO NOT COMMIT THIS FILE - contains sensitive credentials'
+                },
+                modules: {}
+            };
+        }
+
+        try {
+            const content = fs.readFileSync(filePath, 'utf8');
+            return JSON.parse(content);
+        } catch (err) {
+            console.warn(`Warning: Could not read credentials file: ${err.message}`);
+            return { _meta: { version: 1 }, modules: {} };
+        }
+    }
+
+    async save(moduleName, credentials, authType) {
+        const data = await this.load();
+
+        data.modules[moduleName] = {
+            ...credentials,
+            authType,
+            savedAt: new Date().toISOString(),
+        };
+
+        const targetPath = this.getWritePath();
+
+        // Ensure directory exists
+        const dir = path.dirname(targetPath);
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true });
+        }
+
+        fs.writeFileSync(targetPath, JSON.stringify(data, null, 2));
+
+        // Add to .gitignore if saving locally
+        if (targetPath === this.localPath) {
+            this.ensureGitIgnore();
+        }
+
+        return targetPath;
+    }
+
+    async get(moduleName) {
+        const data = await this.load();
+        return data.modules[moduleName] || null;
+    }
+
+    async list() {
+        const data = await this.load();
+        return Object.entries(data.modules).map(([name, creds]) => ({
+            module: name,
+            authType: creds.authType,
+            savedAt: creds.savedAt,
+            entity: creds.entity?.details?.name || creds.entity?.identifiers?.externalId || 'Unknown',
+            hasAccessToken: !!(creds.tokens?.access_token || creds.apiKey),
+            hasRefreshToken: !!creds.tokens?.refresh_token,
+        }));
+    }
+
+    async delete(moduleName) {
+        const data = await this.load();
+
+        if (!data.modules[moduleName]) {
+            return false;
+        }
+
+        delete data.modules[moduleName];
+
+        const targetPath = this.getStoragePath();
+        fs.writeFileSync(targetPath, JSON.stringify(data, null, 2));
+        return true;
+    }
+
+    async deleteAll() {
+        const data = {
+            _meta: {
+                version: 1,
+                warning: 'DO NOT COMMIT THIS FILE - contains sensitive credentials'
+            },
+            modules: {}
+        };
+
+        const targetPath = this.getStoragePath();
+        fs.writeFileSync(targetPath, JSON.stringify(data, null, 2));
+    }
+
+    isInProject() {
+        // Check for indicators of a Frigg project
+        const indicators = [
+            path.join(process.cwd(), 'backend', 'index.js'),
+            path.join(process.cwd(), 'infrastructure.js'),
+            path.join(process.cwd(), 'backend', 'infrastructure.js'),
+            path.join(process.cwd(), 'package.json'),
+        ];
+
+        for (const indicator of indicators) {
+            if (fs.existsSync(indicator)) {
+                // Additional check: look for frigg-related content in package.json
+                if (indicator.endsWith('package.json')) {
+                    try {
+                        const pkg = JSON.parse(fs.readFileSync(indicator, 'utf8'));
+                        if (pkg.dependencies?.['@friggframework/core'] ||
+                            pkg.devDependencies?.['@friggframework/core'] ||
+                            pkg.name?.includes('frigg')) {
+                            return true;
+                        }
+                    } catch {
+                        // Ignore parse errors
+                    }
+                } else {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    ensureGitIgnore() {
+        const gitignorePath = path.join(process.cwd(), '.gitignore');
+        const entry = '.frigg-credentials.json';
+
+        try {
+            if (fs.existsSync(gitignorePath)) {
+                const content = fs.readFileSync(gitignorePath, 'utf8');
+                if (!content.includes(entry)) {
+                    fs.appendFileSync(gitignorePath, `\n# Frigg auth credentials (DO NOT COMMIT)\n${entry}\n`);
+                }
+            } else {
+                // Create new .gitignore
+                fs.writeFileSync(gitignorePath, `# Frigg auth credentials (DO NOT COMMIT)\n${entry}\n`);
+            }
+        } catch (err) {
+            console.warn(`Warning: Could not update .gitignore: ${err.message}`);
+        }
+    }
+}
+
+module.exports = { CredentialStorage };

--- a/packages/devtools/frigg-cli/auth-command/index.js
+++ b/packages/devtools/frigg-cli/auth-command/index.js
@@ -1,0 +1,259 @@
+const chalk = require('chalk');
+const { loadModule, validateModule, getAuthType } = require('./module-loader');
+const { runOAuthFlow } = require('./oauth-flow');
+const { runApiKeyFlow } = require('./api-key-flow');
+const { CredentialStorage } = require('./credential-storage');
+const { runAuthTests } = require('./auth-tester');
+
+async function test(moduleName, options) {
+    console.log(chalk.blue.bold(`\n🔐 Frigg Authenticator\n`));
+    console.log(chalk.gray(`Testing authentication for: ${moduleName}\n`));
+
+    try {
+        // 1. Load and validate module
+        const { definition, Api } = await loadModule(moduleName);
+        validateModule(definition);
+
+        // 2. Determine auth type
+        const authType = getAuthType(Api);
+        console.log(chalk.gray(`Auth type detected: ${authType}`));
+
+        let credentials;
+
+        // 3. Run appropriate auth flow
+        if (authType === 'apiKey' || authType === 'api_key') {
+            if (!options.apiKey) {
+                console.log(chalk.red('\n✗ Error: --api-key is required for API-Key modules'));
+                console.log(chalk.gray(`\nUsage: frigg auth test ${moduleName} --api-key YOUR_API_KEY\n`));
+                process.exit(1);
+            }
+            credentials = await runApiKeyFlow(definition, Api, options.apiKey, options);
+        } else {
+            // OAuth2 flow
+            credentials = await runOAuthFlow(definition, Api, {
+                port: parseInt(options.port, 10) || 3333,
+                timeout: parseInt(options.timeout, 10) || 300,
+                browser: options.browser,
+                verbose: options.verbose,
+            });
+        }
+
+        // 4. Run verification tests
+        await runAuthTests(definition, Api, credentials, {
+            verbose: options.verbose,
+        });
+
+        // 5. Save credentials
+        const storage = new CredentialStorage();
+        const savedPath = await storage.save(moduleName, credentials, authType);
+
+        console.log(chalk.green(`\n✓ Authentication successful for ${moduleName}!`));
+        console.log(chalk.gray(`  Credentials saved to: ${savedPath}`));
+        console.log(chalk.gray(`\n  Use 'frigg auth get ${moduleName} --json' to retrieve credentials.\n`));
+
+    } catch (error) {
+        console.log(chalk.red(`\n✗ Authentication failed: ${error.message}`));
+        if (options.verbose && error.stack) {
+            console.log(chalk.gray('\nStack trace:'));
+            console.log(chalk.gray(error.stack));
+        }
+        process.exit(1);
+    }
+}
+
+async function list(options) {
+    const storage = new CredentialStorage();
+    const credentials = await storage.list();
+
+    if (options.json) {
+        console.log(JSON.stringify(credentials, null, 2));
+        return;
+    }
+
+    console.log(chalk.blue.bold('\n🔐 Saved Credentials\n'));
+
+    if (credentials.length === 0) {
+        console.log(chalk.gray('  No credentials saved.\n'));
+        console.log(chalk.gray('  Run `frigg auth test <module>` to authenticate a module.\n'));
+        return;
+    }
+
+    // Display as table
+    const tableData = credentials.map(c => ({
+        Module: c.module,
+        'Auth Type': c.authType,
+        Entity: c.entity,
+        'Has Access Token': c.hasAccessToken ? '✓' : '✗',
+        'Has Refresh Token': c.hasRefreshToken ? '✓' : '-',
+        'Saved At': formatDate(c.savedAt),
+    }));
+
+    console.table(tableData);
+    console.log('');
+}
+
+async function get(moduleName, options) {
+    const storage = new CredentialStorage();
+    const credentials = await storage.get(moduleName);
+
+    if (!credentials) {
+        console.log(chalk.red(`\n✗ No credentials found for: ${moduleName}`));
+        console.log(chalk.gray(`\n  Run 'frigg auth test ${moduleName}' to authenticate.\n`));
+        process.exit(1);
+    }
+
+    if (options.json) {
+        console.log(JSON.stringify(credentials, null, 2));
+        return;
+    }
+
+    if (options.export) {
+        outputAsEnvVars(moduleName, credentials);
+        return;
+    }
+
+    // Display formatted
+    console.log(chalk.blue.bold(`\n🔐 Credentials for ${moduleName}\n`));
+
+    console.log(chalk.gray('Auth Type:'), credentials.authType);
+    console.log(chalk.gray('Obtained:'), formatDate(credentials.obtainedAt));
+    console.log(chalk.gray('Saved:'), formatDate(credentials.savedAt));
+
+    if (credentials.entity?.details?.name) {
+        console.log(chalk.gray('Entity:'), credentials.entity.details.name);
+    }
+    if (credentials.entity?.identifiers?.externalId) {
+        console.log(chalk.gray('External ID:'), credentials.entity.identifiers.externalId);
+    }
+
+    console.log(chalk.gray('\nTokens:'));
+    if (credentials.tokens?.access_token) {
+        console.log(chalk.gray('  access_token:'), maskToken(credentials.tokens.access_token));
+    }
+    if (credentials.tokens?.refresh_token) {
+        console.log(chalk.gray('  refresh_token:'), maskToken(credentials.tokens.refresh_token));
+    }
+    if (credentials.apiKey) {
+        console.log(chalk.gray('  api_key:'), maskToken(credentials.apiKey));
+    }
+
+    console.log(chalk.gray(`\n  Use --json for full output or --export for environment variables.\n`));
+}
+
+async function deleteCredentials(moduleName, options) {
+    const storage = new CredentialStorage();
+
+    if (options.all) {
+        if (!options.yes) {
+            const confirmed = await confirmAction('Delete ALL saved credentials?');
+            if (!confirmed) {
+                console.log(chalk.gray('Cancelled.'));
+                return;
+            }
+        }
+        await storage.deleteAll();
+        console.log(chalk.green('✓ All credentials deleted'));
+        return;
+    }
+
+    if (!moduleName) {
+        console.log(chalk.red('✗ Error: Please specify a module name or use --all'));
+        console.log(chalk.gray('\nUsage:'));
+        console.log(chalk.gray('  frigg auth delete <module>'));
+        console.log(chalk.gray('  frigg auth delete --all'));
+        process.exit(1);
+    }
+
+    const exists = await storage.get(moduleName);
+    if (!exists) {
+        console.log(chalk.yellow(`No credentials found for: ${moduleName}`));
+        return;
+    }
+
+    if (!options.yes) {
+        const confirmed = await confirmAction(`Delete credentials for ${moduleName}?`);
+        if (!confirmed) {
+            console.log(chalk.gray('Cancelled.'));
+            return;
+        }
+    }
+
+    const deleted = await storage.delete(moduleName);
+    if (deleted) {
+        console.log(chalk.green(`✓ Credentials deleted for ${moduleName}`));
+    } else {
+        console.log(chalk.yellow(`No credentials found for: ${moduleName}`));
+    }
+}
+
+// Helper functions
+
+function formatDate(dateStr) {
+    if (!dateStr) return 'Unknown';
+    try {
+        const date = new Date(dateStr);
+        return date.toLocaleString();
+    } catch {
+        return dateStr;
+    }
+}
+
+function maskToken(token) {
+    if (!token || token.length <= 8) {
+        return '***';
+    }
+    return token.slice(0, 4) + '...' + token.slice(-4);
+}
+
+function outputAsEnvVars(moduleName, credentials) {
+    const prefix = moduleName.toUpperCase().replace(/-/g, '_');
+
+    const vars = [];
+
+    if (credentials.tokens?.access_token) {
+        vars.push(`export ${prefix}_ACCESS_TOKEN="${credentials.tokens.access_token}"`);
+    }
+    if (credentials.tokens?.refresh_token) {
+        vars.push(`export ${prefix}_REFRESH_TOKEN="${credentials.tokens.refresh_token}"`);
+    }
+    if (credentials.apiKey) {
+        vars.push(`export ${prefix}_API_KEY="${credentials.apiKey}"`);
+    }
+    if (credentials.entity?.identifiers?.externalId) {
+        vars.push(`export ${prefix}_EXTERNAL_ID="${credentials.entity.identifiers.externalId}"`);
+    }
+    if (credentials.apiParams?.companyDomain) {
+        vars.push(`export ${prefix}_COMPANY_DOMAIN="${credentials.apiParams.companyDomain}"`);
+    }
+
+    if (vars.length === 0) {
+        console.log(chalk.yellow('# No credentials to export'));
+    } else {
+        console.log(vars.join('\n'));
+    }
+}
+
+async function confirmAction(message) {
+    // Simple confirmation using readline
+    const readline = require('readline');
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+
+    return new Promise((resolve) => {
+        rl.question(chalk.yellow(`${message} [y/N] `), (answer) => {
+            rl.close();
+            resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
+        });
+    });
+}
+
+module.exports = {
+    authCommand: {
+        test,
+        list,
+        get,
+        delete: deleteCredentials,
+    },
+};

--- a/packages/devtools/frigg-cli/auth-command/index.js
+++ b/packages/devtools/frigg-cli/auth-command/index.js
@@ -30,7 +30,6 @@ async function test(moduleName, options) {
             credentials = await runOAuthFlow(definition, Api, {
                 port: parseInt(options.port, 10) || 3333,
                 timeout: parseInt(options.timeout, 10) || 300,
-                browser: options.browser,
                 verbose: options.verbose,
             });
         }
@@ -40,13 +39,14 @@ async function test(moduleName, options) {
             verbose: options.verbose,
         });
 
-        // 5. Save credentials
+        // 5. Save credentials using actual module name from definition
+        const actualModuleName = definition.moduleName || definition.getName?.() || moduleName;
         const storage = new CredentialStorage();
-        const savedPath = await storage.save(moduleName, credentials, authType);
+        const savedPath = await storage.save(actualModuleName, credentials, authType);
 
-        console.log(chalk.green(`\n✓ Authentication successful for ${moduleName}!`));
+        console.log(chalk.green(`\n✓ Authentication successful for ${actualModuleName}!`));
         console.log(chalk.gray(`  Credentials saved to: ${savedPath}`));
-        console.log(chalk.gray(`\n  Use 'frigg auth get ${moduleName} --json' to retrieve credentials.\n`));
+        console.log(chalk.gray(`\n  Use 'frigg auth get ${actualModuleName} --json' to retrieve credentials.\n`));
 
     } catch (error) {
         console.log(chalk.red(`\n✗ Authentication failed: ${error.message}`));

--- a/packages/devtools/frigg-cli/auth-command/index.js
+++ b/packages/devtools/frigg-cli/auth-command/index.js
@@ -22,11 +22,8 @@ async function test(moduleName, options) {
 
         // 3. Run appropriate auth flow
         if (authType === 'apiKey' || authType === 'api_key') {
-            if (!options.apiKey) {
-                console.log(chalk.red('\n✗ Error: --api-key is required for API-Key modules'));
-                console.log(chalk.gray(`\nUsage: frigg auth test ${moduleName} --api-key YOUR_API_KEY\n`));
-                process.exit(1);
-            }
+            // API key flow handles missing --api-key by checking for getAuthorizationRequirements
+            // and rendering an interactive form if available
             credentials = await runApiKeyFlow(definition, Api, options.apiKey, options);
         } else {
             // OAuth2 flow

--- a/packages/devtools/frigg-cli/auth-command/json-schema-form.js
+++ b/packages/devtools/frigg-cli/auth-command/json-schema-form.js
@@ -1,0 +1,67 @@
+const { input, password } = require('@inquirer/prompts');
+const chalk = require('chalk');
+
+/**
+ * Renders a JSON Schema form as interactive CLI prompts
+ *
+ * @param {Object} jsonSchema - JSON Schema object with properties, required fields, etc.
+ * @param {Object} uiSchema - UI Schema with rendering hints (ui:widget, ui:help, ui:placeholder)
+ * @returns {Promise<Object>} - Object containing all form field values
+ */
+async function renderJsonSchemaForm(jsonSchema, uiSchema = {}) {
+    const results = {};
+    const properties = jsonSchema.properties || {};
+    const required = jsonSchema.required || [];
+
+    // Display form title
+    if (jsonSchema.title) {
+        console.log(chalk.blue(`\n📝 ${jsonSchema.title}\n`));
+    }
+
+    for (const [key, prop] of Object.entries(properties)) {
+        const ui = uiSchema[key] || {};
+        const isRequired = required.includes(key);
+        const isPassword = ui['ui:widget'] === 'password';
+
+        // Build prompt message with title
+        const fieldTitle = prop.title || key;
+
+        // Show help text before the prompt if available
+        if (ui['ui:help']) {
+            console.log(chalk.gray(`  (${ui['ui:help']})`));
+        }
+
+        let value;
+        if (isPassword) {
+            value = await password({
+                message: fieldTitle,
+                mask: '*',
+                validate: (input) => {
+                    if (isRequired && !input) {
+                        return `${fieldTitle} is required`;
+                    }
+                    return true;
+                },
+            });
+        } else {
+            value = await input({
+                message: fieldTitle,
+                default: '',
+                validate: (input) => {
+                    if (isRequired && !input) {
+                        return `${fieldTitle} is required`;
+                    }
+                    return true;
+                },
+            });
+        }
+
+        if (value) {
+            results[key] = value;
+        }
+    }
+
+    return results;
+}
+
+module.exports = { renderJsonSchemaForm };

--- a/packages/devtools/frigg-cli/auth-command/module-loader.js
+++ b/packages/devtools/frigg-cli/auth-command/module-loader.js
@@ -1,0 +1,172 @@
+const path = require('path');
+const fs = require('fs');
+const chalk = require('chalk');
+
+async function loadModule(moduleIdentifier) {
+    let modulePath;
+    let searchedPaths = [];
+
+    // 1. Check if it's a relative/absolute path
+    if (moduleIdentifier.startsWith('.') || moduleIdentifier.startsWith('/')) {
+        modulePath = path.resolve(process.cwd(), moduleIdentifier);
+        if (!fs.existsSync(modulePath)) {
+            throw new Error(`Module path not found: ${modulePath}`);
+        }
+    }
+    // 2. Check if it's a scoped package name
+    else if (moduleIdentifier.startsWith('@')) {
+        modulePath = resolveFromNodeModules(moduleIdentifier, searchedPaths);
+        if (!modulePath) {
+            throw new Error(
+                `Could not find module: ${moduleIdentifier}\nSearched paths:\n${searchedPaths.map(p => `  - ${p}`).join('\n')}`
+            );
+        }
+    }
+    // 3. Assume it's a short name like "attio" -> "@friggframework/api-module-attio"
+    else {
+        const fullName = `@friggframework/api-module-${moduleIdentifier}`;
+        modulePath = resolveFromNodeModules(fullName, searchedPaths);
+
+        // If not found, try local src/api-modules path
+        if (!modulePath) {
+            const localPath = path.join(process.cwd(), 'src', 'api-modules', moduleIdentifier);
+            searchedPaths.push(localPath);
+            if (fs.existsSync(localPath)) {
+                modulePath = localPath;
+            }
+        }
+
+        // Also try backend/src/api-modules (common Frigg structure)
+        if (!modulePath) {
+            const backendLocalPath = path.join(process.cwd(), 'backend', 'src', 'api-modules', moduleIdentifier);
+            searchedPaths.push(backendLocalPath);
+            if (fs.existsSync(backendLocalPath)) {
+                modulePath = backendLocalPath;
+            }
+        }
+
+        if (!modulePath) {
+            throw new Error(
+                `Could not find module: ${moduleIdentifier}\nTried:\n` +
+                `  - ${fullName}\n` +
+                `Searched paths:\n${searchedPaths.map(p => `  - ${p}`).join('\n')}`
+            );
+        }
+    }
+
+    console.log(chalk.gray(`Loading module from: ${modulePath}`));
+
+    // Load the module
+    let moduleExports;
+    try {
+        moduleExports = require(modulePath);
+    } catch (err) {
+        throw new Error(`Failed to load module from ${modulePath}: ${err.message}`);
+    }
+
+    // Extract Definition and Api
+    const definition = moduleExports.Definition || moduleExports.definition;
+    const Api = definition?.API || moduleExports.Api || moduleExports.API;
+
+    if (!definition) {
+        throw new Error(
+            `Module ${moduleIdentifier} does not export a Definition.\n` +
+            `Expected exports: { Definition } or { definition }`
+        );
+    }
+
+    if (!Api) {
+        throw new Error(
+            `Module ${moduleIdentifier} does not export an API class.\n` +
+            `Expected Definition.API or exports.Api`
+        );
+    }
+
+    return { definition, Api, modulePath };
+}
+
+function resolveFromNodeModules(packageName, searchedPaths = []) {
+    const pathsToCheck = [
+        // Current working directory
+        path.join(process.cwd(), 'node_modules', packageName),
+        // Backend subdirectory (common Frigg structure)
+        path.join(process.cwd(), 'backend', 'node_modules', packageName),
+        // Parent directory (for monorepos)
+        path.join(process.cwd(), '..', 'node_modules', packageName),
+        // Global installation location (via npm root -g)
+        path.join(process.execPath, '..', '..', 'lib', 'node_modules', packageName),
+    ];
+
+    for (const checkPath of pathsToCheck) {
+        searchedPaths.push(checkPath);
+        if (fs.existsSync(checkPath)) {
+            return checkPath;
+        }
+    }
+
+    return null;
+}
+
+function validateModule(definition) {
+    const errors = [];
+
+    // Check required fields
+    const requiredFields = ['moduleName', 'API'];
+    for (const field of requiredFields) {
+        if (!definition[field]) {
+            errors.push(`Missing required field: ${field}`);
+        }
+    }
+
+    // Check requiredAuthMethods
+    if (!definition.requiredAuthMethods) {
+        errors.push('Missing requiredAuthMethods object');
+    } else {
+        const requiredMethods = ['getEntityDetails', 'testAuthRequest', 'apiPropertiesToPersist'];
+        for (const method of requiredMethods) {
+            if (!definition.requiredAuthMethods[method]) {
+                errors.push(`Missing required auth method: ${method}`);
+            }
+        }
+
+        // getToken is required for OAuth2, optional for API-Key
+        // getCredentialDetails is recommended but not strictly required
+    }
+
+    if (errors.length > 0) {
+        throw new Error(
+            `Module validation failed:\n${errors.map(e => `  - ${e}`).join('\n')}`
+        );
+    }
+
+    console.log(chalk.green(`✓ Module validation passed: ${definition.moduleName}`));
+}
+
+function getAuthType(Api) {
+    // Check the requesterType static property
+    if (Api.requesterType) {
+        return Api.requesterType;
+    }
+
+    // Check prototype chain for OAuth2Requester or ApiKeyRequester
+    const className = Api.name;
+    const protoChain = [];
+    let proto = Api;
+    while (proto && proto.name) {
+        protoChain.push(proto.name);
+        proto = Object.getPrototypeOf(proto);
+    }
+
+    if (protoChain.some(name => name.includes('OAuth2') || name.includes('Oauth2'))) {
+        return 'oauth2';
+    }
+
+    if (protoChain.some(name => name.includes('ApiKey') || name.includes('APIKey'))) {
+        return 'apiKey';
+    }
+
+    // Default to oauth2
+    return 'oauth2';
+}
+
+module.exports = { loadModule, validateModule, getAuthType };

--- a/packages/devtools/frigg-cli/auth-command/oauth-callback-server.js
+++ b/packages/devtools/frigg-cli/auth-command/oauth-callback-server.js
@@ -1,0 +1,431 @@
+const http = require('http');
+const url = require('url');
+const chalk = require('chalk');
+
+class OAuthCallbackServer {
+    constructor(options = {}) {
+        this.port = options.port || 3333;
+        this.timeout = (options.timeout || 300) * 1000; // Convert to milliseconds
+        this.server = null;
+        this._resolveCode = null;
+        this._rejectCode = null;
+        this._timeoutId = null;
+    }
+
+    async start() {
+        return new Promise((resolve, reject) => {
+            this.server = http.createServer(this.handleRequest.bind(this));
+
+            this.server.on('error', (err) => {
+                if (err.code === 'EADDRINUSE') {
+                    reject(
+                        new Error(
+                            `Port ${this.port} is already in use.\n` +
+                                `Try using a different port: frigg auth test <module> --port <different-port>`
+                        )
+                    );
+                } else {
+                    reject(err);
+                }
+            });
+
+            this.server.listen(this.port, () => {
+                console.log(
+                    chalk.gray(
+                        `Callback server listening on http://localhost:${this.port}`
+                    )
+                );
+                resolve();
+            });
+        });
+    }
+
+    handleRequest(req, res) {
+        const parsedUrl = url.parse(req.url, true);
+
+        // Handle OAuth callback (any path - to support module-specific redirects like /attio, /pipedrive)
+        if (parsedUrl.query.code) {
+            this.handleOAuthCallback(parsedUrl.query, res);
+        } else if (parsedUrl.query.error) {
+            this.handleOAuthError(parsedUrl.query, res);
+        } else if (parsedUrl.pathname === '/health') {
+            // Health check endpoint
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ status: 'ready' }));
+        } else {
+            res.writeHead(200, { 'Content-Type': 'text/html' });
+            res.end(this.getWaitingHtml());
+        }
+    }
+
+    handleOAuthCallback(query, res) {
+        const { code, state } = query;
+
+        // Send success page to browser
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(this.getSuccessHtml());
+
+        // Clear timeout
+        if (this._timeoutId) {
+            clearTimeout(this._timeoutId);
+            this._timeoutId = null;
+        }
+
+        // Resolve the waiting promise
+        if (this._resolveCode) {
+            this._resolveCode({ code, state });
+            this._resolveCode = null;
+            this._rejectCode = null;
+        }
+    }
+
+    handleOAuthError(query, res) {
+        const { error, error_description, error_uri } = query;
+
+        // Send error page to browser
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(this.getErrorHtml(error, error_description, error_uri));
+
+        // Clear timeout
+        if (this._timeoutId) {
+            clearTimeout(this._timeoutId);
+            this._timeoutId = null;
+        }
+
+        // Reject the waiting promise
+        if (this._rejectCode) {
+            const errorMessage = error_description
+                ? `OAuth error: ${error} - ${error_description}`
+                : `OAuth error: ${error}`;
+            this._rejectCode(new Error(errorMessage));
+            this._resolveCode = null;
+            this._rejectCode = null;
+        }
+    }
+
+    waitForCode() {
+        return new Promise((resolve, reject) => {
+            this._resolveCode = resolve;
+            this._rejectCode = reject;
+
+            // Set timeout
+            this._timeoutId = setTimeout(() => {
+                this._resolveCode = null;
+                this._rejectCode = null;
+                reject(
+                    new Error(
+                        `OAuth callback timeout after ${
+                            this.timeout / 1000
+                        } seconds.\n` +
+                            `Make sure you completed the authorization in the browser.`
+                    )
+                );
+            }, this.timeout);
+        });
+    }
+
+    getSuccessHtml() {
+        return `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Frigg Auth - Success</title>
+    <style>
+        :root {
+            --primary: hsl(150 45% 30%);
+            --primary-foreground: hsl(150 30% 90%);
+            --background: hsl(0 0% 100%);
+            --foreground: hsl(240 10% 3.9%);
+            --muted-foreground: hsl(240 3.8% 46.1%);
+            --border: hsl(240 5.9% 90%);
+            --radius: 0.5rem;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            background: var(--background);
+        }
+        .container {
+            text-align: center;
+            background: var(--background);
+            padding: 3rem;
+            border-radius: var(--radius);
+            border: 1px solid var(--border);
+            box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+            max-width: 400px;
+        }
+        .icon {
+            width: 64px;
+            height: 64px;
+            margin: 0 auto 1.5rem auto;
+            background: var(--primary);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .icon svg {
+            width: 32px;
+            height: 32px;
+            color: var(--primary-foreground);
+        }
+        h1 {
+            color: var(--foreground);
+            margin: 0 0 0.5rem 0;
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+        p {
+            color: var(--muted-foreground);
+            margin: 0;
+            line-height: 1.6;
+            font-size: 0.875rem;
+        }
+        .frigg-badge {
+            margin-top: 2rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border);
+            font-size: 0.75rem;
+            color: var(--muted-foreground);
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+            </svg>
+        </div>
+        <h1>Authentication Successful</h1>
+        <p>You can close this window and return to the terminal.</p>
+        <div class="frigg-badge">Powered by Frigg</div>
+    </div>
+</body>
+</html>`;
+    }
+
+    getErrorHtml(error, description, errorUri) {
+        return `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Frigg Auth - Error</title>
+    <style>
+        :root {
+            --destructive: hsl(0 84.2% 60.2%);
+            --destructive-foreground: hsl(0 0% 98%);
+            --background: hsl(0 0% 100%);
+            --foreground: hsl(240 10% 3.9%);
+            --muted-foreground: hsl(240 3.8% 46.1%);
+            --border: hsl(240 5.9% 90%);
+            --primary: hsl(150 45% 30%);
+            --radius: 0.5rem;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            background: var(--background);
+        }
+        .container {
+            text-align: center;
+            background: var(--background);
+            padding: 3rem;
+            border-radius: var(--radius);
+            border: 1px solid var(--border);
+            box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+            max-width: 400px;
+        }
+        .icon {
+            width: 64px;
+            height: 64px;
+            margin: 0 auto 1.5rem auto;
+            background: var(--destructive);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .icon svg {
+            width: 32px;
+            height: 32px;
+            color: var(--destructive-foreground);
+        }
+        h1 {
+            color: var(--foreground);
+            margin: 0 0 1rem 0;
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+        .error-code {
+            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+            background: hsl(0 84.2% 97%);
+            color: hsl(0 72% 51%);
+            padding: 0.5rem 1rem;
+            border-radius: calc(var(--radius) - 2px);
+            display: inline-block;
+            margin-bottom: 1rem;
+            font-size: 0.875rem;
+            border: 1px solid hsl(0 84.2% 90%);
+        }
+        p {
+            color: var(--muted-foreground);
+            margin: 0 0 0.5rem 0;
+            line-height: 1.6;
+            font-size: 0.875rem;
+        }
+        a {
+            color: var(--primary);
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .frigg-badge {
+            margin-top: 2rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border);
+            font-size: 0.75rem;
+            color: var(--muted-foreground);
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+        </div>
+        <h1>Authentication Failed</h1>
+        <div class="error-code">${escapeHtml(error)}</div>
+        ${description ? `<p>${escapeHtml(description)}</p>` : ''}
+        ${
+            errorUri
+                ? `<p><a href="${escapeHtml(
+                      errorUri
+                  )}" target="_blank">More information →</a></p>`
+                : ''
+        }
+        <p style="margin-top: 1rem;">Check the terminal for details.</p>
+        <div class="frigg-badge">Powered by Frigg</div>
+    </div>
+</body>
+</html>`;
+    }
+
+    getWaitingHtml() {
+        return `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Frigg Auth - Waiting</title>
+    <style>
+        :root {
+            --primary: hsl(150 45% 30%);
+            --background: hsl(0 0% 100%);
+            --foreground: hsl(240 10% 3.9%);
+            --muted-foreground: hsl(240 3.8% 46.1%);
+            --border: hsl(240 5.9% 90%);
+            --radius: 0.5rem;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            background: var(--background);
+        }
+        .container {
+            text-align: center;
+            background: var(--background);
+            padding: 3rem;
+            border-radius: var(--radius);
+            border: 1px solid var(--border);
+            box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+            max-width: 400px;
+        }
+        .spinner {
+            width: 48px;
+            height: 48px;
+            margin: 0 auto 1.5rem auto;
+            border: 3px solid var(--border);
+            border-top-color: var(--primary);
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+        h1 {
+            color: var(--foreground);
+            margin: 0 0 0.5rem 0;
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+        p {
+            color: var(--muted-foreground);
+            margin: 0;
+            line-height: 1.6;
+            font-size: 0.875rem;
+        }
+        .frigg-badge {
+            margin-top: 2rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border);
+            font-size: 0.75rem;
+            color: var(--muted-foreground);
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="spinner"></div>
+        <h1>Waiting for Authorization</h1>
+        <p>Complete the OAuth flow in your browser to continue.</p>
+        <div class="frigg-badge">Powered by Frigg</div>
+    </div>
+</body>
+</html>`;
+    }
+
+    async stop() {
+        // Clear any pending timeout
+        if (this._timeoutId) {
+            clearTimeout(this._timeoutId);
+            this._timeoutId = null;
+        }
+
+        if (this.server) {
+            return new Promise((resolve) => {
+                this.server.close(() => {
+                    this.server = null;
+                    resolve();
+                });
+            });
+        }
+    }
+}
+
+function escapeHtml(str) {
+    if (!str) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+module.exports = { OAuthCallbackServer };

--- a/packages/devtools/frigg-cli/auth-command/oauth-flow.js
+++ b/packages/devtools/frigg-cli/auth-command/oauth-flow.js
@@ -5,8 +5,9 @@ const crypto = require('crypto');
 
 async function runOAuthFlow(definition, ApiClass, options) {
     const port = options.port || 3333;
-    const redirectUri = `http://localhost:${port}`;
-    const moduleName = definition.moduleName || definition.getName?.() || 'unknown';
+    const redirectUri = process.env.REDIRECT_URI || `http://localhost:${port}`;
+    const moduleName =
+        definition.moduleName || definition.getName?.() || 'unknown';
 
     // 1. Generate state for CSRF protection
     const state = crypto.randomBytes(16).toString('hex');
@@ -30,7 +31,7 @@ async function runOAuthFlow(definition, ApiClass, options) {
     if (!authUrl) {
         throw new Error(
             `Module ${moduleName} did not provide an authorization URL.\n` +
-            `Expected api.getAuthorizationUri() or api.authorizationUri property.`
+                `Expected api.getAuthorizationUri() or api.authorizationUri property.`
         );
     }
 
@@ -54,13 +55,19 @@ async function runOAuthFlow(definition, ApiClass, options) {
         try {
             await openBrowser(authUrl);
         } catch (err) {
-            console.log(chalk.yellow(`Could not open browser automatically: ${err.message}`));
+            console.log(
+                chalk.yellow(
+                    `Could not open browser automatically: ${err.message}`
+                )
+            );
             console.log(chalk.yellow('Please open the URL manually:'));
             console.log(chalk.cyan(`\n  ${authUrl}\n`));
         }
 
         console.log(chalk.gray('Waiting for OAuth callback...'));
-        console.log(chalk.gray(`(Timeout: ${options.timeout || 300} seconds)\n`));
+        console.log(
+            chalk.gray(`(Timeout: ${options.timeout || 300} seconds)\n`)
+        );
 
         // 6. Wait for callback
         const { code, state: returnedState } = await server.waitForCode();
@@ -69,8 +76,8 @@ async function runOAuthFlow(definition, ApiClass, options) {
         if (returnedState && returnedState !== state) {
             throw new Error(
                 'OAuth state mismatch - possible CSRF attack.\n' +
-                `Expected: ${state}\n` +
-                `Received: ${returnedState}`
+                    `Expected: ${state}\n` +
+                    `Received: ${returnedState}`
             );
         }
 
@@ -81,7 +88,9 @@ async function runOAuthFlow(definition, ApiClass, options) {
 
         let tokenResponse;
         if (definition.requiredAuthMethods?.getToken) {
-            tokenResponse = await definition.requiredAuthMethods.getToken(api, { code });
+            tokenResponse = await definition.requiredAuthMethods.getToken(api, {
+                code,
+            });
         } else {
             // Fallback to direct API call
             tokenResponse = await api.getTokenFromCode(code);
@@ -94,17 +103,18 @@ async function runOAuthFlow(definition, ApiClass, options) {
 
         let entityDetails;
         if (definition.requiredAuthMethods?.getEntityDetails) {
-            entityDetails = await definition.requiredAuthMethods.getEntityDetails(
-                api,
-                { code, state: returnedState },
-                tokenResponse,
-                'cli-test-user'
-            );
+            entityDetails =
+                await definition.requiredAuthMethods.getEntityDetails(
+                    api,
+                    { code, state: returnedState },
+                    tokenResponse,
+                    'cli-test-user'
+                );
         } else {
             // Minimal entity details if method not provided
             entityDetails = {
                 identifiers: { externalId: 'unknown', user: 'cli-test-user' },
-                details: { name: 'Unknown' }
+                details: { name: 'Unknown' },
             };
         }
 
@@ -114,19 +124,28 @@ async function runOAuthFlow(definition, ApiClass, options) {
             console.log(chalk.gray(`  Entity: ${entityDetails.details.name}`));
         }
         if (entityDetails?.identifiers?.externalId) {
-            console.log(chalk.gray(`  External ID: ${entityDetails.identifiers.externalId}`));
+            console.log(
+                chalk.gray(
+                    `  External ID: ${entityDetails.identifiers.externalId}`
+                )
+            );
         }
 
         // 10. Collect credential details
         let credentialDetails = {};
         if (definition.requiredAuthMethods?.getCredentialDetails) {
             try {
-                credentialDetails = await definition.requiredAuthMethods.getCredentialDetails(
-                    api,
-                    'cli-test-user'
-                );
+                credentialDetails =
+                    await definition.requiredAuthMethods.getCredentialDetails(
+                        api,
+                        'cli-test-user'
+                    );
             } catch (err) {
-                console.log(chalk.yellow(`  Warning: Could not get credential details: ${err.message}`));
+                console.log(
+                    chalk.yellow(
+                        `  Warning: Could not get credential details: ${err.message}`
+                    )
+                );
             }
         }
 
@@ -144,7 +163,6 @@ async function runOAuthFlow(definition, ApiClass, options) {
             tokenResponse: sanitizeTokenResponse(tokenResponse),
             obtainedAt: new Date().toISOString(),
         };
-
     } finally {
         await server.stop();
     }

--- a/packages/devtools/frigg-cli/auth-command/oauth-flow.js
+++ b/packages/devtools/frigg-cli/auth-command/oauth-flow.js
@@ -5,19 +5,25 @@ const crypto = require('crypto');
 
 async function runOAuthFlow(definition, ApiClass, options) {
     const port = options.port || 3333;
-    const redirectUri = process.env.REDIRECT_URI || `http://localhost:${port}`;
+    const defaultRedirectUri = `http://localhost:${port}`;
+    const redirectUri =
+        definition.env?.redirect_uri ||
+        process.env.REDIRECT_URI ||
+        defaultRedirectUri;
     const moduleName =
         definition.moduleName || definition.getName?.() || 'unknown';
 
     // 1. Generate state for CSRF protection
     const state = crypto.randomBytes(16).toString('hex');
 
-    // 2. Create API instance with auth params
+    // 2. Create API instance with auth params (redirect_uri from definition.env is preserved)
     const apiParams = {
         ...definition.env,
-        redirect_uri: redirectUri,
         state,
     };
+    if (!definition.env?.redirect_uri) {
+        apiParams.redirect_uri = redirectUri;
+    }
     const api = new ApiClass(apiParams);
 
     // 3. Get authorization URL
@@ -35,7 +41,6 @@ async function runOAuthFlow(definition, ApiClass, options) {
         );
     }
 
-    // Add state to URL if not already present
     if (!authUrl.includes('state=')) {
         const separator = authUrl.includes('?') ? '&' : '?';
         authUrl = `${authUrl}${separator}state=${state}`;

--- a/packages/devtools/frigg-cli/auth-command/oauth-flow.js
+++ b/packages/devtools/frigg-cli/auth-command/oauth-flow.js
@@ -1,0 +1,177 @@
+const { OAuthCallbackServer } = require('./oauth-callback-server');
+const { openBrowser } = require('./utils/browser');
+const chalk = require('chalk');
+const crypto = require('crypto');
+
+async function runOAuthFlow(definition, ApiClass, options) {
+    const port = options.port || 3333;
+    const redirectUri = `http://localhost:${port}`;
+    const moduleName = definition.moduleName || definition.getName?.() || 'unknown';
+
+    // 1. Generate state for CSRF protection
+    const state = crypto.randomBytes(16).toString('hex');
+
+    // 2. Create API instance with auth params
+    const apiParams = {
+        ...definition.env,
+        redirect_uri: redirectUri,
+        state,
+    };
+    const api = new ApiClass(apiParams);
+
+    // 3. Get authorization URL
+    let authUrl;
+    if (typeof api.getAuthorizationUri === 'function') {
+        authUrl = api.getAuthorizationUri();
+    } else if (api.authorizationUri) {
+        authUrl = api.authorizationUri;
+    }
+
+    if (!authUrl) {
+        throw new Error(
+            `Module ${moduleName} did not provide an authorization URL.\n` +
+            `Expected api.getAuthorizationUri() or api.authorizationUri property.`
+        );
+    }
+
+    // Add state to URL if not already present
+    if (!authUrl.includes('state=')) {
+        const separator = authUrl.includes('?') ? '&' : '?';
+        authUrl = `${authUrl}${separator}state=${state}`;
+    }
+
+    console.log(chalk.blue('\n📝 OAuth2 Authorization Flow\n'));
+    console.log(chalk.gray(`Module: ${moduleName}`));
+    console.log(chalk.gray(`Redirect URI: ${redirectUri}`));
+
+    // 4. Start callback server
+    const server = new OAuthCallbackServer({ port, timeout: options.timeout });
+    await server.start();
+
+    try {
+        // 5. Open browser or display URL
+        if (options.browser !== false) {
+            console.log(chalk.gray('\nOpening browser for authorization...'));
+            try {
+                await openBrowser(authUrl);
+            } catch (err) {
+                console.log(chalk.yellow(`Could not open browser automatically: ${err.message}`));
+                console.log(chalk.yellow('Please open the URL manually:'));
+                console.log(chalk.cyan(`\n  ${authUrl}\n`));
+            }
+        } else {
+            console.log(chalk.yellow('\nOpen this URL in your browser to authorize:'));
+            console.log(chalk.cyan(`\n  ${authUrl}\n`));
+        }
+
+        console.log(chalk.gray('Waiting for OAuth callback...'));
+        console.log(chalk.gray(`(Timeout: ${options.timeout || 300} seconds)\n`));
+
+        // 6. Wait for callback
+        const { code, state: returnedState } = await server.waitForCode();
+
+        // 7. Verify state (CSRF protection)
+        if (returnedState && returnedState !== state) {
+            throw new Error(
+                'OAuth state mismatch - possible CSRF attack.\n' +
+                `Expected: ${state}\n` +
+                `Received: ${returnedState}`
+            );
+        }
+
+        console.log(chalk.green('✓ Authorization code received'));
+
+        // 8. Exchange code for tokens
+        console.log(chalk.gray('Exchanging code for tokens...'));
+
+        let tokenResponse;
+        if (definition.requiredAuthMethods?.getToken) {
+            tokenResponse = await definition.requiredAuthMethods.getToken(api, { code });
+        } else {
+            // Fallback to direct API call
+            tokenResponse = await api.getTokenFromCode(code);
+        }
+
+        console.log(chalk.green('✓ Tokens received'));
+
+        // 9. Get entity details
+        console.log(chalk.gray('Fetching entity details...'));
+
+        let entityDetails;
+        if (definition.requiredAuthMethods?.getEntityDetails) {
+            entityDetails = await definition.requiredAuthMethods.getEntityDetails(
+                api,
+                { code, state: returnedState },
+                tokenResponse,
+                'cli-test-user'
+            );
+        } else {
+            // Minimal entity details if method not provided
+            entityDetails = {
+                identifiers: { externalId: 'unknown', user: 'cli-test-user' },
+                details: { name: 'Unknown' }
+            };
+        }
+
+        console.log(chalk.green('✓ Entity details retrieved'));
+
+        if (entityDetails?.details?.name) {
+            console.log(chalk.gray(`  Entity: ${entityDetails.details.name}`));
+        }
+        if (entityDetails?.identifiers?.externalId) {
+            console.log(chalk.gray(`  External ID: ${entityDetails.identifiers.externalId}`));
+        }
+
+        // 10. Collect credential details
+        let credentialDetails = {};
+        if (definition.requiredAuthMethods?.getCredentialDetails) {
+            try {
+                credentialDetails = await definition.requiredAuthMethods.getCredentialDetails(
+                    api,
+                    'cli-test-user'
+                );
+            } catch (err) {
+                console.log(chalk.yellow(`  Warning: Could not get credential details: ${err.message}`));
+            }
+        }
+
+        // 11. Return credentials object
+        return {
+            tokens: {
+                access_token: api.access_token,
+                refresh_token: api.refresh_token,
+                accessTokenExpire: api.accessTokenExpire,
+                refreshTokenExpire: api.refreshTokenExpire,
+            },
+            entity: entityDetails,
+            credential: credentialDetails,
+            apiParams: sanitizeApiParams(apiParams),
+            tokenResponse: sanitizeTokenResponse(tokenResponse),
+            obtainedAt: new Date().toISOString(),
+        };
+
+    } finally {
+        await server.stop();
+    }
+}
+
+function sanitizeApiParams(params) {
+    // Remove sensitive data that shouldn't be stored
+    const sanitized = { ...params };
+    delete sanitized.client_secret;
+    return sanitized;
+}
+
+function sanitizeTokenResponse(response) {
+    if (!response) return null;
+    // Keep only metadata, not the actual tokens
+    return {
+        token_type: response.token_type,
+        expires_in: response.expires_in,
+        scope: response.scope,
+        // Include any service-specific metadata (like api_domain for Pipedrive)
+        api_domain: response.api_domain,
+    };
+}
+
+module.exports = { runOAuthFlow };

--- a/packages/devtools/frigg-cli/auth-command/oauth-flow.js
+++ b/packages/devtools/frigg-cli/auth-command/oauth-flow.js
@@ -49,18 +49,13 @@ async function runOAuthFlow(definition, ApiClass, options) {
     await server.start();
 
     try {
-        // 5. Open browser or display URL
-        if (options.browser !== false) {
-            console.log(chalk.gray('\nOpening browser for authorization...'));
-            try {
-                await openBrowser(authUrl);
-            } catch (err) {
-                console.log(chalk.yellow(`Could not open browser automatically: ${err.message}`));
-                console.log(chalk.yellow('Please open the URL manually:'));
-                console.log(chalk.cyan(`\n  ${authUrl}\n`));
-            }
-        } else {
-            console.log(chalk.yellow('\nOpen this URL in your browser to authorize:'));
+        // 5. Open browser for authorization
+        console.log(chalk.gray('\nOpening browser for authorization...'));
+        try {
+            await openBrowser(authUrl);
+        } catch (err) {
+            console.log(chalk.yellow(`Could not open browser automatically: ${err.message}`));
+            console.log(chalk.yellow('Please open the URL manually:'));
             console.log(chalk.cyan(`\n  ${authUrl}\n`));
         }
 

--- a/packages/devtools/frigg-cli/auth-command/utils/browser.js
+++ b/packages/devtools/frigg-cli/auth-command/utils/browser.js
@@ -1,0 +1,30 @@
+const { exec } = require('child_process');
+const os = require('os');
+
+async function openBrowser(url) {
+    const platform = os.platform();
+    let command;
+
+    switch (platform) {
+        case 'darwin':
+            command = `open "${url}"`;
+            break;
+        case 'win32':
+            command = `start "" "${url}"`;
+            break;
+        default:
+            command = `xdg-open "${url}"`;
+    }
+
+    return new Promise((resolve, reject) => {
+        exec(command, (error) => {
+            if (error) {
+                reject(new Error(`Failed to open browser: ${error.message}`));
+            } else {
+                resolve();
+            }
+        });
+    });
+}
+
+module.exports = { openBrowser };

--- a/packages/devtools/frigg-cli/index.js
+++ b/packages/devtools/frigg-cli/index.js
@@ -85,6 +85,7 @@ const { uiCommand } = require('./ui-command');
 const { dbSetupCommand } = require('./db-setup-command');
 const { doctorCommand } = require('./doctor-command');
 const { repairCommand } = require('./repair-command');
+const { authCommand } = require('./auth-command');
 
 const program = new Command();
 
@@ -168,6 +169,41 @@ program
     .option('-v, --verbose', 'enable verbose output')
     .action(repairCommand);
 
+// Auth command group for testing API module authentication
+const authProgram = program
+    .command('auth')
+    .description('Test API module authentication');
+
+authProgram
+    .command('test <module>')
+    .description('Test authentication for an API module')
+    .option('--api-key <key>', 'API key for API-Key authentication')
+    .option('--port <port>', 'Callback server port', '3333')
+    .option('--no-browser', 'Do not auto-open browser (print URL instead)')
+    .option('--timeout <seconds>', 'OAuth callback timeout', '300')
+    .option('-v, --verbose', 'Enable verbose output')
+    .action(authCommand.test);
+
+authProgram
+    .command('list')
+    .description('List saved credentials')
+    .option('--json', 'Output as JSON')
+    .action(authCommand.list);
+
+authProgram
+    .command('get <module>')
+    .description('Get credentials for a module')
+    .option('--json', 'Output as JSON')
+    .option('--export', 'Export as environment variables')
+    .action(authCommand.get);
+
+authProgram
+    .command('delete [module]')
+    .description('Delete saved credentials')
+    .option('--all', 'Delete all credentials')
+    .option('-y, --yes', 'Skip confirmation')
+    .action(authCommand.delete);
+
 program.parse(process.argv);
 
-module.exports = { initCommand, installCommand, startCommand, buildCommand, deployCommand, generateIamCommand, uiCommand, dbSetupCommand, doctorCommand, repairCommand };
+module.exports = { initCommand, installCommand, startCommand, buildCommand, deployCommand, generateIamCommand, uiCommand, dbSetupCommand, doctorCommand, repairCommand, authCommand };

--- a/packages/devtools/frigg-cli/index.js
+++ b/packages/devtools/frigg-cli/index.js
@@ -179,7 +179,6 @@ authProgram
     .description('Test authentication for an API module')
     .option('--api-key <key>', 'API key for API-Key authentication')
     .option('--port <port>', 'Callback server port', '3333')
-    .option('--no-browser', 'Do not auto-open browser (print URL instead)')
     .option('--timeout <seconds>', 'OAuth callback timeout', '300')
     .option('-v, --verbose', 'Enable verbose output')
     .action(authCommand.test);


### PR DESCRIPTION
## Summary

Adds `frigg auth` command for testing API module authentication flows without deploying full Frigg infrastructure. This enables API module developers to quickly validate OAuth2 and API-Key authentication during development.

## Demo

🎥 **[Watch the demo](https://www.loom.com/share/0deb8db5808f4ca5abba7d1fbbb6d0fe)**

## Features

- **OAuth2 authentication** with local callback server (auto-opens browser)
- **API-Key authentication** with interactive JSON Schema forms
- **Credential persistence** to `.frigg-credentials.json` (auto-added to `.gitignore`)
- **Comprehensive testing** of all `requiredAuthMethods`:
  - `testAuthRequest` - Verify authentication works
  - `getEntityDetails` - Validate entity consistency post-auth
  - `getCredentialDetails` - Verify credential structure
  - Token refresh (if module supports it)
  - `apiPropertiesToPersist` verification (credential + entity properties)

## Interactive JSON Schema Forms for API-Key Modules

API-Key modules with `getAuthorizationRequirements` render interactive CLI forms:

```
$ frigg auth test .

📝 Quo API Authorization

  (Your Quo API key)
  API Key: ********************************

🔑 API-Key Authentication Flow

Module: quo
✓ API key configured
```

Form features:
- Displays title from `jsonSchema.title`
- Shows help text from `ui:help` before each field
- Masks password fields (`ui:widget: 'password'`) with `*`
- Validates required fields
- Multi-field support (e.g., company ID, public key, private key)

The `--api-key` flag still works and bypasses the form.

## Commands

```bash
# Test OAuth2 authentication
frigg auth test .              # Current directory module
frigg auth test attio          # By module name
frigg auth test . --port 8080  # Custom callback port

# Test API-Key authentication (interactive form)
frigg auth test .              # Renders JSON Schema form if getAuthorizationRequirements exists

# Test API-Key authentication (explicit)
frigg auth test . --api-key sk_xxx

# Manage saved credentials
frigg auth list                # List all saved credentials
frigg auth get attio --json    # Get as JSON for scripts
frigg auth delete attio        # Delete credentials
```

## Test Plan

- [x] OAuth2 flow tested with Attio module
- [x] API-Key flow tested with Quo module (interactive form)
- [x] Credentials saved and retrievable
- [x] All `requiredAuthMethods` validated post-auth
- [x] Summary output shows pass/skip/fail for each test