### PR TITLE
Fix: use correct property for refresh auth

### DIFF
--- a/packages/core/modules/requester/oauth-2.js
+++ b/packages/core/modules/requester/oauth-2.js
@@ -2,37 +2,117 @@ const { Requester } = require('./requester');
 const { get } = require('../../assertions');
 const { ModuleConstants } = require('../ModuleConstants');
 
+/**
+ * OAuth 2.0 Requester - Base class for API modules using OAuth 2.0 authentication.
+ *
+ * Supports multiple OAuth 2.0 grant types:
+ * - `authorization_code` (default): Standard OAuth flow with user consent
+ * - `client_credentials`: Server-to-server authentication without user
+ * - `password`: Resource Owner Password Credentials grant
+ *
+ * @extends Requester
+ *
+ * @example
+ * // Authorization Code flow (default)
+ * const api = new MyApi({ grant_type: 'authorization_code' });
+ * const authUrl = api.getAuthorizationUri();
+ * // After user authorizes...
+ * await api.getTokenFromCode(code);
+ *
+ * @example
+ * // Client Credentials flow
+ * const api = new MyApi({
+ *     grant_type: 'client_credentials',
+ *     client_id: process.env.CLIENT_ID,
+ *     client_secret: process.env.CLIENT_SECRET,
+ *     audience: 'https://api.example.com',
+ * });
+ * await api.getTokenFromClientCredentials();
+ */
 class OAuth2Requester extends Requester {
 
     static requesterType = ModuleConstants.authType.oauth2;
 
+    /**
+     * Creates an OAuth2Requester instance.
+     *
+     * @param {Object} params - Configuration parameters
+     * @param {string} [params.grant_type='authorization_code'] - OAuth grant type:
+     *   'authorization_code', 'client_credentials', or 'password'
+     * @param {string} [params.client_id] - OAuth client ID
+     * @param {string} [params.client_secret] - OAuth client secret
+     * @param {string} [params.redirect_uri] - OAuth redirect URI for authorization code flow
+     * @param {string} [params.scope] - OAuth scopes (space-separated)
+     * @param {string} [params.authorizationUri] - Authorization endpoint URL
+     * @param {string} [params.tokenUri] - Token endpoint URL for exchanging codes/credentials
+     * @param {string} [params.baseURL] - Base URL for API requests
+     * @param {string} [params.access_token] - Existing access token
+     * @param {string} [params.refresh_token] - Existing refresh token
+     * @param {Date} [params.accessTokenExpire] - Access token expiration date
+     * @param {Date} [params.refreshTokenExpire] - Refresh token expiration date
+     * @param {string} [params.audience] - Token audience (for client_credentials)
+     * @param {string} [params.username] - Username (for password grant)
+     * @param {string} [params.password] - Password (for password grant)
+     * @param {string} [params.state] - OAuth state parameter for CSRF protection
+     */
     constructor(params) {
         super(params);
+        /** @type {string} Delegate type for token update notifications */
         this.DLGT_TOKEN_UPDATE = 'TOKEN_UPDATE';
+        /** @type {string} Delegate type for token deauthorization notifications */
         this.DLGT_TOKEN_DEAUTHORIZED = 'TOKEN_DEAUTHORIZED';
 
         this.delegateTypes.push(this.DLGT_TOKEN_UPDATE);
         this.delegateTypes.push(this.DLGT_TOKEN_DEAUTHORIZED);
 
+        /** @type {string} OAuth grant type */
         this.grant_type = get(params, 'grant_type', 'authorization_code');
+        /** @type {string|null} OAuth client ID */
         this.client_id = get(params, 'client_id', null);
+        /** @type {string|null} OAuth client secret */
         this.client_secret = get(params, 'client_secret', null);
+        /** @type {string|null} OAuth redirect URI */
         this.redirect_uri = get(params, 'redirect_uri', null);
+        /** @type {string|null} OAuth scopes */
         this.scope = get(params, 'scope', null);
+        /** @type {string|null} Authorization endpoint URL */
         this.authorizationUri = get(params, 'authorizationUri', null);
+        /** @type {string|null} Token endpoint URL */
+        this.tokenUri = get(params, 'tokenUri', null);
+        /** @type {string|null} Base URL for API requests */
         this.baseURL = get(params, 'baseURL', null);
+        /** @type {string|null} Current access token */
         this.access_token = get(params, 'access_token', null);
+        /** @type {string|null} Current refresh token */
         this.refresh_token = get(params, 'refresh_token', null);
+        /** @type {Date|null} Access token expiration */
         this.accessTokenExpire = get(params, 'accessTokenExpire', null);
+        /** @type {Date|null} Refresh token expiration */
         this.refreshTokenExpire = get(params, 'refreshTokenExpire', null);
+        /** @type {string|null} Token audience */
         this.audience = get(params, 'audience', null);
+        /** @type {string|null} Username for password grant */
         this.username = get(params, 'username', null);
+        /** @type {string|null} Password for password grant */
         this.password = get(params, 'password', null);
+        /** @type {string|null} OAuth state for CSRF protection */
         this.state = get(params, 'state', null);
 
+        /** @type {boolean} Whether this requester supports token refresh */
         this.isRefreshable = true;
     }
 
+    /**
+     * Sets OAuth tokens and calculates expiration times.
+     * Notifies delegates of token update via DLGT_TOKEN_UPDATE.
+     *
+     * @param {Object} params - Token response from OAuth server
+     * @param {string} params.access_token - The access token
+     * @param {string} [params.refresh_token] - The refresh token (if provided)
+     * @param {number} [params.expires_in] - Access token lifetime in seconds
+     * @param {number} [params.x_refresh_token_expires_in] - Refresh token lifetime in seconds
+     * @returns {Promise<void>}
+     */
     async setTokens(params) {
         this.access_token = get(params, 'access_token');
         this.refresh_token = get(params, 'refresh_token', null);
@@ -49,10 +129,20 @@ class OAuth2Requester extends Requester {
         await this.notify(this.DLGT_TOKEN_UPDATE);
     }
 
+    /**
+     * Gets the OAuth authorization URL for initiating the authorization code flow.
+     *
+     * @returns {string|null} The authorization URL
+     */
     getAuthorizationUri() {
         return this.authorizationUri;
     }
 
+    /**
+     * Returns authorization requirements for this OAuth flow.
+     *
+     * @returns {{url: string|null, type: string}} Authorization requirements
+     */
     getAuthorizationRequirements() {
         return {
             url: this.getAuthorizationUri(),
@@ -60,8 +150,13 @@ class OAuth2Requester extends Requester {
         };
     }
 
-    // this.client_id, this.client_secret, this.redirect_uri, and this.tokenUri
-    // will need to be defined in the child class before super(params)
+    /**
+     * Exchanges an authorization code for access and refresh tokens.
+     * Requires client_id, client_secret, redirect_uri, and tokenUri to be set.
+     *
+     * @param {string} code - The authorization code from the OAuth callback
+     * @returns {Promise<Object>} Token response containing access_token, refresh_token, etc.
+     */
     async getTokenFromCode(code) {
         const params = new URLSearchParams();
         params.append('grant_type', 'authorization_code');
@@ -82,9 +177,14 @@ class OAuth2Requester extends Requester {
         return response;
     }
 
-    // REPLACE getTokenFromCode IN THE CHILD IF NEEDED
-    // this.client_id, this.client_secret, this.redirect_uri, and this.tokenUri
-    // will need to be defined in the child class before super(params)
+    /**
+     * Exchanges an authorization code for tokens using Basic Auth header.
+     * Alternative to getTokenFromCode() for OAuth servers requiring Basic Auth.
+     * Override getTokenFromCode() in child class to use this instead.
+     *
+     * @param {string} code - The authorization code from the OAuth callback
+     * @returns {Promise<Object>} Token response containing access_token, refresh_token, etc.
+     */
     async getTokenFromCodeBasicAuthHeader(code) {
         const params = new URLSearchParams();
         params.append('grant_type', 'authorization_code');
@@ -108,8 +208,14 @@ class OAuth2Requester extends Requester {
         return response;
     }
 
-    // this.client_id, this.client_secret, this.redirect_uri, and this.tokenUri
-    // will need to be defined in the child class before super(params)
+    /**
+     * Refreshes the access token using the refresh token.
+     * Used for authorization_code and password grant types.
+     *
+     * @param {Object} refreshTokenObject - Object containing refresh_token
+     * @param {string} refreshTokenObject.refresh_token - The refresh token
+     * @returns {Promise<Object>} New token response
+     */
     async refreshAccessToken(refreshTokenObject) {
         this.access_token = undefined;
         const params = new URLSearchParams();
@@ -131,6 +237,12 @@ class OAuth2Requester extends Requester {
         return response;
     }
 
+    /**
+     * Adds OAuth Bearer token to request headers.
+     *
+     * @param {Object} headers - Headers object to modify
+     * @returns {Promise<Object>} Headers with Authorization added
+     */
     async addAuthHeaders(headers) {
         if (this.access_token) {
             headers.Authorization = `Bearer ${this.access_token}`;
@@ -139,15 +251,29 @@ class OAuth2Requester extends Requester {
         return headers;
     }
 
+    /**
+     * Checks if the requester has valid authentication.
+     *
+     * @returns {boolean} True if authenticated with valid tokens
+     */
     isAuthenticated() {
-        return (
-            this.accessToken !== null &&
-            this.refreshToken !== null &&
+        return !!(
+            this.access_token !== null &&
+            this.refresh_token !== null &&
             this.accessTokenExpire &&
             this.refreshTokenExpire
         );
     }
 
+    /**
+     * Refreshes authentication based on the configured grant type.
+     * - For authorization_code/password: Uses refreshAccessToken() with refresh_token
+     * - For client_credentials: Uses getTokenFromClientCredentials() to get new token
+     *
+     * On failure, notifies delegates via DLGT_INVALID_AUTH.
+     *
+     * @returns {Promise<void>}
+     */
     async refreshAuth() {
         try {
             if (this.grant_type !== 'client_credentials') {
@@ -162,6 +288,12 @@ class OAuth2Requester extends Requester {
         }
     }
 
+    /**
+     * Obtains tokens using the Resource Owner Password Credentials grant.
+     * Requires username and password to be set.
+     *
+     * @returns {Promise<Object|undefined>} Token response or undefined on error
+     */
     async getTokenFromUsernamePassword() {
         try {
             const url = this.tokenUri;
@@ -188,6 +320,13 @@ class OAuth2Requester extends Requester {
         }
     }
 
+    /**
+     * Obtains tokens using the Client Credentials grant.
+     * Used for server-to-server authentication without a user context.
+     * Requires client_id, client_secret, and optionally audience to be set.
+     *
+     * @returns {Promise<Object|undefined>} Token response or undefined on error
+     */
     async getTokenFromClientCredentials() {
         try {
             const url = this.tokenUri;

--- a/packages/core/modules/requester/oauth-2.js
+++ b/packages/core/modules/requester/oauth-2.js
@@ -150,7 +150,7 @@ class OAuth2Requester extends Requester {
 
     async refreshAuth() {
         try {
-            if (this.grantType !== 'client_credentials') {
+            if (this.grant_type !== 'client_credentials') {
                 await this.refreshAccessToken({
                     refresh_token: this.refresh_token,
                 });

--- a/packages/core/modules/requester/oauth-2.test.js
+++ b/packages/core/modules/requester/oauth-2.test.js
@@ -1,0 +1,217 @@
+const { OAuth2Requester } = require('./oauth-2');
+
+describe('OAuth2Requester', () => {
+    describe('constructor', () => {
+        it('should set grant_type to authorization_code by default', () => {
+            const requester = new OAuth2Requester({});
+            expect(requester.grant_type).toBe('authorization_code');
+        });
+
+        it('should set grant_type from params', () => {
+            const requester = new OAuth2Requester({ grant_type: 'client_credentials' });
+            expect(requester.grant_type).toBe('client_credentials');
+        });
+
+        it('should set isRefreshable to true', () => {
+            const requester = new OAuth2Requester({});
+            expect(requester.isRefreshable).toBe(true);
+        });
+    });
+
+    describe('refreshAuth', () => {
+        it('should call refreshAccessToken for authorization_code grant type', async () => {
+            const requester = new OAuth2Requester({
+                grant_type: 'authorization_code',
+                refresh_token: 'test-refresh-token',
+            });
+            requester.refreshAccessToken = jest.fn().mockResolvedValue({
+                access_token: 'new-token',
+            });
+
+            await requester.refreshAuth();
+
+            expect(requester.refreshAccessToken).toHaveBeenCalledWith({
+                refresh_token: 'test-refresh-token',
+            });
+        });
+
+        it('should call refreshAccessToken for password grant type', async () => {
+            const requester = new OAuth2Requester({
+                grant_type: 'password',
+                refresh_token: 'test-refresh-token',
+            });
+            requester.refreshAccessToken = jest.fn().mockResolvedValue({
+                access_token: 'new-token',
+            });
+
+            await requester.refreshAuth();
+
+            expect(requester.refreshAccessToken).toHaveBeenCalledWith({
+                refresh_token: 'test-refresh-token',
+            });
+        });
+
+        it('should call getTokenFromClientCredentials for client_credentials grant type', async () => {
+            const requester = new OAuth2Requester({
+                grant_type: 'client_credentials',
+            });
+            requester.getTokenFromClientCredentials = jest.fn().mockResolvedValue({
+                access_token: 'new-token',
+            });
+            requester.refreshAccessToken = jest.fn();
+
+            await requester.refreshAuth();
+
+            expect(requester.getTokenFromClientCredentials).toHaveBeenCalled();
+            expect(requester.refreshAccessToken).not.toHaveBeenCalled();
+        });
+
+        it('should notify DLGT_INVALID_AUTH on error during refresh', async () => {
+            const requester = new OAuth2Requester({
+                grant_type: 'authorization_code',
+                refresh_token: 'test-refresh-token',
+            });
+            requester.refreshAccessToken = jest.fn().mockRejectedValue(new Error('Token expired'));
+            requester.notify = jest.fn();
+
+            await requester.refreshAuth();
+
+            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+        });
+
+        it('should notify DLGT_INVALID_AUTH on error during client_credentials refresh', async () => {
+            const requester = new OAuth2Requester({
+                grant_type: 'client_credentials',
+            });
+            requester.getTokenFromClientCredentials = jest.fn().mockRejectedValue(new Error('Invalid credentials'));
+            requester.notify = jest.fn();
+
+            await requester.refreshAuth();
+
+            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+        });
+    });
+
+    describe('setTokens', () => {
+        it('should set access_token and refresh_token', async () => {
+            const requester = new OAuth2Requester({});
+            requester.notify = jest.fn();
+
+            await requester.setTokens({
+                access_token: 'test-access-token',
+                refresh_token: 'test-refresh-token',
+                expires_in: 3600,
+            });
+
+            expect(requester.access_token).toBe('test-access-token');
+            expect(requester.refresh_token).toBe('test-refresh-token');
+            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_TOKEN_UPDATE);
+        });
+    });
+
+    describe('addAuthHeaders', () => {
+        it('should add Authorization header when access_token is set', async () => {
+            const requester = new OAuth2Requester({
+                access_token: 'test-token',
+            });
+            const headers = {};
+
+            await requester.addAuthHeaders(headers);
+
+            expect(headers.Authorization).toBe('Bearer test-token');
+        });
+
+        it('should not add Authorization header when access_token is not set', async () => {
+            const requester = new OAuth2Requester({});
+            const headers = {};
+
+            await requester.addAuthHeaders(headers);
+
+            expect(headers.Authorization).toBeUndefined();
+        });
+    });
+
+    describe('getAuthorizationRequirements', () => {
+        it('should return authorization requirements with url and type', () => {
+            const requester = new OAuth2Requester({
+                authorizationUri: 'https://example.com/oauth/authorize',
+            });
+
+            const requirements = requester.getAuthorizationRequirements();
+
+            expect(requirements).toEqual({
+                url: 'https://example.com/oauth/authorize',
+                type: 'oauth2',
+            });
+        });
+    });
+
+    describe('isAuthenticated', () => {
+        it('should return true when all required properties are set', () => {
+            const requester = new OAuth2Requester({
+                access_token: 'test-access-token',
+                refresh_token: 'test-refresh-token',
+                accessTokenExpire: new Date(Date.now() + 3600000),
+                refreshTokenExpire: new Date(Date.now() + 86400000),
+            });
+
+            expect(requester.isAuthenticated()).toBe(true);
+        });
+
+        it('should return false when access_token is null', () => {
+            const requester = new OAuth2Requester({
+                refresh_token: 'test-refresh-token',
+                accessTokenExpire: new Date(Date.now() + 3600000),
+                refreshTokenExpire: new Date(Date.now() + 86400000),
+            });
+
+            expect(requester.isAuthenticated()).toBe(false);
+        });
+
+        it('should return false when refresh_token is null', () => {
+            const requester = new OAuth2Requester({
+                access_token: 'test-access-token',
+                accessTokenExpire: new Date(Date.now() + 3600000),
+                refreshTokenExpire: new Date(Date.now() + 86400000),
+            });
+
+            expect(requester.isAuthenticated()).toBe(false);
+        });
+
+        it('should return false when accessTokenExpire is not set', () => {
+            const requester = new OAuth2Requester({
+                access_token: 'test-access-token',
+                refresh_token: 'test-refresh-token',
+                refreshTokenExpire: new Date(Date.now() + 86400000),
+            });
+
+            expect(requester.isAuthenticated()).toBe(false);
+        });
+
+        it('should return false when refreshTokenExpire is not set', () => {
+            const requester = new OAuth2Requester({
+                access_token: 'test-access-token',
+                refresh_token: 'test-refresh-token',
+                accessTokenExpire: new Date(Date.now() + 3600000),
+            });
+
+            expect(requester.isAuthenticated()).toBe(false);
+        });
+    });
+
+    describe('tokenUri initialization', () => {
+        it('should initialize tokenUri from params', () => {
+            const requester = new OAuth2Requester({
+                tokenUri: 'https://example.com/oauth/token',
+            });
+
+            expect(requester.tokenUri).toBe('https://example.com/oauth/token');
+        });
+
+        it('should default tokenUri to null', () => {
+            const requester = new OAuth2Requester({});
+
+            expect(requester.tokenUri).toBeNull();
+        });
+    });
+});

--- a/packages/devtools/test/mock-api.js
+++ b/packages/devtools/test/mock-api.js
@@ -219,8 +219,7 @@ const mockApi = (Api, classOptionByName = {}) => {
             // TODO read authentication mode from module package
             if (authenticationMode === 'client_credentials') {
                 // TODO make generic (tied to crossbeam api)
-                api.grantType = 'client_credentials';
-                api.refreshAccessToken = api.getTokenFromClientCredentials;
+                api.grant_type = 'client_credentials';
 
                 if (process.env.CROSSBEAM_API_BASE_URL)
                     api.baseUrl = process.env.CROSSBEAM_API_BASE_URL;
@@ -231,7 +230,6 @@ const mockApi = (Api, classOptionByName = {}) => {
 
                 api.client_secret = process.env.CROSSBEAM_TEST_CLIENT_SECRET;
                 api.client_id = process.env.CROSSBEAM_TEST_CLIENT_ID;
-                api.refreshAccessToken = api.getTokenFromClientCredentials;
 
                 this.tokenResponse = await api.getTokenFromClientCredentials();
             } else if (authenticationMode === 'puppet') {


### PR DESCRIPTION
## Summary

  - Fix multiple property naming bugs in `OAuth2Requester` where camelCase was incorrectly used instead of snake_case, causing `client_credentials` flow and `isAuthenticated()` to silently fail
  - Add comprehensive test suite (19 tests) and JSDoc documentation for `OAuth2Requester`
  - Remove workarounds in `mock-api.js` that were compensating for the broken `refreshAuth()` method

  ## Changes

  ### Bug Fixes

  **`oauth-2.js` - `refreshAuth()` method:**
  - Fixed `this.grantType` → `this.grant_type` (property was undefined, causing `client_credentials` grant type to always fail)

  **`oauth-2.js` - `isAuthenticated()` method:**
  - Fixed `this.accessToken` → `this.access_token` (property was undefined)
  - Fixed `this.refreshToken` → `this.refresh_token` (property was undefined)
  - Added `!!` coercion to ensure boolean return value (was returning `null` due to short-circuit evaluation)

  **`oauth-2.js` - Constructor:**
  - Added missing `this.tokenUri` initialization (was used throughout class but never initialized)

  **`mock-api.js`:**
  - Fixed `api.grantType` → `api.grant_type`
  - Removed redundant `api.refreshAccessToken = api.getTokenFromClientCredentials` workarounds (2 occurrences) that were compensating for the broken `refreshAuth()` method

  ### New Test Coverage

  Added `oauth-2.test.js` with 19 tests covering:
  - Constructor initialization (default `grant_type`, custom `grant_type`, `isRefreshable`, `tokenUri`)
  - `refreshAuth()` behavior for all grant types (`authorization_code`, `password`, `client_credentials`)
  - Error handling (notifies `DLGT_INVALID_AUTH` on failure)
  - `setTokens()` token storage and notification
  - `addAuthHeaders()` with/without access token
  - `getAuthorizationRequirements()` return value
  - `isAuthenticated()` for all edge cases

  ### Documentation

  Added comprehensive JSDoc to `OAuth2Requester`:
  - Class-level documentation with usage examples for different grant types
  - All constructor parameters documented with types
  - All instance properties annotated with `@type`
  - All methods documented with `@param` and `@returns`

  ## Test Plan

  - [x] All 19 new `oauth-2.test.js` tests pass
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.524.e81f52e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.524.e81f52e.0
  npm install @friggframework/devtools@2.0.0--canary.524.e81f52e.0
  npm install @friggframework/eslint-config@2.0.0--canary.524.e81f52e.0
  npm install @friggframework/prettier-config@2.0.0--canary.524.e81f52e.0
  npm install @friggframework/schemas@2.0.0--canary.524.e81f52e.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.524.e81f52e.0
  npm install @friggframework/test@2.0.0--canary.524.e81f52e.0
  npm install @friggframework/ui@2.0.0--canary.524.e81f52e.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.524.e81f52e.0
  yarn add @friggframework/devtools@2.0.0--canary.524.e81f52e.0
  yarn add @friggframework/eslint-config@2.0.0--canary.524.e81f52e.0
  yarn add @friggframework/prettier-config@2.0.0--canary.524.e81f52e.0
  yarn add @friggframework/schemas@2.0.0--canary.524.e81f52e.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.524.e81f52e.0
  yarn add @friggframework/test@2.0.0--canary.524.e81f52e.0
  yarn add @friggframework/ui@2.0.0--canary.524.e81f52e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
