### PR TITLE
fix(requester): improve auth refresh handling and tests

### DIFF
--- a/packages/core/modules/requester/oauth-2.js
+++ b/packages/core/modules/requester/oauth-2.js
@@ -239,11 +239,14 @@ class OAuth2Requester extends Requester {
 
     /**
      * Adds OAuth Bearer token to request headers.
+     * Clears any existing Authorization header first to prevent stale tokens
+     * from being reused after failed refresh attempts.
      *
      * @param {Object} headers - Headers object to modify
      * @returns {Promise<Object>} Headers with Authorization added
      */
     async addAuthHeaders(headers) {
+        delete headers.Authorization;
         if (this.access_token) {
             headers.Authorization = `Bearer ${this.access_token}`;
         }
@@ -272,7 +275,7 @@ class OAuth2Requester extends Requester {
      *
      * On failure, notifies delegates via DLGT_INVALID_AUTH.
      *
-     * @returns {Promise<void>}
+     * @returns {Promise<boolean>} True if refresh succeeded, false if failed
      */
     async refreshAuth() {
         try {
@@ -283,8 +286,10 @@ class OAuth2Requester extends Requester {
             } else {
                 await this.getTokenFromClientCredentials();
             }
+            return true;
         } catch {
             await this.notify(this.DLGT_INVALID_AUTH);
+            return false;
         }
     }
 

--- a/packages/core/modules/requester/oauth-2.test.js
+++ b/packages/core/modules/requester/oauth-2.test.js
@@ -28,8 +28,9 @@ describe('OAuth2Requester', () => {
                 access_token: 'new-token',
             });
 
-            await requester.refreshAuth();
+            const result = await requester.refreshAuth();
 
+            expect(result).toBe(true);
             expect(requester.refreshAccessToken).toHaveBeenCalledWith({
                 refresh_token: 'test-refresh-token',
             });
@@ -44,8 +45,9 @@ describe('OAuth2Requester', () => {
                 access_token: 'new-token',
             });
 
-            await requester.refreshAuth();
+            const result = await requester.refreshAuth();
 
+            expect(result).toBe(true);
             expect(requester.refreshAccessToken).toHaveBeenCalledWith({
                 refresh_token: 'test-refresh-token',
             });
@@ -60,13 +62,14 @@ describe('OAuth2Requester', () => {
             });
             requester.refreshAccessToken = jest.fn();
 
-            await requester.refreshAuth();
+            const result = await requester.refreshAuth();
 
+            expect(result).toBe(true);
             expect(requester.getTokenFromClientCredentials).toHaveBeenCalled();
             expect(requester.refreshAccessToken).not.toHaveBeenCalled();
         });
 
-        it('should notify DLGT_INVALID_AUTH on error during refresh', async () => {
+        it('should return false and notify DLGT_INVALID_AUTH on error during refresh', async () => {
             const requester = new OAuth2Requester({
                 grant_type: 'authorization_code',
                 refresh_token: 'test-refresh-token',
@@ -74,20 +77,22 @@ describe('OAuth2Requester', () => {
             requester.refreshAccessToken = jest.fn().mockRejectedValue(new Error('Token expired'));
             requester.notify = jest.fn();
 
-            await requester.refreshAuth();
+            const result = await requester.refreshAuth();
 
+            expect(result).toBe(false);
             expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
         });
 
-        it('should notify DLGT_INVALID_AUTH on error during client_credentials refresh', async () => {
+        it('should return false and notify DLGT_INVALID_AUTH on error during client_credentials refresh', async () => {
             const requester = new OAuth2Requester({
                 grant_type: 'client_credentials',
             });
             requester.getTokenFromClientCredentials = jest.fn().mockRejectedValue(new Error('Invalid credentials'));
             requester.notify = jest.fn();
 
-            await requester.refreshAuth();
+            const result = await requester.refreshAuth();
 
+            expect(result).toBe(false);
             expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
         });
     });
@@ -128,6 +133,26 @@ describe('OAuth2Requester', () => {
             await requester.addAuthHeaders(headers);
 
             expect(headers.Authorization).toBeUndefined();
+        });
+
+        it('should clear existing Authorization header when access_token is not set', async () => {
+            const requester = new OAuth2Requester({});
+            const headers = { Authorization: 'Bearer old-stale-token' };
+
+            await requester.addAuthHeaders(headers);
+
+            expect(headers.Authorization).toBeUndefined();
+        });
+
+        it('should replace existing Authorization header with new token', async () => {
+            const requester = new OAuth2Requester({
+                access_token: 'new-token',
+            });
+            const headers = { Authorization: 'Bearer old-stale-token' };
+
+            await requester.addAuthHeaders(headers);
+
+            expect(headers.Authorization).toBe('Bearer new-token');
         });
     });
 
@@ -212,6 +237,191 @@ describe('OAuth2Requester', () => {
             const requester = new OAuth2Requester({});
 
             expect(requester.tokenUri).toBeNull();
+        });
+    });
+
+    describe('401 retry flow integration', () => {
+        it('should retry with NEW token after successful refresh (not cached old token)', async () => {
+            const capturedHeaders = [];
+            const mockFetch = jest.fn()
+                .mockImplementationOnce(async (url, options) => {
+                    capturedHeaders.push({ ...options.headers });
+                    return {
+                        status: 401,
+                        headers: { get: () => 'application/json' },
+                        json: async () => ({ error: 'Unauthorized' }),
+                    };
+                })
+                .mockImplementationOnce(async (url, options) => {
+                    capturedHeaders.push({ ...options.headers });
+                    return {
+                        status: 200,
+                        headers: { get: () => 'application/json' },
+                        json: async () => ({ success: true }),
+                    };
+                });
+
+            const requester = new OAuth2Requester({
+                access_token: 'old-expired-token',
+                refresh_token: 'valid-refresh-token',
+                grant_type: 'authorization_code',
+                fetch: mockFetch,
+            });
+
+            requester.refreshAccessToken = jest.fn().mockImplementation(async () => {
+                requester.access_token = 'brand-new-token';
+                return { access_token: 'brand-new-token' };
+            });
+
+            const result = await requester._get({ url: 'https://api.example.com/data' });
+
+            expect(result).toEqual({ success: true });
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+            expect(capturedHeaders[0].Authorization).toBe('Bearer old-expired-token');
+            expect(capturedHeaders[1].Authorization).toBe('Bearer brand-new-token');
+        });
+
+        it('should NOT retry when refresh fails', async () => {
+            const mockFetch = jest.fn().mockResolvedValue({
+                status: 401,
+                headers: { get: () => 'application/json' },
+                json: async () => ({ error: 'Unauthorized' }),
+            });
+
+            const requester = new OAuth2Requester({
+                access_token: 'old-expired-token',
+                refresh_token: 'invalid-refresh-token',
+                grant_type: 'authorization_code',
+                fetch: mockFetch,
+            });
+
+            requester.refreshAccessToken = jest.fn().mockRejectedValue(new Error('Refresh token expired'));
+            requester.notify = jest.fn();
+
+            await expect(requester._get({ url: 'https://api.example.com/data' }))
+                .rejects.toThrow();
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+        });
+
+        it('should not retry when refresh throws and access_token becomes undefined', async () => {
+            const capturedHeaders = [];
+            const mockFetch = jest.fn().mockImplementation(async (url, options) => {
+                capturedHeaders.push({ ...options.headers });
+                return {
+                    status: 401,
+                    headers: { get: () => 'application/json' },
+                    json: async () => ({ error: 'Unauthorized' }),
+                };
+            });
+
+            const requester = new OAuth2Requester({
+                access_token: 'old-expired-token',
+                refresh_token: 'invalid-refresh-token',
+                grant_type: 'authorization_code',
+                fetch: mockFetch,
+            });
+
+            requester.refreshAccessToken = jest.fn().mockImplementation(async () => {
+                requester.access_token = undefined;
+                throw new Error('Refresh failed');
+            });
+            requester.notify = jest.fn();
+
+            await expect(requester._get({ url: 'https://api.example.com/data' }))
+                .rejects.toThrow();
+
+            expect(capturedHeaders[0].Authorization).toBe('Bearer old-expired-token');
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not include Authorization header when access_token is undefined', async () => {
+            const mockFetch = jest.fn().mockResolvedValue({
+                status: 200,
+                headers: { get: () => 'application/json' },
+                json: async () => ({ success: true }),
+            });
+
+            const requester = new OAuth2Requester({
+                access_token: undefined,
+                fetch: mockFetch,
+            });
+
+            await requester._get({ url: 'https://api.example.com/data' });
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(mockFetch.mock.calls[0][1].headers.Authorization).toBeUndefined();
+        });
+
+        it('should not retry more than once for consecutive 401s', async () => {
+            const mockFetch = jest.fn().mockResolvedValue({
+                status: 401,
+                headers: { get: () => 'application/json' },
+                json: async () => ({ error: 'Unauthorized' }),
+            });
+
+            const requester = new OAuth2Requester({
+                access_token: 'token',
+                refresh_token: 'refresh',
+                grant_type: 'authorization_code',
+                fetch: mockFetch,
+            });
+
+            requester.refreshAccessToken = jest.fn().mockImplementation(async () => {
+                requester.access_token = 'new-but-still-invalid-token';
+                return { access_token: 'new-but-still-invalid-token' };
+            });
+            requester.notify = jest.fn();
+
+            await expect(requester._get({ url: 'https://api.example.com/data' }))
+                .rejects.toThrow();
+
+            // Should call fetch twice: initial + 1 retry after refresh
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+            // Should notify DLGT_INVALID_AUTH after second 401
+            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+        });
+
+        it('should use getTokenFromClientCredentials for client_credentials grant type on 401', async () => {
+            const capturedHeaders = [];
+            const mockFetch = jest.fn()
+                .mockImplementationOnce(async (url, options) => {
+                    capturedHeaders.push({ ...options.headers });
+                    return {
+                        status: 401,
+                        headers: { get: () => 'application/json' },
+                        json: async () => ({ error: 'Unauthorized' }),
+                    };
+                })
+                .mockImplementationOnce(async (url, options) => {
+                    capturedHeaders.push({ ...options.headers });
+                    return {
+                        status: 200,
+                        headers: { get: () => 'application/json' },
+                        json: async () => ({ data: 'success' }),
+                    };
+                });
+
+            const requester = new OAuth2Requester({
+                access_token: 'old-cc-token',
+                grant_type: 'client_credentials',
+                fetch: mockFetch,
+            });
+
+            requester.getTokenFromClientCredentials = jest.fn().mockImplementation(async () => {
+                requester.access_token = 'new-cc-token';
+                return { access_token: 'new-cc-token' };
+            });
+            requester.refreshAccessToken = jest.fn();
+
+            const result = await requester._get({ url: 'https://api.example.com/data' });
+
+            expect(result).toEqual({ data: 'success' });
+            expect(requester.getTokenFromClientCredentials).toHaveBeenCalled();
+            expect(requester.refreshAccessToken).not.toHaveBeenCalled();
+            expect(capturedHeaders[0].Authorization).toBe('Bearer old-cc-token');
+            expect(capturedHeaders[1].Authorization).toBe('Bearer new-cc-token');
         });
     });
 });

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -75,8 +75,10 @@ class Requester extends Delegate {
                 await this.notify(this.DLGT_INVALID_AUTH);
             } else {
                 this.refreshCount++;
-                await this.refreshAuth();
-                return this._request(url, options, i + 1); // Retries
+                const refreshSucceeded = await this.refreshAuth();
+                if (refreshSucceeded) {
+                    return this._request(url, options, i + 1);
+                }
             }
         }
 
@@ -108,7 +110,6 @@ class Requester extends Delegate {
     }
 
     async _post(options, stringify = true) {
-        console.log('options', options);
         const fetchOptions = {
             method: 'POST',
             credentials: 'include',


### PR DESCRIPTION
## Summary

  - Fix token refresh retry logic to prevent stale Authorization headers from being reused after failed refresh attempts
  - `refreshAuth()` now returns a boolean to indicate success/failure, preventing unnecessary retries
  - Remove debug `console.log` that was leaking sensitive request data in production logs

  ## Changes

  ### Bug Fixes

  **1. Stale Authorization header reuse** (`oauth-2.js:247`)
  - `addAuthHeaders()` now deletes existing Authorization header before setting a new one
  - Prevents cached expired tokens from being sent on retry when `access_token` becomes undefined

  **2. Silent refresh failure causing unnecessary retries** (`oauth-2.js:280-294`, `requester.js:78-81`)
  - `refreshAuth()` now returns `true` on success, `false` on failure
  - `requester.js` checks return value before retrying - no retry if refresh failed
  - Prevents wasted API calls with invalid credentials

  **3. Debug console.log removed** (`requester.js:113`)
  - Removed `console.log('options', options)` that was logging sensitive request data

  ### Tests

  Added comprehensive integration tests for 401 retry flow:
  - Retry uses NEW token after successful refresh (not cached old token)
  - NO retry when refresh fails
  - No retry when refresh throws and access_token becomes undefined  
  - No Authorization header when access_token is undefined
  - No infinite retry loops for consecutive 401s
  - Client credentials grant type uses correct refresh method

  ## Test Plan

  - [x] All 27 OAuth2Requester tests pass
  - [x] Verified header clearing prevents stale token reuse
  - [x] Verified failed refresh stops retry loop
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.525.35c9beb.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.525.35c9beb.0
  npm install @friggframework/devtools@2.0.0--canary.525.35c9beb.0
  npm install @friggframework/eslint-config@2.0.0--canary.525.35c9beb.0
  npm install @friggframework/prettier-config@2.0.0--canary.525.35c9beb.0
  npm install @friggframework/schemas@2.0.0--canary.525.35c9beb.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.525.35c9beb.0
  npm install @friggframework/test@2.0.0--canary.525.35c9beb.0
  npm install @friggframework/ui@2.0.0--canary.525.35c9beb.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.525.35c9beb.0
  yarn add @friggframework/devtools@2.0.0--canary.525.35c9beb.0
  yarn add @friggframework/eslint-config@2.0.0--canary.525.35c9beb.0
  yarn add @friggframework/prettier-config@2.0.0--canary.525.35c9beb.0
  yarn add @friggframework/schemas@2.0.0--canary.525.35c9beb.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.525.35c9beb.0
  yarn add @friggframework/test@2.0.0--canary.525.35c9beb.0
  yarn add @friggframework/ui@2.0.0--canary.525.35c9beb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
