### PR TITLE
fix(devtools): pass refresh_token to refreshAccessToken in auth-tester

### DIFF
--- a/packages/devtools/frigg-cli/auth-command/auth-tester.js
+++ b/packages/devtools/frigg-cli/auth-command/auth-tester.js
@@ -280,7 +280,7 @@ async function testTokenRefresh(api, savedCredentials, options) {
 
     try {
         const oldToken = api.access_token;
-        await api.refreshAccessToken();
+        await api.refreshAccessToken({ refresh_token: api.refresh_token });
         const newToken = api.access_token;
 
         return {


### PR DESCRIPTION
## Summary

- Fix token refresh test in `frigg auth test` command that was failing with "Cannot read properties of undefined (reading 'refresh_token')"
- Pass the required `refresh_token` parameter to `refreshAccessToken()` method

## Changes

### Bug Fix
- **auth-tester.js**: Pass `{ refresh_token: api.refresh_token }` to `api.refreshAccessToken()` call in `testTokenRefresh()` function

### Root Cause
The `OAuth2Requester.refreshAccessToken()` method expects the refresh token to be passed in the params object, but the auth-tester was calling it without arguments. This caused the token refresh test to always fail for OAuth2 modules.

### Before
```javascript
await api.refreshAccessToken();
```

### After
```javascript
await api.refreshAccessToken({ refresh_token: api.refresh_token });
```

## Testing

Verified fix with Clio OAuth2 module:
```
4. Testing token refresh...
   ✓ token refreshed successfully
```