### PR TITLE
feat(core): add data JSON field to Entity model for dynamic property persistence

### DIFF
--- a/packages/core/modules/repositories/module-repository-documentdb.js
+++ b/packages/core/modules/repositories/module-repository-documentdb.js
@@ -101,47 +101,74 @@ class ModuleRepositoryDocumentDB extends ModuleRepositoryInterface {
     }
 
     async createEntity(entityData) {
+        const {
+            user,
+            userId,
+            credential,
+            credentialId,
+            name,
+            moduleName,
+            externalId,
+            ...dynamicData
+        } = entityData;
+
         const document = {
-            userId: toObjectId(entityData.user || entityData.userId),
-            credentialId: toObjectId(entityData.credential || entityData.credentialId) || null,
-            name: entityData.name ?? null,
-            moduleName: entityData.moduleName ?? null,
-            externalId: entityData.externalId ?? null,
-            accountId: entityData.accountId ?? null,
+            userId: toObjectId(userId || user),
+            credentialId: toObjectId(credentialId || credential) || null,
+            name: name ?? null,
+            moduleName: moduleName ?? null,
+            externalId: externalId ?? null,
+            data: dynamicData,
         };
         const insertedId = await insertOne(this.prisma, 'Entity', document);
         const created = await findOne(this.prisma, 'Entity', { _id: insertedId });
-        const credential = await this._fetchCredential(created?.credentialId);
-        return this._mapEntity(created, credential);
+        const credentialObj = await this._fetchCredential(created?.credentialId);
+        return this._mapEntity(created, credentialObj);
     }
 
     async updateEntity(entityId, updates) {
         const objectId = toObjectId(entityId);
         if (!objectId) return null;
+
+        const existing = await findOne(this.prisma, 'Entity', { _id: objectId });
+        if (!existing) return null;
+
+        const {
+            user,
+            userId,
+            credential,
+            credentialId,
+            name,
+            moduleName,
+            externalId,
+            ...dynamicData
+        } = updates;
+
         const updatePayload = {};
-        if (updates.user !== undefined || updates.userId !== undefined) {
-            const userVal = updates.user !== undefined ? updates.user : updates.userId;
-            updatePayload.userId = toObjectId(userVal) || null;
+        if (user !== undefined || userId !== undefined) {
+            updatePayload.userId = toObjectId(userId || user) || null;
         }
-        if (updates.credential !== undefined || updates.credentialId !== undefined) {
-            const credVal = updates.credential !== undefined ? updates.credential : updates.credentialId;
-            updatePayload.credentialId = toObjectId(credVal) || null;
+        if (credential !== undefined || credentialId !== undefined) {
+            updatePayload.credentialId = toObjectId(credentialId || credential) || null;
         }
-        if (updates.name !== undefined) updatePayload.name = updates.name;
-        if (updates.moduleName !== undefined) updatePayload.moduleName = updates.moduleName;
-        if (updates.externalId !== undefined) updatePayload.externalId = updates.externalId;
-        if (updates.accountId !== undefined) updatePayload.accountId = updates.accountId;
-        const result = await updateOne(
+        if (name !== undefined) updatePayload.name = name;
+        if (moduleName !== undefined) updatePayload.moduleName = moduleName;
+        if (externalId !== undefined) updatePayload.externalId = externalId;
+
+        if (Object.keys(dynamicData).length > 0) {
+            updatePayload.data = { ...(existing.data || {}), ...dynamicData };
+        }
+
+        await updateOne(
             this.prisma,
             'Entity',
             { _id: objectId },
             { $set: updatePayload }
         );
-        const modified = result?.nModified ?? result?.n ?? 0;
-        if (modified === 0) return null;
         const updated = await findOne(this.prisma, 'Entity', { _id: objectId });
-        const credential = await this._fetchCredential(updated?.credentialId);
-        return this._mapEntity(updated, credential);
+        if (!updated) return null;
+        const credentialObj = await this._fetchCredential(updated?.credentialId);
+        return this._mapEntity(updated, credentialObj);
     }
 
     async deleteEntity(entityId) {
@@ -291,14 +318,15 @@ class ModuleRepositoryDocumentDB extends ModuleRepositoryInterface {
     }
 
     _mapEntity(doc, credential) {
+        const dynamicData = doc?.data || {};
         return {
             id: fromObjectId(doc?._id),
-            accountId: doc?.accountId ?? null,
             credential,
             userId: fromObjectId(doc?.userId),
             name: doc?.name ?? null,
             externalId: doc?.externalId ?? null,
             moduleName: doc?.moduleName ?? null,
+            ...dynamicData,
         };
     }
 }

--- a/packages/core/modules/repositories/module-repository-mongo.js
+++ b/packages/core/modules/repositories/module-repository-mongo.js
@@ -97,12 +97,12 @@ class ModuleRepositoryMongo extends ModuleRepositoryInterface {
 
         return {
             id: entity.id,
-            accountId: entity.accountId,
             credential,
             userId: entity.userId,
             name: entity.name,
             externalId: entity.externalId,
             moduleName: entity.moduleName,
+            ...(entity.data || {}),
         };
     }
 
@@ -123,12 +123,12 @@ class ModuleRepositoryMongo extends ModuleRepositoryInterface {
 
         return entities.map((e) => ({
             id: e.id,
-            accountId: e.accountId,
             credential: credentialMap.get(e.credentialId) || null,
             userId: e.userId,
             name: e.name,
             externalId: e.externalId,
             moduleName: e.moduleName,
+            ...(e.data || {}),
         }));
     }
 
@@ -149,12 +149,12 @@ class ModuleRepositoryMongo extends ModuleRepositoryInterface {
 
         return entities.map((e) => ({
             id: e.id,
-            accountId: e.accountId,
             credential: credentialMap.get(e.credentialId) || null,
             userId: e.userId,
             name: e.name,
             externalId: e.externalId,
             moduleName: e.moduleName,
+            ...(e.data || {}),
         }));
     }
 
@@ -179,12 +179,12 @@ class ModuleRepositoryMongo extends ModuleRepositoryInterface {
 
         return entities.map((e) => ({
             id: e.id,
-            accountId: e.accountId,
             credential: credentialMap.get(e.credentialId) || null,
             userId: e.userId,
             name: e.name,
             externalId: e.externalId,
             moduleName: e.moduleName,
+            ...(e.data || {}),
         }));
     }
 
@@ -225,12 +225,12 @@ class ModuleRepositoryMongo extends ModuleRepositoryInterface {
 
         return {
             id: entity.id,
-            accountId: entity.accountId,
             credential,
             userId: entity.userId,
             name: entity.name,
             externalId: entity.externalId,
             moduleName: entity.moduleName,
+            ...(entity.data || {}),
         };
     }
 
@@ -242,29 +242,40 @@ class ModuleRepositoryMongo extends ModuleRepositoryInterface {
      * @returns {Promise<Object>} Created entity object with string IDs
      */
     async createEntity(entityData) {
+        const {
+            user,
+            userId,
+            credential,
+            credentialId,
+            name,
+            moduleName,
+            externalId,
+            ...dynamicData
+        } = entityData;
+
         const data = {
-            userId: entityData.user || entityData.userId,
-            credentialId: entityData.credential || entityData.credentialId,
-            name: entityData.name,
-            moduleName: entityData.moduleName,
-            externalId: entityData.externalId,
-            accountId: entityData.accountId,
+            userId: userId || user,
+            credentialId: credentialId || credential,
+            name,
+            moduleName,
+            externalId,
+            data: dynamicData,
         };
 
         const entity = await this.prisma.entity.create({
             data,
         });
 
-        const credential = await this._fetchCredential(entity.credentialId);
+        const credentialObj = await this._fetchCredential(entity.credentialId);
 
         return {
             id: entity.id,
-            accountId: entity.accountId,
-            credential,
+            credential: credentialObj,
             userId: entity.userId,
             name: entity.name,
             externalId: entity.externalId,
             moduleName: entity.moduleName,
+            ...(entity.data || {}),
         };
     }
 
@@ -277,36 +288,56 @@ class ModuleRepositoryMongo extends ModuleRepositoryInterface {
      * @returns {Promise<Object|null>} Updated entity object with string IDs or null if not found
      */
     async updateEntity(entityId, updates) {
-        const data = {};
-        if (updates.user !== undefined) data.userId = updates.user;
-        if (updates.userId !== undefined) data.userId = updates.userId;
-        if (updates.credential !== undefined)
-            data.credentialId = updates.credential;
-        if (updates.credentialId !== undefined)
-            data.credentialId = updates.credentialId;
-        if (updates.name !== undefined) data.name = updates.name;
-        if (updates.moduleName !== undefined)
-            data.moduleName = updates.moduleName;
-        if (updates.externalId !== undefined)
-            data.externalId = updates.externalId;
-        if (updates.accountId !== undefined) data.accountId = updates.accountId;
+        const existing = await this.prisma.entity.findUnique({
+            where: { id: entityId },
+        });
+
+        if (!existing) {
+            return null;
+        }
+
+        const {
+            user,
+            userId,
+            credential,
+            credentialId,
+            name,
+            moduleName,
+            externalId,
+            ...dynamicData
+        } = updates;
+
+        const schemaUpdates = {};
+        if (user !== undefined || userId !== undefined) {
+            schemaUpdates.userId = userId || user;
+        }
+        if (credential !== undefined || credentialId !== undefined) {
+            schemaUpdates.credentialId = credentialId || credential;
+        }
+        if (name !== undefined) schemaUpdates.name = name;
+        if (moduleName !== undefined) schemaUpdates.moduleName = moduleName;
+        if (externalId !== undefined) schemaUpdates.externalId = externalId;
+
+        if (Object.keys(dynamicData).length > 0) {
+            schemaUpdates.data = { ...(existing.data || {}), ...dynamicData };
+        }
 
         try {
             const entity = await this.prisma.entity.update({
                 where: { id: entityId },
-                data,
+                data: schemaUpdates,
             });
 
-            const credential = await this._fetchCredential(entity.credentialId);
+            const credentialObj = await this._fetchCredential(entity.credentialId);
 
             return {
                 id: entity.id,
-                accountId: entity.accountId,
-                credential,
+                credential: credentialObj,
                 userId: entity.userId,
                 name: entity.name,
                 externalId: entity.externalId,
                 moduleName: entity.moduleName,
+                ...(entity.data || {}),
             };
         } catch (error) {
             if (error.code === 'P2025') {

--- a/packages/core/modules/repositories/module-repository-postgres.js
+++ b/packages/core/modules/repositories/module-repository-postgres.js
@@ -131,12 +131,12 @@ class ModuleRepositoryPostgres extends ModuleRepositoryInterface {
 
         return {
             id: entity.id.toString(),
-            accountId: entity.accountId,
             credential,
             userId: entity.userId?.toString(),
             name: entity.name,
             externalId: entity.externalId,
             moduleName: entity.moduleName,
+            ...(entity.data || {}),
         };
     }
 
@@ -159,12 +159,12 @@ class ModuleRepositoryPostgres extends ModuleRepositoryInterface {
 
         return entities.map((e) => ({
             id: e.id.toString(),
-            accountId: e.accountId,
             credential: credentialMap.get(e.credentialId) || null,
             userId: e.userId?.toString(),
             name: e.name,
             externalId: e.externalId,
             moduleName: e.moduleName,
+            ...(e.data || {}),
         }));
     }
 
@@ -187,12 +187,12 @@ class ModuleRepositoryPostgres extends ModuleRepositoryInterface {
 
         return entities.map((e) => ({
             id: e.id.toString(),
-            accountId: e.accountId,
             credential: credentialMap.get(e.credentialId) || null,
             userId: e.userId?.toString(),
             name: e.name,
             externalId: e.externalId,
             moduleName: e.moduleName,
+            ...(e.data || {}),
         }));
     }
 
@@ -219,12 +219,12 @@ class ModuleRepositoryPostgres extends ModuleRepositoryInterface {
 
         return entities.map((e) => ({
             id: e.id.toString(),
-            accountId: e.accountId,
             credential: credentialMap.get(e.credentialId) || null,
             userId: e.userId?.toString(),
             name: e.name,
             externalId: e.externalId,
             moduleName: e.moduleName,
+            ...(e.data || {}),
         }));
     }
 
@@ -266,12 +266,12 @@ class ModuleRepositoryPostgres extends ModuleRepositoryInterface {
 
         return {
             id: entity.id.toString(),
-            accountId: entity.accountId,
             credential,
             userId: entity.userId?.toString(),
             name: entity.name,
             externalId: entity.externalId,
             moduleName: entity.moduleName,
+            ...(entity.data || {}),
         };
     }
 
@@ -283,31 +283,40 @@ class ModuleRepositoryPostgres extends ModuleRepositoryInterface {
      * @returns {Promise<Object>} Created entity object with string IDs
      */
     async createEntity(entityData) {
+        const {
+            user,
+            userId,
+            credential,
+            credentialId,
+            name,
+            moduleName,
+            externalId,
+            ...dynamicData
+        } = entityData;
+
         const data = {
-            userId: this._convertId(entityData.user || entityData.userId),
-            credentialId: this._convertId(
-                entityData.credential || entityData.credentialId
-            ),
-            name: entityData.name,
-            moduleName: entityData.moduleName,
-            externalId: entityData.externalId,
-            accountId: entityData.accountId,
+            userId: this._convertId(userId || user),
+            credentialId: this._convertId(credentialId || credential),
+            name,
+            moduleName,
+            externalId,
+            data: dynamicData,
         };
 
         const entity = await this.prisma.entity.create({
             data,
         });
 
-        const credential = await this._fetchCredential(entity.credentialId);
+        const credentialObj = await this._fetchCredential(entity.credentialId);
 
         return {
             id: entity.id.toString(),
-            accountId: entity.accountId,
-            credential,
+            credential: credentialObj,
             userId: entity.userId?.toString(),
             name: entity.name,
             externalId: entity.externalId,
             moduleName: entity.moduleName,
+            ...(entity.data || {}),
         };
     }
 
@@ -320,40 +329,58 @@ class ModuleRepositoryPostgres extends ModuleRepositoryInterface {
      * @returns {Promise<Object|null>} Updated entity object with string IDs or null if not found
      */
     async updateEntity(entityId, updates) {
-        const data = {};
-        if (updates.user !== undefined)
-            data.userId = this._convertId(updates.user);
-        if (updates.userId !== undefined)
-            data.userId = this._convertId(updates.userId);
-        if (updates.credential !== undefined)
-            data.credentialId = this._convertId(updates.credential);
-        if (updates.credentialId !== undefined)
-            data.credentialId = this._convertId(updates.credentialId);
-        if (updates.name !== undefined) data.name = updates.name;
-        if (updates.moduleName !== undefined)
-            data.moduleName = updates.moduleName;
-        if (updates.externalId !== undefined)
-            data.externalId = updates.externalId;
-        if (updates.accountId !== undefined) data.accountId = updates.accountId;
+        const intId = this._convertId(entityId);
+
+        const existing = await this.prisma.entity.findUnique({
+            where: { id: intId },
+        });
+
+        if (!existing) {
+            return null;
+        }
+
+        const {
+            user,
+            userId,
+            credential,
+            credentialId,
+            name,
+            moduleName,
+            externalId,
+            ...dynamicData
+        } = updates;
+
+        const schemaUpdates = {};
+        if (user !== undefined || userId !== undefined) {
+            schemaUpdates.userId = this._convertId(userId || user);
+        }
+        if (credential !== undefined || credentialId !== undefined) {
+            schemaUpdates.credentialId = this._convertId(credentialId || credential);
+        }
+        if (name !== undefined) schemaUpdates.name = name;
+        if (moduleName !== undefined) schemaUpdates.moduleName = moduleName;
+        if (externalId !== undefined) schemaUpdates.externalId = externalId;
+
+        if (Object.keys(dynamicData).length > 0) {
+            schemaUpdates.data = { ...(existing.data || {}), ...dynamicData };
+        }
 
         try {
-            const intId = this._convertId(entityId);
-
             const entity = await this.prisma.entity.update({
                 where: { id: intId },
-                data,
+                data: schemaUpdates,
             });
 
-            const credential = await this._fetchCredential(entity.credentialId);
+            const credentialObj = await this._fetchCredential(entity.credentialId);
 
             return {
                 id: entity.id.toString(),
-                accountId: entity.accountId,
-                credential,
+                credential: credentialObj,
                 userId: entity.userId?.toString(),
                 name: entity.name,
                 externalId: entity.externalId,
                 moduleName: entity.moduleName,
+                ...(entity.data || {}),
             };
         } catch (error) {
             if (error.code === 'P2025') {

--- a/packages/core/modules/repositories/module-repository.js
+++ b/packages/core/modules/repositories/module-repository.js
@@ -42,12 +42,12 @@ class ModuleRepository extends ModuleRepositoryInterface {
 
         return {
             id: entity.id,
-            accountId: entity.accountId,
             credential: entity.credential,
             userId: entity.userId,
             name: entity.name,
             externalId: entity.externalId,
             moduleName: entity.moduleName,
+            ...(entity.data || {}),
         };
     }
 
@@ -66,12 +66,12 @@ class ModuleRepository extends ModuleRepositoryInterface {
 
         return entities.map((e) => ({
             id: e.id,
-            accountId: e.accountId,
             credential: e.credential,
             userId: e.userId,
             name: e.name,
             externalId: e.externalId,
             moduleName: e.moduleName,
+            ...(e.data || {}),
         }));
     }
 
@@ -90,12 +90,12 @@ class ModuleRepository extends ModuleRepositoryInterface {
 
         return entities.map((e) => ({
             id: e.id,
-            accountId: e.accountId,
             credential: e.credential,
             userId: e.userId,
             name: e.name,
             externalId: e.externalId,
             moduleName: e.moduleName,
+            ...(e.data || {}),
         }));
     }
 
@@ -118,12 +118,12 @@ class ModuleRepository extends ModuleRepositoryInterface {
 
         return entities.map((e) => ({
             id: e.id,
-            accountId: e.accountId,
             credential: e.credential,
             userId: e.userId,
             name: e.name,
             externalId: e.externalId,
             moduleName: e.moduleName,
+            ...(e.data || {}),
         }));
     }
 
@@ -163,12 +163,12 @@ class ModuleRepository extends ModuleRepositoryInterface {
 
         return {
             id: entity.id,
-            accountId: entity.accountId,
             credential: entity.credential,
             userId: entity.userId,
             name: entity.name,
             externalId: entity.externalId,
             moduleName: entity.moduleName,
+            ...(entity.data || {}),
         };
     }
 
@@ -180,14 +180,24 @@ class ModuleRepository extends ModuleRepositoryInterface {
      * @returns {Promise<Object>} Created entity object
      */
     async createEntity(entityData) {
-        // Convert Mongoose-style fields to Prisma
+        const {
+            user,
+            userId,
+            credential,
+            credentialId,
+            name,
+            moduleName,
+            externalId,
+            ...dynamicData
+        } = entityData;
+
         const data = {
-            userId: entityData.user || entityData.userId,
-            credentialId: entityData.credential || entityData.credentialId,
-            name: entityData.name,
-            moduleName: entityData.moduleName,
-            externalId: entityData.externalId,
-            accountId: entityData.accountId,
+            userId: userId || user,
+            credentialId: credentialId || credential,
+            name,
+            moduleName,
+            externalId,
+            data: dynamicData,
         };
 
         const entity = await this.prisma.entity.create({
@@ -197,12 +207,12 @@ class ModuleRepository extends ModuleRepositoryInterface {
 
         return {
             id: entity.id,
-            accountId: entity.accountId,
             credential: entity.credential,
             userId: entity.userId,
             name: entity.name,
             externalId: entity.externalId,
             moduleName: entity.moduleName,
+            ...(entity.data || {}),
         };
     }
 
@@ -215,36 +225,55 @@ class ModuleRepository extends ModuleRepositoryInterface {
      * @returns {Promise<Object|null>} Updated entity object or null if not found
      */
     async updateEntity(entityId, updates) {
-        // Convert Mongoose-style fields to Prisma
-        const data = {};
-        if (updates.user !== undefined) data.userId = updates.user;
-        if (updates.userId !== undefined) data.userId = updates.userId;
-        if (updates.credential !== undefined)
-            data.credentialId = updates.credential;
-        if (updates.credentialId !== undefined)
-            data.credentialId = updates.credentialId;
-        if (updates.name !== undefined) data.name = updates.name;
-        if (updates.moduleName !== undefined)
-            data.moduleName = updates.moduleName;
-        if (updates.externalId !== undefined)
-            data.externalId = updates.externalId;
-        if (updates.accountId !== undefined) data.accountId = updates.accountId;
+        const existing = await this.prisma.entity.findUnique({
+            where: { id: entityId },
+        });
+
+        if (!existing) {
+            return null;
+        }
+
+        const {
+            user,
+            userId,
+            credential,
+            credentialId,
+            name,
+            moduleName,
+            externalId,
+            ...dynamicData
+        } = updates;
+
+        const schemaUpdates = {};
+        if (user !== undefined || userId !== undefined) {
+            schemaUpdates.userId = userId || user;
+        }
+        if (credential !== undefined || credentialId !== undefined) {
+            schemaUpdates.credentialId = credentialId || credential;
+        }
+        if (name !== undefined) schemaUpdates.name = name;
+        if (moduleName !== undefined) schemaUpdates.moduleName = moduleName;
+        if (externalId !== undefined) schemaUpdates.externalId = externalId;
+
+        if (Object.keys(dynamicData).length > 0) {
+            schemaUpdates.data = { ...(existing.data || {}), ...dynamicData };
+        }
 
         try {
             const entity = await this.prisma.entity.update({
                 where: { id: entityId },
-                data,
+                data: schemaUpdates,
                 include: { credential: true },
             });
 
             return {
                 id: entity.id,
-                accountId: entity.accountId,
                 credential: entity.credential,
                 userId: entity.userId,
                 name: entity.name,
                 externalId: entity.externalId,
                 moduleName: entity.moduleName,
+                ...(entity.data || {}),
             };
         } catch (error) {
             if (error.code === 'P2025') {

--- a/packages/core/prisma-mongodb/schema.prisma
+++ b/packages/core/prisma-mongodb/schema.prisma
@@ -119,6 +119,8 @@ model Entity {
   moduleName   String?
   externalId   String?
 
+  data Json @default("{}")
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/packages/core/prisma-postgresql/schema.prisma
+++ b/packages/core/prisma-postgresql/schema.prisma
@@ -116,6 +116,8 @@ model Entity {
   moduleName   String?
   externalId   String?
 
+  data Json @default("{}")
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 


### PR DESCRIPTION
## Summary

- Add `data` JSON field to Entity model for persisting dynamic properties from `apiPropertiesToPersist.entity`
- Follow the same pattern already used for Credential model to ensure consistency
- Fix DocumentDB `updateEntity` to not incorrectly return `null` when zero fields are modified

## Changes

### Schema Updates
- **prisma-mongodb/schema.prisma**: Add `data Json @default("{}")` field to Entity model
- **prisma-postgresql/schema.prisma**: Add `data Json @default("{}")` field to Entity model

### Repository Updates
All module repositories updated with the credential-pattern for dynamic data persistence:

- **module-repository.js**: Base Prisma implementation
- **module-repository-mongo.js**: MongoDB adapter
- **module-repository-postgres.js**: PostgreSQL adapter
- **module-repository-documentdb.js**: DocumentDB adapter

Each repository now:
- Separates schema fields from dynamic data in `createEntity()` using destructuring
- Merges dynamic data with existing data in `updateEntity()`
- Spreads `entity.data` back to top level in all find methods for backward compatibility

### Bug Fix
- **module-repository-documentdb.js**: Fixed `updateEntity()` returning `null` when zero fields are modified, making it consistent with MongoDB/PostgreSQL implementations

## Related Issues

None referenced.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.527.9817fce.1</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.527.9817fce.1
  npm install @friggframework/devtools@2.0.0--canary.527.9817fce.1
  npm install @friggframework/eslint-config@2.0.0--canary.527.9817fce.1
  npm install @friggframework/prettier-config@2.0.0--canary.527.9817fce.1
  npm install @friggframework/schemas@2.0.0--canary.527.9817fce.1
  npm install @friggframework/serverless-plugin@2.0.0--canary.527.9817fce.1
  npm install @friggframework/test@2.0.0--canary.527.9817fce.1
  npm install @friggframework/ui@2.0.0--canary.527.9817fce.1
  # or 
  yarn add @friggframework/core@2.0.0--canary.527.9817fce.1
  yarn add @friggframework/devtools@2.0.0--canary.527.9817fce.1
  yarn add @friggframework/eslint-config@2.0.0--canary.527.9817fce.1
  yarn add @friggframework/prettier-config@2.0.0--canary.527.9817fce.1
  yarn add @friggframework/schemas@2.0.0--canary.527.9817fce.1
  yarn add @friggframework/serverless-plugin@2.0.0--canary.527.9817fce.1
  yarn add @friggframework/test@2.0.0--canary.527.9817fce.1
  yarn add @friggframework/ui@2.0.0--canary.527.9817fce.1
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.68`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/core`
    - feat(core): add data JSON field to Entity model for dynamic property persistence [#527](https://github.com/friggframework/frigg/pull/527) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - fix(devtools): pass refresh_token to refreshAccessToken in auth-tester [#526](https://github.com/friggframework/frigg/pull/526) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
