### PR TITLE
fix(core): add debug logging to OAuth2Requester.refreshAuth()

### DIFF
--- a/packages/core/modules/requester/oauth-2.js
+++ b/packages/core/modules/requester/oauth-2.js
@@ -279,6 +279,15 @@ class OAuth2Requester extends Requester {
      */
     async refreshAuth() {
         try {
+            console.log('[OAuth2Requester.refreshAuth] Starting token refresh', {
+                grant_type: this.grant_type,
+                has_refresh_token: !!this.refresh_token,
+                has_client_id: !!this.client_id,
+                has_client_secret: !!this.client_secret,
+                has_token_uri: !!this.tokenUri,
+                tokenUri: this.tokenUri,
+            });
+
             if (this.grant_type !== 'client_credentials') {
                 await this.refreshAccessToken({
                     refresh_token: this.refresh_token,
@@ -286,8 +295,15 @@ class OAuth2Requester extends Requester {
             } else {
                 await this.getTokenFromClientCredentials();
             }
+            console.log('[OAuth2Requester.refreshAuth] Token refresh succeeded');
             return true;
-        } catch {
+        } catch (error) {
+            console.error('[OAuth2Requester.refreshAuth] Token refresh failed', {
+                error_message: error?.message,
+                error_name: error?.name,
+                response_status: error?.response?.status,
+                response_data: error?.response?.data,
+            });
             await this.notify(this.DLGT_INVALID_AUTH);
             return false;
         }


### PR DESCRIPTION
## Summary
- Added console logging to `refreshAuth()` method in OAuth2Requester
- Logs token refresh attempt details (grant_type, presence of credentials)
- Logs success confirmation when refresh succeeds
- Logs failure details (error message, response status/data) when refresh fails

## Problem
The `refreshAuth()` method was catching errors silently, making it impossible to diagnose token refresh failures in production. When tokens expired and refresh failed, there was no way to see **why** from CloudWatch logs.

## Solution
Added targeted debug logging that captures:
- Whether required OAuth parameters are present (client_id, client_secret, refresh_token, tokenUri)
- The tokenUri being used
- Success/failure status
- Error details on failure

## Test plan
- [ ] Verify logs appear in local development when token refresh is triggered
- [ ] Verify logs capture relevant details without exposing sensitive tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.528.da2ff89.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.528.da2ff89.0
  npm install @friggframework/devtools@2.0.0--canary.528.da2ff89.0
  npm install @friggframework/eslint-config@2.0.0--canary.528.da2ff89.0
  npm install @friggframework/prettier-config@2.0.0--canary.528.da2ff89.0
  npm install @friggframework/schemas@2.0.0--canary.528.da2ff89.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.528.da2ff89.0
  npm install @friggframework/test@2.0.0--canary.528.da2ff89.0
  npm install @friggframework/ui@2.0.0--canary.528.da2ff89.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.528.da2ff89.0
  yarn add @friggframework/devtools@2.0.0--canary.528.da2ff89.0
  yarn add @friggframework/eslint-config@2.0.0--canary.528.da2ff89.0
  yarn add @friggframework/prettier-config@2.0.0--canary.528.da2ff89.0
  yarn add @friggframework/schemas@2.0.0--canary.528.da2ff89.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.528.da2ff89.0
  yarn add @friggframework/test@2.0.0--canary.528.da2ff89.0
  yarn add @friggframework/ui@2.0.0--canary.528.da2ff89.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
