### PR TITLE
fix(oauth2): add defensive logging for refresh_token preservation

### DIFF
--- a/packages/core/handlers/app-handler-helpers.js
+++ b/packages/core/handlers/app-handler-helpers.js
@@ -32,6 +32,7 @@ const createApp = (applyMiddleware) => {
             flushDebugLog(boomError);
             res.status(statusCode).json({ error: 'Internal Server Error' });
         } else {
+            console.warn(`[Frigg] ${req.method} ${req.path} -> ${statusCode}: ${err.message}`);
             res.status(statusCode).json({ error: err.message });
         }
     });

--- a/packages/core/modules/module.js
+++ b/packages/core/modules/module.js
@@ -42,7 +42,9 @@ class Module extends Delegate {
         const apiParams = {
             ...this.definition.env,
             delegate: this,
-            ...(this.credential?.data ? this.apiParamsFromCredential(this.credential.data) : {}), // Handle case when credential is undefined
+            ...(this.credential?.data
+                ? this.apiParamsFromCredential(this.credential.data)
+                : {}), // Handle case when credential is undefined
             ...this.apiParamsFromEntity(this.entity),
         };
         this.api = new this.apiClass(apiParams);
@@ -103,8 +105,9 @@ class Module extends Delegate {
         const apiParams = this.apiParamsFromCredential(this.api);
 
         if (!apiParams.refresh_token && this.api.isRefreshable) {
-            console.warn(`[Module.onTokenUpdate] refresh_token missing from apiParams for module ${this.name}. ` +
-                `Existing DB value will be preserved via merge.`);
+            console.warn(
+                `[Frigg] No refresh_token in apiParams for module ${this.name}.`
+            );
         }
 
         Object.assign(credentialDetails.details, apiParams);

--- a/packages/core/modules/module.js
+++ b/packages/core/modules/module.js
@@ -100,10 +100,14 @@ class Module extends Delegate {
             this.api,
             this.userId
         );
-        Object.assign(
-            credentialDetails.details,
-            this.apiParamsFromCredential(this.api)
-        );
+        const apiParams = this.apiParamsFromCredential(this.api);
+
+        if (!apiParams.refresh_token && this.api.isRefreshable) {
+            console.warn(`[Module.onTokenUpdate] refresh_token missing from apiParams for module ${this.name}. ` +
+                `Existing DB value will be preserved via merge.`);
+        }
+
+        Object.assign(credentialDetails.details, apiParams);
         credentialDetails.details.authIsValid = true;
 
         const persisted = await this.credentialRepository.upsertCredential(

--- a/packages/core/modules/requester/oauth-2.js
+++ b/packages/core/modules/requester/oauth-2.js
@@ -118,6 +118,8 @@ class OAuth2Requester extends Requester {
         const newRefreshToken = get(params, 'refresh_token', null);
         if (newRefreshToken !== null) {
             this.refresh_token = newRefreshToken;
+        } else {
+            console.log('[OAuth2Requester.setTokens] No refresh_token in response, preserving existing');
         }
         const accessExpiresIn = get(params, 'expires_in', null);
         const refreshExpiresIn = get(

--- a/packages/core/modules/requester/oauth-2.js
+++ b/packages/core/modules/requester/oauth-2.js
@@ -30,7 +30,6 @@ const { ModuleConstants } = require('../ModuleConstants');
  * await api.getTokenFromClientCredentials();
  */
 class OAuth2Requester extends Requester {
-
     static requesterType = ModuleConstants.authType.oauth2;
 
     /**
@@ -119,7 +118,15 @@ class OAuth2Requester extends Requester {
         if (newRefreshToken !== null) {
             this.refresh_token = newRefreshToken;
         } else {
-            console.log('[OAuth2Requester.setTokens] No refresh_token in response, preserving existing');
+            if (this.refresh_token) {
+                console.log(
+                    '[Frigg] No refresh_token in response, preserving existing'
+                );
+            } else {
+                console.log(
+                    '[Frigg] Current refresh_token is null and no new refresh_token in response'
+                );
+            }
         }
         const accessExpiresIn = get(params, 'expires_in', null);
         const refreshExpiresIn = get(
@@ -130,7 +137,9 @@ class OAuth2Requester extends Requester {
 
         this.accessTokenExpire = new Date(Date.now() + accessExpiresIn * 1000);
         if (refreshExpiresIn !== null) {
-            this.refreshTokenExpire = new Date(Date.now() + refreshExpiresIn * 1000);
+            this.refreshTokenExpire = new Date(
+                Date.now() + refreshExpiresIn * 1000
+            );
         }
 
         await this.notify(this.DLGT_TOKEN_UPDATE);
@@ -239,6 +248,7 @@ class OAuth2Requester extends Requester {
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
         };
+        console.log('[Frigg] Refreshing access token with options');
         const response = await this._post(options, false);
         await this.setTokens(response);
         return response;
@@ -286,7 +296,7 @@ class OAuth2Requester extends Requester {
      */
     async refreshAuth() {
         try {
-            console.log('[OAuth2Requester.refreshAuth] Starting token refresh', {
+            console.log('[Frigg] Starting token refresh', {
                 grant_type: this.grant_type,
                 has_refresh_token: !!this.refresh_token,
                 has_client_id: !!this.client_id,
@@ -302,10 +312,10 @@ class OAuth2Requester extends Requester {
             } else {
                 await this.getTokenFromClientCredentials();
             }
-            console.log('[OAuth2Requester.refreshAuth] Token refresh succeeded');
+            console.log('[Frigg] Token refresh succeeded');
             return true;
         } catch (error) {
-            console.error('[OAuth2Requester.refreshAuth] Token refresh failed', {
+            console.error('[Frigg] Token refresh failed', {
                 error_message: error?.message,
                 error_name: error?.name,
                 response_status: error?.response?.status,


### PR DESCRIPTION
## Summary
- Adds a `console.log` trace in `OAuth2Requester.setTokens()` when the token refresh response omits `refresh_token`, confirming the existing value is preserved
- Adds a `console.warn` in `Module.onTokenUpdate()` when `refresh_token` is missing from the extracted `apiParams` for refreshable modules, aiding early detection of misconfigured modules or unexpected OAuth provider behavior

## Context
The `setTokens()` fix that preserves `refresh_token` during token refresh (merged in #531) works correctly end-to-end. These logging additions are defensive hardening to make it easier to trace token refresh behavior in production, especially for providers like Zoho and Google that only return `refresh_token` on the initial authorization code exchange.

## Test plan
- [x] Existing `module-on-token-update.test.js` passes (3/3 tests)
- [x] Verified the full token refresh data flow preserves `refresh_token` when response omits it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.537.a16631c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.537.a16631c.0
  npm install @friggframework/devtools@2.0.0--canary.537.a16631c.0
  npm install @friggframework/eslint-config@2.0.0--canary.537.a16631c.0
  npm install @friggframework/prettier-config@2.0.0--canary.537.a16631c.0
  npm install @friggframework/schemas@2.0.0--canary.537.a16631c.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.537.a16631c.0
  npm install @friggframework/test@2.0.0--canary.537.a16631c.0
  npm install @friggframework/ui@2.0.0--canary.537.a16631c.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.537.a16631c.0
  yarn add @friggframework/devtools@2.0.0--canary.537.a16631c.0
  yarn add @friggframework/eslint-config@2.0.0--canary.537.a16631c.0
  yarn add @friggframework/prettier-config@2.0.0--canary.537.a16631c.0
  yarn add @friggframework/schemas@2.0.0--canary.537.a16631c.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.537.a16631c.0
  yarn add @friggframework/test@2.0.0--canary.537.a16631c.0
  yarn add @friggframework/ui@2.0.0--canary.537.a16631c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.71`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - feat(scheduler): add EventBridge Scheduler commands and infrastructure [#531](https://github.com/friggframework/frigg/pull/531) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/core`
    - fix(oauth2): add defensive logging for refresh_token preservation [#537](https://github.com/friggframework/frigg/pull/537) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
