### PR TITLE
fix(logging): enhance debug logging for auth headers

### DIFF
--- a/packages/core/handlers/app-handler-helpers.js
+++ b/packages/core/handlers/app-handler-helpers.js
@@ -19,6 +19,11 @@ const createApp = (applyMiddleware) => {
         })
     );
 
+    app.use((req, res, next) => {
+        console.log(`[Frigg] ${req.method} ${req.path}`);
+        next();
+    });
+
     if (applyMiddleware) applyMiddleware(app);
 
     // Handle sending error response and logging server errors to console
@@ -29,6 +34,8 @@ const createApp = (applyMiddleware) => {
         } = boomError;
 
         if (statusCode >= 500) {
+            console.error(`[Frigg] ${req.method} ${req.path} -> ${statusCode}: ${err.message}`);
+            console.error(err.stack);
             flushDebugLog(boomError);
             res.status(statusCode).json({ error: 'Internal Server Error' });
         } else {

--- a/packages/core/handlers/app-handler-helpers.js
+++ b/packages/core/handlers/app-handler-helpers.js
@@ -32,15 +32,19 @@ const createApp = (applyMiddleware) => {
             flushDebugLog(boomError);
             res.status(statusCode).json({ error: 'Internal Server Error' });
         } else {
-            const authHeaders = Object.entries(req.headers)
-                .filter(([key]) => key.startsWith('x-frigg') || key === 'authorization')
-                .reduce((acc, [key, value]) => {
-                    acc[key] = key === 'x-frigg-api-key' ? `${value.substring(0, 4)}...`
-                        : key === 'authorization' ? `${value.split(' ')[0]} ...`
-                        : value;
+            try {
+                const allHeaders = Object.entries(req.headers).reduce((acc, [key, value]) => {
+                    if (key === 'x-frigg-api-key' || key === 'authorization') {
+                        acc[key] = `${String(value).substring(0, 6)}...(redacted)`;
+                    } else {
+                        acc[key] = value;
+                    }
                     return acc;
                 }, {});
-            console.warn(`[Frigg] ${req.method} ${req.path} -> ${statusCode}: ${err.message}`, JSON.stringify({ authHeaders }));
+                console.warn(`[Frigg] ${req.method} ${req.path} -> ${statusCode}: ${err.message}`, JSON.stringify({ headers: allHeaders }));
+            } catch (logErr) {
+                console.warn(`[Frigg] ${req.method} ${req.path} -> ${statusCode}: ${err.message} (header logging failed: ${logErr.message})`);
+            }
             res.status(statusCode).json({ error: err.message });
         }
     });

--- a/packages/core/handlers/app-handler-helpers.js
+++ b/packages/core/handlers/app-handler-helpers.js
@@ -32,7 +32,15 @@ const createApp = (applyMiddleware) => {
             flushDebugLog(boomError);
             res.status(statusCode).json({ error: 'Internal Server Error' });
         } else {
-            console.warn(`[Frigg] ${req.method} ${req.path} -> ${statusCode}: ${err.message}`);
+            const authHeaders = Object.entries(req.headers)
+                .filter(([key]) => key.startsWith('x-frigg') || key === 'authorization')
+                .reduce((acc, [key, value]) => {
+                    acc[key] = key === 'x-frigg-api-key' ? `${value.substring(0, 4)}...`
+                        : key === 'authorization' ? `${value.split(' ')[0]} ...`
+                        : value;
+                    return acc;
+                }, {});
+            console.warn(`[Frigg] ${req.method} ${req.path} -> ${statusCode}: ${err.message}`, JSON.stringify({ authHeaders }));
             res.status(statusCode).json({ error: err.message });
         }
     });

--- a/packages/core/handlers/app-handler-helpers.js
+++ b/packages/core/handlers/app-handler-helpers.js
@@ -32,19 +32,7 @@ const createApp = (applyMiddleware) => {
             flushDebugLog(boomError);
             res.status(statusCode).json({ error: 'Internal Server Error' });
         } else {
-            try {
-                const allHeaders = Object.entries(req.headers).reduce((acc, [key, value]) => {
-                    if (key === 'x-frigg-api-key' || key === 'authorization') {
-                        acc[key] = `${String(value).substring(0, 6)}...(redacted)`;
-                    } else {
-                        acc[key] = value;
-                    }
-                    return acc;
-                }, {});
-                console.warn(`[Frigg] ${req.method} ${req.path} -> ${statusCode}: ${err.message}`, JSON.stringify({ headers: allHeaders }));
-            } catch (logErr) {
-                console.warn(`[Frigg] ${req.method} ${req.path} -> ${statusCode}: ${err.message} (header logging failed: ${logErr.message})`);
-            }
+            console.warn(`[Frigg] ${req.method} ${req.path} -> ${statusCode}: ${err.message}`);
             res.status(statusCode).json({ error: err.message });
         }
     });

--- a/packages/core/modules/module.js
+++ b/packages/core/modules/module.js
@@ -92,6 +92,7 @@ class Module extends Delegate {
         try {
             if (await this.testAuthRequest(this.api)) validAuth = true;
         } catch (e) {
+            console.error(`[Frigg][testAuth] Failed for module ${this.name}: ${e.message}`);
             flushDebugLog(e);
         }
         return validAuth;

--- a/packages/core/modules/use-cases/process-authorization-callback.js
+++ b/packages/core/modules/use-cases/process-authorization-callback.js
@@ -15,6 +15,8 @@ class ProcessAuthorizationCallback {
     }
 
     async execute(userId, entityType, params) {
+        console.log(`[Frigg][OAuth] Starting callback for entityType=${entityType}, userId=${userId}`);
+
         const moduleDefinition = this.moduleDefinitions.find((def) => {
             return entityType === def.moduleName;
         });
@@ -34,26 +36,37 @@ class ProcessAuthorizationCallback {
             definition: moduleDefinition,
         });
 
+        const authType = module.apiClass.requesterType;
+        console.log(`[Frigg][OAuth] Module created: name=${module.getName()}, authType=${authType}`);
+
         let tokenResponse;
-        if (module.apiClass.requesterType === ModuleConstants.authType.oauth2) {
+        if (authType === ModuleConstants.authType.oauth2) {
+            console.log(`[Frigg][OAuth] Exchanging authorization code for token...`);
             tokenResponse = await moduleDefinition.requiredAuthMethods.getToken(
                 module.api,
                 params
             );
+            console.log(`[Frigg][OAuth] Token exchange successful, keys: ${Object.keys(tokenResponse || {}).join(', ')}`);
         } else {
+            console.log(`[Frigg][OAuth] Setting auth params (non-OAuth2)...`);
             tokenResponse =
                 await moduleDefinition.requiredAuthMethods.setAuthParams(
                     module.api,
                     params
                 );
             await this.onTokenUpdate(module, moduleDefinition, userId);
+            console.log(`[Frigg][OAuth] Auth params set and credential persisted`);
         }
 
+        console.log(`[Frigg][OAuth] Testing auth...`);
         const authRes = await module.testAuth();
         if (!authRes) {
+            console.error(`[Frigg][OAuth] testAuth() returned false — authorization failed`);
             throw new Error('Authorization failed');
         }
+        console.log(`[Frigg][OAuth] Auth test passed`);
 
+        console.log(`[Frigg][OAuth] Fetching entity details...`);
         const entityDetails =
             await moduleDefinition.requiredAuthMethods.getEntityDetails(
                 module.api,
@@ -61,17 +74,20 @@ class ProcessAuthorizationCallback {
                 tokenResponse,
                 userId
             );
+        console.log(`[Frigg][OAuth] Entity details received: identifiers=${JSON.stringify(entityDetails.identifiers)}`);
 
         Object.assign(
             entityDetails.details,
             module.apiParamsFromEntity(module.api)
         );
 
+        console.log(`[Frigg][OAuth] Finding or creating entity...`);
         const persistedEntity = await this.findOrCreateEntity(
             entityDetails,
             entityType,
             module.credential.id
         );
+        console.log(`[Frigg][OAuth] Done — entity_id=${persistedEntity.id}, credential_id=${module.credential.id}`);
 
         return {
             credential_id: module.credential.id,

--- a/packages/core/user/use-cases/authenticate-user.js
+++ b/packages/core/user/use-cases/authenticate-user.js
@@ -2,12 +2,12 @@ const Boom = require('@hapi/boom');
 
 /**
  * Use case for authenticating a user using multiple authentication strategies.
- * 
+ *
  * Supports three authentication modes in priority order:
  * 1. Shared Secret (backend-to-backend with x-frigg-api-key + x-frigg headers)
  * 2. Adopter JWT (custom JWT authentication)
  * 3. Frigg Native Token (bearer token from /user/login)
- * 
+ *
  * x-frigg-appUserId and x-frigg-appOrgId headers are automatically supported
  * for user identification with any auth mode. When present with JWT or Frigg
  * tokens, they are validated to match the authenticated user.
@@ -50,29 +50,18 @@ class AuthenticateUser {
         const authModes = this.userConfig.authModes || { friggToken: true };
         const appUserId = req.headers['x-frigg-appuserid'];
         const appOrgId = req.headers['x-frigg-apporgid'];
-        let user = null;
-
-        // DEBUG: Log ALL request headers to catch misspellings
-        const allHeaders = Object.entries(req.headers).reduce((acc, [key, value]) => {
-            if (key === 'x-frigg-api-key' || key === 'authorization') {
-                acc[key] = `${String(value).substring(0, 6)}...(redacted)`;
-            } else {
-                acc[key] = value;
-            }
-            return acc;
-        }, {});
-        console.log(`[Frigg][DEBUG] ${req.method} ${req.path} - ALL headers:`, JSON.stringify(allHeaders));
-        console.log(`[Frigg][DEBUG] Parsed auth values:`, JSON.stringify({
-            appUserId: appUserId ?? '(undefined)',
-            appOrgId: appOrgId ?? '(undefined)',
-            enabledAuthModes: authModes,
-        }));
+        console.log(
+            '[Frigg] header list:',
+            JSON.stringify(Object.keys(req.headers))
+        );
 
         // Priority 1: Shared Secret (backend-to-backend with API key)
         if (authModes.sharedSecret !== false) {
             const apiKey = req.headers['x-frigg-api-key'];
             if (apiKey) {
-                console.log(`[Frigg][DEBUG] Taking shared secret auth path`);
+                console.log(
+                    '[Frigg] Attempting shared secret authentication with API key'
+                );
                 // Validate the API key (authentication)
                 await this.authenticateWithSharedSecret.execute(apiKey);
                 // Get user from x-frigg headers (authorization)
@@ -81,6 +70,9 @@ class AuthenticateUser {
                     appOrgId
                 );
             }
+            console.log(
+                '[Frigg] No x-frigg-api-key header found, skipping shared secret authentication'
+            );
         }
 
         // Priority 2: Adopter JWT (if enabled)
@@ -88,10 +80,11 @@ class AuthenticateUser {
             authModes.adopterJwt === true &&
             req.headers.authorization?.startsWith('Bearer ')
         ) {
+            console.log('[Frigg] Attempting Adopter JWT authentication');
             const token = req.headers.authorization.split(' ')[1];
             // Detect JWT format (3 parts separated by dots)
             if (token && token.split('.').length === 3) {
-                user = await this.getUserFromAdopterJwt.execute(token);
+                const user = await this.getUserFromAdopterJwt.execute(token);
                 // Validate x-frigg headers match JWT claims if present
                 if (appUserId || appOrgId) {
                     this.validateUserMatch(user, appUserId, appOrgId);
@@ -102,7 +95,8 @@ class AuthenticateUser {
 
         // Priority 3: Frigg native token (default)
         if (authModes.friggToken !== false && req.headers.authorization) {
-            user = await this.getUserFromBearerToken.execute(
+            console.log('[Frigg] Attempting Frigg native token authentication');
+            const user = await this.getUserFromBearerToken.execute(
                 req.headers.authorization
             );
             // Validate x-frigg headers match token user if present
@@ -140,5 +134,3 @@ class AuthenticateUser {
 }
 
 module.exports = { AuthenticateUser };
-
-

--- a/packages/core/user/use-cases/authenticate-user.js
+++ b/packages/core/user/use-cases/authenticate-user.js
@@ -52,20 +52,19 @@ class AuthenticateUser {
         const appOrgId = req.headers['x-frigg-apporgid'];
         let user = null;
 
-        // DEBUG: Log all auth-related headers
-        const xFriggHeaders = Object.entries(req.headers)
-            .filter(([key]) => key.startsWith('x-frigg'))
-            .reduce((acc, [key, value]) => {
-                acc[key] = key === 'x-frigg-api-key' ? `${value.substring(0, 4)}...` : value;
-                return acc;
-            }, {});
-        const hasAuthorization = !!req.headers.authorization;
-        console.log(`[Frigg][DEBUG] ${req.method} ${req.path} - Auth headers:`, JSON.stringify({
-            xFriggHeaders,
-            hasAuthorization,
-            authorizationType: hasAuthorization ? req.headers.authorization.split(' ')[0] : null,
-            appUserId: appUserId || '(missing)',
-            appOrgId: appOrgId || '(missing)',
+        // DEBUG: Log ALL request headers to catch misspellings
+        const allHeaders = Object.entries(req.headers).reduce((acc, [key, value]) => {
+            if (key === 'x-frigg-api-key' || key === 'authorization') {
+                acc[key] = `${String(value).substring(0, 6)}...(redacted)`;
+            } else {
+                acc[key] = value;
+            }
+            return acc;
+        }, {});
+        console.log(`[Frigg][DEBUG] ${req.method} ${req.path} - ALL headers:`, JSON.stringify(allHeaders));
+        console.log(`[Frigg][DEBUG] Parsed auth values:`, JSON.stringify({
+            appUserId: appUserId ?? '(undefined)',
+            appOrgId: appOrgId ?? '(undefined)',
             enabledAuthModes: authModes,
         }));
 

--- a/packages/core/user/use-cases/authenticate-user.js
+++ b/packages/core/user/use-cases/authenticate-user.js
@@ -52,10 +52,28 @@ class AuthenticateUser {
         const appOrgId = req.headers['x-frigg-apporgid'];
         let user = null;
 
+        // DEBUG: Log all auth-related headers
+        const xFriggHeaders = Object.entries(req.headers)
+            .filter(([key]) => key.startsWith('x-frigg'))
+            .reduce((acc, [key, value]) => {
+                acc[key] = key === 'x-frigg-api-key' ? `${value.substring(0, 4)}...` : value;
+                return acc;
+            }, {});
+        const hasAuthorization = !!req.headers.authorization;
+        console.log(`[Frigg][DEBUG] ${req.method} ${req.path} - Auth headers:`, JSON.stringify({
+            xFriggHeaders,
+            hasAuthorization,
+            authorizationType: hasAuthorization ? req.headers.authorization.split(' ')[0] : null,
+            appUserId: appUserId || '(missing)',
+            appOrgId: appOrgId || '(missing)',
+            enabledAuthModes: authModes,
+        }));
+
         // Priority 1: Shared Secret (backend-to-backend with API key)
         if (authModes.sharedSecret !== false) {
             const apiKey = req.headers['x-frigg-api-key'];
             if (apiKey) {
+                console.log(`[Frigg][DEBUG] Taking shared secret auth path`);
                 // Validate the API key (authentication)
                 await this.authenticateWithSharedSecret.execute(apiKey);
                 // Get user from x-frigg headers (authorization)

--- a/packages/core/user/use-cases/get-user-from-x-frigg-headers.js
+++ b/packages/core/user/use-cases/get-user-from-x-frigg-headers.js
@@ -28,6 +28,15 @@ class GetUserFromXFriggHeaders {
      * @throws {Boom} 400 Bad Request if neither ID is provided or if both IDs are provided but belong to different users.
      */
     async execute(appUserId, appOrgId) {
+        console.log(`[Frigg][DEBUG] getUserFromXFriggHeaders called with:`, JSON.stringify({
+            appUserId: appUserId || '(falsy)',
+            appOrgId: appOrgId || '(falsy)',
+            appUserIdType: typeof appUserId,
+            appOrgIdType: typeof appOrgId,
+            individualUserRequired: this.userConfig.individualUserRequired,
+            organizationUserRequired: this.userConfig.organizationUserRequired,
+        }));
+
         // At least one header must be provided
         if (!appUserId && !appOrgId) {
             throw Boom.badRequest(

--- a/packages/core/user/use-cases/get-user-from-x-frigg-headers.js
+++ b/packages/core/user/use-cases/get-user-from-x-frigg-headers.js
@@ -28,15 +28,6 @@ class GetUserFromXFriggHeaders {
      * @throws {Boom} 400 Bad Request if neither ID is provided or if both IDs are provided but belong to different users.
      */
     async execute(appUserId, appOrgId) {
-        console.log(`[Frigg][DEBUG] getUserFromXFriggHeaders called with:`, JSON.stringify({
-            appUserId: appUserId || '(falsy)',
-            appOrgId: appOrgId || '(falsy)',
-            appUserIdType: typeof appUserId,
-            appOrgIdType: typeof appOrgId,
-            individualUserRequired: this.userConfig.individualUserRequired,
-            organizationUserRequired: this.userConfig.organizationUserRequired,
-        }));
-
         // At least one header must be provided
         if (!appUserId && !appOrgId) {
             throw Boom.badRequest(


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.540.d07ab53.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.540.d07ab53.0
  npm install @friggframework/devtools@2.0.0--canary.540.d07ab53.0
  npm install @friggframework/eslint-config@2.0.0--canary.540.d07ab53.0
  npm install @friggframework/prettier-config@2.0.0--canary.540.d07ab53.0
  npm install @friggframework/schemas@2.0.0--canary.540.d07ab53.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.540.d07ab53.0
  npm install @friggframework/test@2.0.0--canary.540.d07ab53.0
  npm install @friggframework/ui@2.0.0--canary.540.d07ab53.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.540.d07ab53.0
  yarn add @friggframework/devtools@2.0.0--canary.540.d07ab53.0
  yarn add @friggframework/eslint-config@2.0.0--canary.540.d07ab53.0
  yarn add @friggframework/prettier-config@2.0.0--canary.540.d07ab53.0
  yarn add @friggframework/schemas@2.0.0--canary.540.d07ab53.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.540.d07ab53.0
  yarn add @friggframework/test@2.0.0--canary.540.d07ab53.0
  yarn add @friggframework/ui@2.0.0--canary.540.d07ab53.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
