### PR TITLE
fix(infra): self-heal VPC subnet-route table association drift

### DIFF
--- a/packages/devtools/infrastructure/domains/networking/vpc-builder.js
+++ b/packages/devtools/infrastructure/domains/networking/vpc-builder.js
@@ -977,7 +977,7 @@ class VpcBuilder extends InfrastructureBuilder {
         }
 
         // Ensure subnet associations
-        this.ensureSubnetAssociations(appDefinition, {}, result);
+        this.ensureSubnetAssociations(appDefinition, discoveredResources, result);
 
         // Create endpoints
         if (endpointsToCreate.includes('s3')) {

--- a/packages/devtools/infrastructure/domains/shared/cloudformation-discovery.js
+++ b/packages/devtools/infrastructure/domains/shared/cloudformation-discovery.js
@@ -562,7 +562,8 @@ class CloudFormationDiscovery {
                             .map(a => a.SubnetId);
                         
                         console.log(`  Route table has ${associatedSubnetIds.length} associated subnets: ${associatedSubnetIds.join(', ')}`);
-                        
+                        discovered.routeTableAssociationCount = associatedSubnetIds.length;
+
                         // Use the associated subnets if available
                         if (associatedSubnetIds.length >= 2) {
                             discovered.privateSubnetId1 = associatedSubnetIds[0];

--- a/packages/devtools/infrastructure/domains/shared/cloudformation-discovery.js
+++ b/packages/devtools/infrastructure/domains/shared/cloudformation-discovery.js
@@ -162,8 +162,8 @@ class CloudFormationDiscovery {
                         // Extract subnet IDs from route table associations
                         const associations = routeTable.Associations || [];
                         const subnetAssociations = associations.filter(a => a.SubnetId);
-                        
-                        
+                        discovered.routeTableAssociationCount = subnetAssociations.length;
+
                         if (subnetAssociations.length >= 1 && !discovered.privateSubnetId1) {
                             discovered.privateSubnetId1 = subnetAssociations[0].SubnetId;
                             console.log(`  ✓ Extracted private subnet 1 from associations: ${subnetAssociations[0].SubnetId}`);
@@ -570,17 +570,25 @@ class CloudFormationDiscovery {
                             discovered.privateSubnetId2 = associatedSubnetIds[1];
                             console.log(`  ✓ Extracted subnets from route table associations: ${discovered.privateSubnetId1}, ${discovered.privateSubnetId2}`);
                         } else if (associatedSubnetIds.length === 1) {
-                            // Only 1 associated subnet, use another subnet from VPC as backup
+                            // Only 1 associated subnet, use another private subnet from VPC as backup
                             discovered.privateSubnetId1 = associatedSubnetIds[0];
-                            discovered.privateSubnetId2 = subnetsResponse.Subnets.find(s => s.SubnetId !== associatedSubnetIds[0])?.SubnetId;
+                            const otherPrivateSubnet = subnetsResponse.Subnets.find(
+                                s => s.SubnetId !== associatedSubnetIds[0] && !s.MapPublicIpOnLaunch
+                            );
+                            discovered.privateSubnetId2 = otherPrivateSubnet?.SubnetId;
                             console.log(`  ✓ Extracted subnets (1 from route table, 1 fallback): ${discovered.privateSubnetId1}, ${discovered.privateSubnetId2}`);
                         } else if (subnetsResponse.Subnets.length >= 2) {
-                            // Edge case: route table Associations array is empty even when queried by ID
-                            // This can happen when associations exist in CloudFormation but AWS API doesn't return them
-                            // Fallback: Use first 2 subnets from VPC (all subnets in same VPC should work)
-                            discovered.privateSubnetId1 = subnetsResponse.Subnets[0].SubnetId;
-                            discovered.privateSubnetId2 = subnetsResponse.Subnets[1].SubnetId;
-                            console.log(`  ✓ Using first 2 subnets from VPC (route table Associations empty): ${discovered.privateSubnetId1}, ${discovered.privateSubnetId2}`);
+                            // Route table has 0 associations — pick private subnets from VPC
+                            const privateSubnets = subnetsResponse.Subnets.filter(s => !s.MapPublicIpOnLaunch);
+                            if (privateSubnets.length >= 2) {
+                                discovered.privateSubnetId1 = privateSubnets[0].SubnetId;
+                                discovered.privateSubnetId2 = privateSubnets[1].SubnetId;
+                                console.log(`  ✓ Using private subnets from VPC (route table Associations empty): ${discovered.privateSubnetId1}, ${discovered.privateSubnetId2}`);
+                            } else {
+                                discovered.privateSubnetId1 = subnetsResponse.Subnets[0].SubnetId;
+                                discovered.privateSubnetId2 = subnetsResponse.Subnets[1].SubnetId;
+                                console.warn('  ⚠️  Could not identify private subnets by MapPublicIpOnLaunch, using first 2 VPC subnets');
+                            }
                         }
                     }
                 }

--- a/packages/devtools/infrastructure/domains/shared/cloudformation-discovery.test.js
+++ b/packages/devtools/infrastructure/domains/shared/cloudformation-discovery.test.js
@@ -936,7 +936,8 @@ describe('CloudFormationDiscovery', () => {
             // - VPC has 3 subnets: 1 public (NAT/IGW) + 2 private (Lambda)
             // - IGW route table has all 3 associated (default route table)
             // - Frigg lambda route table has 0 associations (drift)
-            // Expected: select only the 2 private subnets (MapPublicIpOnLaunch=false)
+            // - Frigg-managed subnet query returns nothing useful
+            // Expected: the fallback path selects only the 2 private subnets (MapPublicIpOnLaunch=false)
             const mockStack = {
                 StackName: 'test-stack',
                 Outputs: []
@@ -949,7 +950,7 @@ describe('CloudFormationDiscovery', () => {
 
             const sendMock = jest.fn();
             sendMock
-                // Path 1: DescribeRouteTablesCommand — route table with 0 subnet associations
+                // External reference extraction: route table with 0 subnet associations
                 .mockResolvedValueOnce({
                     RouteTables: [{
                         RouteTableId: 'rtb-lambda',
@@ -962,7 +963,11 @@ describe('CloudFormationDiscovery', () => {
                 })
                 // DescribeSecurityGroupsCommand — default SG
                 .mockResolvedValueOnce({ SecurityGroups: [{ GroupId: 'sg-default' }] })
-                // Path 2: DescribeSubnetsCommand — 3 subnets (1 public, 2 private)
+                // Frigg-managed subnet query returns nothing, forcing the fallback path to run
+                .mockResolvedValueOnce({
+                    Subnets: []
+                })
+                // Fallback VPC-wide subnet query — 3 subnets (1 public, 2 private)
                 .mockResolvedValueOnce({
                     Subnets: [
                         { SubnetId: 'subnet-public', VpcId: 'vpc-456', MapPublicIpOnLaunch: true, AvailabilityZone: 'us-east-1a' },
@@ -970,7 +975,7 @@ describe('CloudFormationDiscovery', () => {
                         { SubnetId: 'subnet-priv-2', VpcId: 'vpc-456', MapPublicIpOnLaunch: false, AvailabilityZone: 'us-east-1c' },
                     ]
                 })
-                // Path 2: DescribeRouteTablesCommand — lambda route table still has 0 subnet associations
+                // Fallback route table query — lambda route table still has 0 subnet associations
                 .mockResolvedValueOnce({
                     RouteTables: [{
                         RouteTableId: 'rtb-lambda',
@@ -996,6 +1001,21 @@ describe('CloudFormationDiscovery', () => {
 
             // Should record 0 associations for self-heal to detect
             expect(result.routeTableAssociationCount).toBe(0);
+
+            // Verify the test actually exercised the fallback path:
+            // 1) route table query for external refs
+            // 2) default security group query
+            // 3) Frigg-managed subnet query (empty)
+            // 4) all-subnets-in-VPC fallback query
+            // 5) route table query for association extraction
+            expect(sendMock).toHaveBeenCalledTimes(5);
+            expect(sendMock.mock.calls[2][0].input.Filters).toEqual([
+                { Name: 'vpc-id', Values: ['vpc-456'] },
+                { Name: 'tag:ManagedBy', Values: ['Frigg'] },
+            ]);
+            expect(sendMock.mock.calls[3][0].input.Filters).toEqual([
+                { Name: 'vpc-id', Values: ['vpc-456'] },
+            ]);
         });
 
         it('should handle VPC with only 1 associated subnet (use second as fallback)', async () => {

--- a/packages/devtools/infrastructure/domains/shared/cloudformation-discovery.test.js
+++ b/packages/devtools/infrastructure/domains/shared/cloudformation-discovery.test.js
@@ -931,6 +931,73 @@ describe('CloudFormationDiscovery', () => {
             expect(result.privateSubnetId2).toBe('subnet-bbb');
         });
 
+        it('should select only private subnets when route table has 0 associations and VPC has public + private subnets', async () => {
+            // Real-world drift scenario:
+            // - VPC has 3 subnets: 1 public (NAT/IGW) + 2 private (Lambda)
+            // - IGW route table has all 3 associated (default route table)
+            // - Frigg lambda route table has 0 associations (drift)
+            // Expected: select only the 2 private subnets (MapPublicIpOnLaunch=false)
+            const mockStack = {
+                StackName: 'test-stack',
+                Outputs: []
+            };
+
+            const mockResources = [
+                { LogicalResourceId: 'FriggLambdaRouteTable', PhysicalResourceId: 'rtb-lambda', ResourceType: 'AWS::EC2::RouteTable' },
+                { LogicalResourceId: 'FriggVPC', PhysicalResourceId: 'vpc-456', ResourceType: 'AWS::EC2::VPC' }
+            ];
+
+            const sendMock = jest.fn();
+            sendMock
+                // Path 1: DescribeRouteTablesCommand — route table with 0 subnet associations
+                .mockResolvedValueOnce({
+                    RouteTables: [{
+                        RouteTableId: 'rtb-lambda',
+                        VpcId: 'vpc-456',
+                        Associations: [
+                            { RouteTableAssociationId: 'rtbassoc-main', Main: true }
+                        ],
+                        Routes: [{ NatGatewayId: 'nat-789', DestinationCidrBlock: '0.0.0.0/0' }]
+                    }]
+                })
+                // DescribeSecurityGroupsCommand — default SG
+                .mockResolvedValueOnce({ SecurityGroups: [{ GroupId: 'sg-default' }] })
+                // Path 2: DescribeSubnetsCommand — 3 subnets (1 public, 2 private)
+                .mockResolvedValueOnce({
+                    Subnets: [
+                        { SubnetId: 'subnet-public', VpcId: 'vpc-456', MapPublicIpOnLaunch: true, AvailabilityZone: 'us-east-1a' },
+                        { SubnetId: 'subnet-priv-1', VpcId: 'vpc-456', MapPublicIpOnLaunch: false, AvailabilityZone: 'us-east-1b' },
+                        { SubnetId: 'subnet-priv-2', VpcId: 'vpc-456', MapPublicIpOnLaunch: false, AvailabilityZone: 'us-east-1c' },
+                    ]
+                })
+                // Path 2: DescribeRouteTablesCommand — lambda route table still has 0 subnet associations
+                .mockResolvedValueOnce({
+                    RouteTables: [{
+                        RouteTableId: 'rtb-lambda',
+                        Associations: [
+                            { RouteTableAssociationId: 'rtbassoc-main', Main: true }
+                        ]
+                    }]
+                });
+
+            mockProvider.describeStack.mockResolvedValue(mockStack);
+            mockProvider.listStackResources.mockResolvedValue(mockResources);
+            mockProvider.getEC2Client = jest.fn().mockReturnValue({ send: sendMock });
+
+            const result = await cfDiscovery.discoverFromStack('test-stack');
+
+            // Should select ONLY the 2 private subnets
+            expect(result.privateSubnetId1).toBe('subnet-priv-1');
+            expect(result.privateSubnetId2).toBe('subnet-priv-2');
+
+            // Should NOT select the public subnet
+            expect(result.privateSubnetId1).not.toBe('subnet-public');
+            expect(result.privateSubnetId2).not.toBe('subnet-public');
+
+            // Should record 0 associations for self-heal to detect
+            expect(result.routeTableAssociationCount).toBe(0);
+        });
+
         it('should handle VPC with only 1 associated subnet (use second as fallback)', async () => {
             const mockStack = {
                 StackName: 'test-stack',

--- a/packages/devtools/infrastructure/domains/shared/cloudformation-discovery.test.js
+++ b/packages/devtools/infrastructure/domains/shared/cloudformation-discovery.test.js
@@ -1,6 +1,6 @@
 /**
  * Tests for CloudFormation-based Resource Discovery
- * 
+ *
  * Tests discovering resources from existing CloudFormation stacks
  * before falling back to direct AWS API discovery.
  */
@@ -28,7 +28,9 @@ describe('CloudFormationDiscovery', () => {
             const result = await cfDiscovery.discoverFromStack('test-stack');
 
             expect(result).toBeNull();
-            expect(mockProvider.describeStack).toHaveBeenCalledWith('test-stack');
+            expect(mockProvider.describeStack).toHaveBeenCalledWith(
+                'test-stack'
+            );
         });
 
         it('should extract VPC resources from stack outputs', async () => {
@@ -36,7 +38,10 @@ describe('CloudFormationDiscovery', () => {
                 StackName: 'test-stack',
                 Outputs: [
                     { OutputKey: 'VpcId', OutputValue: 'vpc-123' },
-                    { OutputKey: 'PrivateSubnetIds', OutputValue: 'subnet-1,subnet-2' },
+                    {
+                        OutputKey: 'PrivateSubnetIds',
+                        OutputValue: 'subnet-1,subnet-2',
+                    },
                     { OutputKey: 'PublicSubnetId', OutputValue: 'subnet-3' },
                     { OutputKey: 'SecurityGroupId', OutputValue: 'sg-123' },
                 ],
@@ -61,7 +66,10 @@ describe('CloudFormationDiscovery', () => {
             const mockStack = {
                 StackName: 'test-stack',
                 Outputs: [
-                    { OutputKey: 'KMS_KEY_ARN', OutputValue: 'arn:aws:kms:us-east-1:123456789:key/abc' },
+                    {
+                        OutputKey: 'KMS_KEY_ARN',
+                        OutputValue: 'arn:aws:kms:us-east-1:123456789:key/abc',
+                    },
                 ],
             };
 
@@ -80,10 +88,26 @@ describe('CloudFormationDiscovery', () => {
         it('should extract VPC subnets from stack resources', async () => {
             const mockStack = { StackName: 'test-stack', Outputs: [] };
             const mockResources = [
-                { LogicalResourceId: 'FriggPrivateSubnet1', PhysicalResourceId: 'subnet-priv-1', ResourceType: 'AWS::EC2::Subnet' },
-                { LogicalResourceId: 'FriggPrivateSubnet2', PhysicalResourceId: 'subnet-priv-2', ResourceType: 'AWS::EC2::Subnet' },
-                { LogicalResourceId: 'FriggPublicSubnet', PhysicalResourceId: 'subnet-pub-1', ResourceType: 'AWS::EC2::Subnet' },
-                { LogicalResourceId: 'FriggPublicSubnet2', PhysicalResourceId: 'subnet-pub-2', ResourceType: 'AWS::EC2::Subnet' },
+                {
+                    LogicalResourceId: 'FriggPrivateSubnet1',
+                    PhysicalResourceId: 'subnet-priv-1',
+                    ResourceType: 'AWS::EC2::Subnet',
+                },
+                {
+                    LogicalResourceId: 'FriggPrivateSubnet2',
+                    PhysicalResourceId: 'subnet-priv-2',
+                    ResourceType: 'AWS::EC2::Subnet',
+                },
+                {
+                    LogicalResourceId: 'FriggPublicSubnet',
+                    PhysicalResourceId: 'subnet-pub-1',
+                    ResourceType: 'AWS::EC2::Subnet',
+                },
+                {
+                    LogicalResourceId: 'FriggPublicSubnet2',
+                    PhysicalResourceId: 'subnet-pub-2',
+                    ResourceType: 'AWS::EC2::Subnet',
+                },
             ];
 
             mockProvider.describeStack.mockResolvedValue(mockStack);
@@ -100,12 +124,36 @@ describe('CloudFormationDiscovery', () => {
         it('should extract route tables and VPC endpoints from stack resources', async () => {
             const mockStack = { StackName: 'test-stack', Outputs: [] };
             const mockResources = [
-                { LogicalResourceId: 'FriggLambdaRouteTable', PhysicalResourceId: 'rtb-123', ResourceType: 'AWS::EC2::RouteTable' },
-                { LogicalResourceId: 'FriggVPCEndpointSecurityGroup', PhysicalResourceId: 'sg-vpce-123', ResourceType: 'AWS::EC2::SecurityGroup' },
-                { LogicalResourceId: 'FriggS3VPCEndpoint', PhysicalResourceId: 'vpce-s3-123', ResourceType: 'AWS::EC2::VPCEndpoint' },
-                { LogicalResourceId: 'FriggDynamoDBVPCEndpoint', PhysicalResourceId: 'vpce-ddb-123', ResourceType: 'AWS::EC2::VPCEndpoint' },
-                { LogicalResourceId: 'FriggKMSVPCEndpoint', PhysicalResourceId: 'vpce-kms-123', ResourceType: 'AWS::EC2::VPCEndpoint' },
-                { LogicalResourceId: 'FriggSecretsManagerVPCEndpoint', PhysicalResourceId: 'vpce-sm-123', ResourceType: 'AWS::EC2::VPCEndpoint' },
+                {
+                    LogicalResourceId: 'FriggLambdaRouteTable',
+                    PhysicalResourceId: 'rtb-123',
+                    ResourceType: 'AWS::EC2::RouteTable',
+                },
+                {
+                    LogicalResourceId: 'FriggVPCEndpointSecurityGroup',
+                    PhysicalResourceId: 'sg-vpce-123',
+                    ResourceType: 'AWS::EC2::SecurityGroup',
+                },
+                {
+                    LogicalResourceId: 'FriggS3VPCEndpoint',
+                    PhysicalResourceId: 'vpce-s3-123',
+                    ResourceType: 'AWS::EC2::VPCEndpoint',
+                },
+                {
+                    LogicalResourceId: 'FriggDynamoDBVPCEndpoint',
+                    PhysicalResourceId: 'vpce-ddb-123',
+                    ResourceType: 'AWS::EC2::VPCEndpoint',
+                },
+                {
+                    LogicalResourceId: 'FriggKMSVPCEndpoint',
+                    PhysicalResourceId: 'vpce-kms-123',
+                    ResourceType: 'AWS::EC2::VPCEndpoint',
+                },
+                {
+                    LogicalResourceId: 'FriggSecretsManagerVPCEndpoint',
+                    PhysicalResourceId: 'vpce-sm-123',
+                    ResourceType: 'AWS::EC2::VPCEndpoint',
+                },
             ];
 
             mockProvider.describeStack.mockResolvedValue(mockStack);
@@ -224,7 +272,8 @@ describe('CloudFormationDiscovery', () => {
             const mockResources = [
                 {
                     LogicalResourceId: 'DbMigrationQueue',
-                    PhysicalResourceId: 'https://sqs.us-east-1.amazonaws.com/123456789/test-queue',
+                    PhysicalResourceId:
+                        'https://sqs.us-east-1.amazonaws.com/123456789/test-queue',
                     ResourceType: 'AWS::SQS::Queue',
                 },
             ];
@@ -237,7 +286,8 @@ describe('CloudFormationDiscovery', () => {
             expect(result).toEqual({
                 fromCloudFormationStack: true,
                 stackName: 'test-stack',
-                migrationQueueUrl: 'https://sqs.us-east-1.amazonaws.com/123456789/test-queue',
+                migrationQueueUrl:
+                    'https://sqs.us-east-1.amazonaws.com/123456789/test-queue',
                 existingLogicalIds: ['DbMigrationQueue'],
             });
         });
@@ -301,7 +351,10 @@ describe('CloudFormationDiscovery', () => {
                 StackName: 'test-stack',
                 Outputs: [
                     { OutputKey: 'VpcId', OutputValue: 'vpc-123' },
-                    { OutputKey: 'KMS_KEY_ARN', OutputValue: 'arn:aws:kms:us-east-1:123456789:key/abc' },
+                    {
+                        OutputKey: 'KMS_KEY_ARN',
+                        OutputValue: 'arn:aws:kms:us-east-1:123456789:key/abc',
+                    },
                 ],
             };
 
@@ -377,7 +430,9 @@ describe('CloudFormationDiscovery', () => {
 
             mockProvider.describeStack.mockResolvedValue(mockStack);
             mockProvider.listStackResources.mockResolvedValue(mockResources);
-            mockProvider.getEC2Client = jest.fn().mockReturnValue(mockEC2Client);
+            mockProvider.getEC2Client = jest
+                .fn()
+                .mockReturnValue(mockEC2Client);
 
             // Mock security group query for VPC ID
             mockEC2Client.send.mockResolvedValueOnce({
@@ -392,7 +447,10 @@ describe('CloudFormationDiscovery', () => {
                         MapPublicIpOnLaunch: false,
                         Tags: [
                             { Key: 'ManagedBy', Value: 'Frigg' },
-                            { Key: 'aws:cloudformation:logical-id', Value: 'FriggPrivateSubnet1' },
+                            {
+                                Key: 'aws:cloudformation:logical-id',
+                                Value: 'FriggPrivateSubnet1',
+                            },
                         ],
                     },
                     {
@@ -400,7 +458,10 @@ describe('CloudFormationDiscovery', () => {
                         MapPublicIpOnLaunch: false,
                         Tags: [
                             { Key: 'ManagedBy', Value: 'Frigg' },
-                            { Key: 'aws:cloudformation:logical-id', Value: 'FriggPrivateSubnet2' },
+                            {
+                                Key: 'aws:cloudformation:logical-id',
+                                Value: 'FriggPrivateSubnet2',
+                            },
                         ],
                     },
                 ],
@@ -433,7 +494,9 @@ describe('CloudFormationDiscovery', () => {
 
             mockProvider.describeStack.mockResolvedValue(mockStack);
             mockProvider.listStackResources.mockResolvedValue(mockResources);
-            mockProvider.getEC2Client = jest.fn().mockReturnValue(mockEC2Client);
+            mockProvider.getEC2Client = jest
+                .fn()
+                .mockReturnValue(mockEC2Client);
 
             // Mock security group query for VPC ID
             mockEC2Client.send.mockResolvedValueOnce({
@@ -441,7 +504,9 @@ describe('CloudFormationDiscovery', () => {
             });
 
             // Mock subnet query failure
-            mockEC2Client.send.mockRejectedValueOnce(new Error('EC2 API Error'));
+            mockEC2Client.send.mockRejectedValueOnce(
+                new Error('EC2 API Error')
+            );
 
             const result = await cfDiscovery.discoverFromStack('test-stack');
 
@@ -472,9 +537,13 @@ describe('CloudFormationDiscovery', () => {
 
             const result = await cfDiscovery.discoverFromStack('test-stack');
 
-            expect(result.defaultKmsKeyId).toBe('arn:aws:kms:us-east-1:123456789:key/abc-123');
+            expect(result.defaultKmsKeyId).toBe(
+                'arn:aws:kms:us-east-1:123456789:key/abc-123'
+            );
             expect(result.kmsKeyAlias).toBe('alias/test-service-dev-frigg-kms');
-            expect(mockProvider.describeKmsKey).toHaveBeenCalledWith('alias/test-service-dev-frigg-kms');
+            expect(mockProvider.describeKmsKey).toHaveBeenCalledWith(
+                'alias/test-service-dev-frigg-kms'
+            );
         });
 
         it('should query AWS API for KMS alias when serviceName and stage are provided', async () => {
@@ -499,9 +568,13 @@ describe('CloudFormationDiscovery', () => {
 
             const result = await cfDiscovery.discoverFromStack('test-stack');
 
-            expect(result.defaultKmsKeyId).toBe('arn:aws:kms:us-east-1:123456789:key/abc-123');
+            expect(result.defaultKmsKeyId).toBe(
+                'arn:aws:kms:us-east-1:123456789:key/abc-123'
+            );
             expect(result.kmsKeyAlias).toBe('alias/test-service-dev-frigg-kms');
-            expect(mockProvider.describeKmsKey).toHaveBeenCalledWith('alias/test-service-dev-frigg-kms');
+            expect(mockProvider.describeKmsKey).toHaveBeenCalledWith(
+                'alias/test-service-dev-frigg-kms'
+            );
         });
 
         it('should handle KMS alias not found gracefully', async () => {
@@ -515,9 +588,11 @@ describe('CloudFormationDiscovery', () => {
             mockProvider.describeStack.mockResolvedValue(mockStack);
             mockProvider.listStackResources.mockResolvedValue(mockResources);
             mockProvider.region = 'us-east-1';
-            mockProvider.describeKmsKey = jest.fn().mockRejectedValue(
-                new Error('Alias/test-service-dev-frigg-kms is not found')
-            );
+            mockProvider.describeKmsKey = jest
+                .fn()
+                .mockRejectedValue(
+                    new Error('Alias/test-service-dev-frigg-kms is not found')
+                );
 
             cfDiscovery.serviceName = 'test-service';
             cfDiscovery.stage = 'dev';
@@ -537,7 +612,8 @@ describe('CloudFormationDiscovery', () => {
             const mockResources = [
                 {
                     LogicalResourceId: 'FriggKMSKey',
-                    PhysicalResourceId: 'arn:aws:kms:us-east-1:123456789:key/xyz-789',
+                    PhysicalResourceId:
+                        'arn:aws:kms:us-east-1:123456789:key/xyz-789',
                     ResourceType: 'AWS::KMS::Key',
                 },
             ];
@@ -549,7 +625,9 @@ describe('CloudFormationDiscovery', () => {
             const result = await cfDiscovery.discoverFromStack('test-stack');
 
             // Should use the key from stack resources, not query for alias
-            expect(result.defaultKmsKeyId).toBe('arn:aws:kms:us-east-1:123456789:key/xyz-789');
+            expect(result.defaultKmsKeyId).toBe(
+                'arn:aws:kms:us-east-1:123456789:key/xyz-789'
+            );
             expect(mockProvider.describeKmsKey).not.toHaveBeenCalled();
         });
 
@@ -562,7 +640,8 @@ describe('CloudFormationDiscovery', () => {
             const mockResources = [
                 {
                     LogicalResourceId: 'FriggKMSKey',
-                    PhysicalResourceId: 'arn:aws:kms:us-east-1:123456789:key/xyz-789',
+                    PhysicalResourceId:
+                        'arn:aws:kms:us-east-1:123456789:key/xyz-789',
                     ResourceType: 'AWS::KMS::Key',
                 },
                 {
@@ -581,9 +660,13 @@ describe('CloudFormationDiscovery', () => {
 
             const result = await cfDiscovery.discoverFromStack('test-stack');
 
-            expect(result.defaultKmsKeyId).toBe('arn:aws:kms:us-east-1:123456789:key/xyz-789');
+            expect(result.defaultKmsKeyId).toBe(
+                'arn:aws:kms:us-east-1:123456789:key/xyz-789'
+            );
             expect(result.kmsKeyAlias).toBe('alias/test-service-dev-frigg-kms');
-            expect(mockProvider.describeKmsKey).toHaveBeenCalledWith('alias/test-service-dev-frigg-kms');
+            expect(mockProvider.describeKmsKey).toHaveBeenCalledWith(
+                'alias/test-service-dev-frigg-kms'
+            );
         });
     });
 
@@ -638,7 +721,9 @@ describe('CloudFormationDiscovery', () => {
             mockProvider.describeStack.mockResolvedValue(mockStack);
             mockProvider.listStackResources.mockResolvedValue(mockResources);
 
-            const result = await cfDiscovery.discoverFromStack('create-frigg-app-production');
+            const result = await cfDiscovery.discoverFromStack(
+                'create-frigg-app-production'
+            );
 
             // Verify routing infrastructure was discovered
             expect(result.routeTableId).toBe('rtb-0b83aca77ccde20a6');
@@ -723,7 +808,9 @@ describe('CloudFormationDiscovery', () => {
             // Lambda security group should be extracted
             expect(result.lambdaSecurityGroupId).toBe('sg-01002240c6a446202');
             expect(result.defaultSecurityGroupId).toBe('sg-01002240c6a446202');
-            expect(result.existingLogicalIds).toContain('FriggLambdaSecurityGroup');
+            expect(result.existingLogicalIds).toContain(
+                'FriggLambdaSecurityGroup'
+            );
         });
 
         it('should support FriggPrivateRoute naming for NAT routes', async () => {
@@ -774,22 +861,27 @@ describe('CloudFormationDiscovery', () => {
 
             mockProvider.describeStack.mockResolvedValue(mockStack);
             mockProvider.listStackResources.mockResolvedValue(mockResources);
-            
+
             // Mock EC2 DescribeRouteTables to return route table with VPC info
             mockProvider.getEC2Client = jest.fn().mockReturnValue({
                 send: jest.fn().mockResolvedValue({
-                    RouteTables: [{
-                        RouteTableId: 'rtb-real-id',
-                        VpcId: 'vpc-extracted',
-                        Routes: [
-                            { NatGatewayId: 'nat-extracted', DestinationCidrBlock: '0.0.0.0/0' }
-                        ],
-                        Associations: [
-                            { SubnetId: 'subnet-1' },
-                            { SubnetId: 'subnet-2' }
-                        ]
-                    }]
-                })
+                    RouteTables: [
+                        {
+                            RouteTableId: 'rtb-real-id',
+                            VpcId: 'vpc-extracted',
+                            Routes: [
+                                {
+                                    NatGatewayId: 'nat-extracted',
+                                    DestinationCidrBlock: '0.0.0.0/0',
+                                },
+                            ],
+                            Associations: [
+                                { SubnetId: 'subnet-1' },
+                                { SubnetId: 'subnet-2' },
+                            ],
+                        },
+                    ],
+                }),
             });
 
             const result = await cfDiscovery.discoverFromStack('test-stack');
@@ -799,7 +891,7 @@ describe('CloudFormationDiscovery', () => {
             expect(result.existingNatGatewayId).toBe('nat-extracted');
             expect(result.privateSubnetId1).toBe('subnet-1');
             expect(result.privateSubnetId2).toBe('subnet-2');
-            
+
             // Should NOT throw 'stackName is not defined' error
             expect(result).toBeDefined();
         });
@@ -810,30 +902,60 @@ describe('CloudFormationDiscovery', () => {
             // CRITICAL: Frontify production uses OLD naming convention
             const mockStack = {
                 StackName: 'create-frigg-app-production',
-                Outputs: []
+                Outputs: [],
             };
 
             const mockResources = [
-                { LogicalResourceId: 'FriggLambdaRouteTable', PhysicalResourceId: 'rtb-123', ResourceType: 'AWS::EC2::RouteTable' },
-                { LogicalResourceId: 'FriggNATRoute', PhysicalResourceId: 'rtb-123|0.0.0.0/0', ResourceType: 'AWS::EC2::Route' },
-                { LogicalResourceId: 'FriggSubnet1RouteAssociation', PhysicalResourceId: 'rtbassoc-1', ResourceType: 'AWS::EC2::SubnetRouteTableAssociation' },
-                { LogicalResourceId: 'FriggSubnet2RouteAssociation', PhysicalResourceId: 'rtbassoc-2', ResourceType: 'AWS::EC2::SubnetRouteTableAssociation' },
-                { LogicalResourceId: 'VPCEndpointS3', PhysicalResourceId: 'vpce-s3-123', ResourceType: 'AWS::EC2::VPCEndpoint' },
-                { LogicalResourceId: 'VPCEndpointDynamoDB', PhysicalResourceId: 'vpce-ddb-123', ResourceType: 'AWS::EC2::VPCEndpoint' }
+                {
+                    LogicalResourceId: 'FriggLambdaRouteTable',
+                    PhysicalResourceId: 'rtb-123',
+                    ResourceType: 'AWS::EC2::RouteTable',
+                },
+                {
+                    LogicalResourceId: 'FriggNATRoute',
+                    PhysicalResourceId: 'rtb-123|0.0.0.0/0',
+                    ResourceType: 'AWS::EC2::Route',
+                },
+                {
+                    LogicalResourceId: 'FriggSubnet1RouteAssociation',
+                    PhysicalResourceId: 'rtbassoc-1',
+                    ResourceType: 'AWS::EC2::SubnetRouteTableAssociation',
+                },
+                {
+                    LogicalResourceId: 'FriggSubnet2RouteAssociation',
+                    PhysicalResourceId: 'rtbassoc-2',
+                    ResourceType: 'AWS::EC2::SubnetRouteTableAssociation',
+                },
+                {
+                    LogicalResourceId: 'VPCEndpointS3',
+                    PhysicalResourceId: 'vpce-s3-123',
+                    ResourceType: 'AWS::EC2::VPCEndpoint',
+                },
+                {
+                    LogicalResourceId: 'VPCEndpointDynamoDB',
+                    PhysicalResourceId: 'vpce-ddb-123',
+                    ResourceType: 'AWS::EC2::VPCEndpoint',
+                },
             ];
 
             mockProvider.describeStack.mockResolvedValue(mockStack);
             mockProvider.listStackResources.mockResolvedValue(mockResources);
 
-            const result = await cfDiscovery.discoverFromStack('create-frigg-app-production');
+            const result = await cfDiscovery.discoverFromStack(
+                'create-frigg-app-production'
+            );
 
             // CRITICAL: existingLogicalIds MUST contain old VPC endpoint names
             expect(result.existingLogicalIds).toBeDefined();
             expect(result.existingLogicalIds).toContain('FriggNATRoute');
-            expect(result.existingLogicalIds).toContain('FriggSubnet1RouteAssociation');
-            expect(result.existingLogicalIds).toContain('FriggSubnet2RouteAssociation');
-            expect(result.existingLogicalIds).toContain('VPCEndpointS3');  // OLD naming
-            expect(result.existingLogicalIds).toContain('VPCEndpointDynamoDB');  // OLD naming
+            expect(result.existingLogicalIds).toContain(
+                'FriggSubnet1RouteAssociation'
+            );
+            expect(result.existingLogicalIds).toContain(
+                'FriggSubnet2RouteAssociation'
+            );
+            expect(result.existingLogicalIds).toContain('VPCEndpointS3'); // OLD naming
+            expect(result.existingLogicalIds).toContain('VPCEndpointDynamoDB'); // OLD naming
 
             // Should also have the flat discovery properties
             expect(result.routeTableId).toBe('rtb-123');
@@ -845,15 +967,35 @@ describe('CloudFormationDiscovery', () => {
         it('should track NEW VPC endpoint logical IDs (FriggS3VPCEndpoint pattern) for newer stacks', async () => {
             const mockStack = {
                 StackName: 'test-stack',
-                Outputs: []
+                Outputs: [],
             };
 
             const mockResources = [
-                { LogicalResourceId: 'FriggLambdaRouteTable', PhysicalResourceId: 'rtb-456', ResourceType: 'AWS::EC2::RouteTable' },
-                { LogicalResourceId: 'FriggPrivateRoute', PhysicalResourceId: 'rtb-456|0.0.0.0/0', ResourceType: 'AWS::EC2::Route' },
-                { LogicalResourceId: 'FriggS3VPCEndpoint', PhysicalResourceId: 'vpce-s3-456', ResourceType: 'AWS::EC2::VPCEndpoint' },
-                { LogicalResourceId: 'FriggDynamoDBVPCEndpoint', PhysicalResourceId: 'vpce-ddb-456', ResourceType: 'AWS::EC2::VPCEndpoint' },
-                { LogicalResourceId: 'FriggKMSVPCEndpoint', PhysicalResourceId: 'vpce-kms-456', ResourceType: 'AWS::EC2::VPCEndpoint' }
+                {
+                    LogicalResourceId: 'FriggLambdaRouteTable',
+                    PhysicalResourceId: 'rtb-456',
+                    ResourceType: 'AWS::EC2::RouteTable',
+                },
+                {
+                    LogicalResourceId: 'FriggPrivateRoute',
+                    PhysicalResourceId: 'rtb-456|0.0.0.0/0',
+                    ResourceType: 'AWS::EC2::Route',
+                },
+                {
+                    LogicalResourceId: 'FriggS3VPCEndpoint',
+                    PhysicalResourceId: 'vpce-s3-456',
+                    ResourceType: 'AWS::EC2::VPCEndpoint',
+                },
+                {
+                    LogicalResourceId: 'FriggDynamoDBVPCEndpoint',
+                    PhysicalResourceId: 'vpce-ddb-456',
+                    ResourceType: 'AWS::EC2::VPCEndpoint',
+                },
+                {
+                    LogicalResourceId: 'FriggKMSVPCEndpoint',
+                    PhysicalResourceId: 'vpce-kms-456',
+                    ResourceType: 'AWS::EC2::VPCEndpoint',
+                },
             ];
 
             mockProvider.describeStack.mockResolvedValue(mockStack);
@@ -864,9 +1006,11 @@ describe('CloudFormationDiscovery', () => {
             // Should track NEW naming pattern in existingLogicalIds
             expect(result.existingLogicalIds).toContain('FriggPrivateRoute');
             expect(result.existingLogicalIds).toContain('FriggS3VPCEndpoint');
-            expect(result.existingLogicalIds).toContain('FriggDynamoDBVPCEndpoint');
+            expect(result.existingLogicalIds).toContain(
+                'FriggDynamoDBVPCEndpoint'
+            );
             expect(result.existingLogicalIds).toContain('FriggKMSVPCEndpoint');
-            
+
             // Should NOT contain old naming patterns
             expect(result.existingLogicalIds).not.toContain('FriggNATRoute');
             expect(result.existingLogicalIds).not.toContain('VPCEndpointS3');
@@ -879,50 +1023,89 @@ describe('CloudFormationDiscovery', () => {
             // 1. Query ALL subnets in VPC using vpc-id filter (not association filter!)
             // 2. Query route table by ID (RouteTableIds parameter, not Filters!)
             // 3. Extract subnet IDs from route table's Associations array
-            
+
             const mockStack = {
                 StackName: 'test-stack',
-                Outputs: []
+                Outputs: [],
             };
 
             const mockResources = [
-                { LogicalResourceId: 'FriggLambdaRouteTable', PhysicalResourceId: 'rtb-123', ResourceType: 'AWS::EC2::RouteTable' },
-                { LogicalResourceId: 'FriggVPC', PhysicalResourceId: 'vpc-456', ResourceType: 'AWS::EC2::VPC' }
+                {
+                    LogicalResourceId: 'FriggLambdaRouteTable',
+                    PhysicalResourceId: 'rtb-123',
+                    ResourceType: 'AWS::EC2::RouteTable',
+                },
+                {
+                    LogicalResourceId: 'FriggVPC',
+                    PhysicalResourceId: 'vpc-456',
+                    ResourceType: 'AWS::EC2::VPC',
+                },
             ];
 
             const sendMock = jest.fn();
             sendMock
                 .mockResolvedValueOnce({
-                    RouteTables: [{
-                        RouteTableId: 'rtb-123',
-                        VpcId: 'vpc-456',
-                        Associations: [],
-                        Routes: [{ NatGatewayId: 'nat-789', DestinationCidrBlock: '0.0.0.0/0' }]
-                    }]
+                    RouteTables: [
+                        {
+                            RouteTableId: 'rtb-123',
+                            VpcId: 'vpc-456',
+                            Associations: [],
+                            Routes: [
+                                {
+                                    NatGatewayId: 'nat-789',
+                                    DestinationCidrBlock: '0.0.0.0/0',
+                                },
+                            ],
+                        },
+                    ],
                 })
-                .mockResolvedValueOnce({ SecurityGroups: [{ GroupId: 'sg-default' }] })
+                .mockResolvedValueOnce({
+                    SecurityGroups: [{ GroupId: 'sg-default' }],
+                })
                 .mockResolvedValueOnce({
                     Subnets: [
-                        { SubnetId: 'subnet-aaa', VpcId: 'vpc-456', AvailabilityZone: 'us-east-1a' },
-                        { SubnetId: 'subnet-bbb', VpcId: 'vpc-456', AvailabilityZone: 'us-east-1b' },
-                        { SubnetId: 'subnet-ccc', VpcId: 'vpc-456', AvailabilityZone: 'us-east-1c' }
-                    ]
+                        {
+                            SubnetId: 'subnet-aaa',
+                            VpcId: 'vpc-456',
+                            AvailabilityZone: 'us-east-1a',
+                        },
+                        {
+                            SubnetId: 'subnet-bbb',
+                            VpcId: 'vpc-456',
+                            AvailabilityZone: 'us-east-1b',
+                        },
+                        {
+                            SubnetId: 'subnet-ccc',
+                            VpcId: 'vpc-456',
+                            AvailabilityZone: 'us-east-1c',
+                        },
+                    ],
                 })
                 .mockResolvedValueOnce({
-                    RouteTables: [{
-                        RouteTableId: 'rtb-123',
-                        Associations: [
-                            { RouteTableAssociationId: 'rtbassoc-111', SubnetId: 'subnet-aaa' },
-                            { RouteTableAssociationId: 'rtbassoc-222', SubnetId: 'subnet-bbb' }
-                        ]
-                    }]
+                    RouteTables: [
+                        {
+                            RouteTableId: 'rtb-123',
+                            Associations: [
+                                {
+                                    RouteTableAssociationId: 'rtbassoc-111',
+                                    SubnetId: 'subnet-aaa',
+                                },
+                                {
+                                    RouteTableAssociationId: 'rtbassoc-222',
+                                    SubnetId: 'subnet-bbb',
+                                },
+                            ],
+                        },
+                    ],
                 });
-            
+
             const mockEC2Client = { send: sendMock };
 
             mockProvider.describeStack.mockResolvedValue(mockStack);
             mockProvider.listStackResources.mockResolvedValue(mockResources);
-            mockProvider.getEC2Client = jest.fn().mockReturnValue(mockEC2Client);
+            mockProvider.getEC2Client = jest
+                .fn()
+                .mockReturnValue(mockEC2Client);
 
             const result = await cfDiscovery.discoverFromStack('test-stack');
 
@@ -940,54 +1123,96 @@ describe('CloudFormationDiscovery', () => {
             // Expected: the fallback path selects only the 2 private subnets (MapPublicIpOnLaunch=false)
             const mockStack = {
                 StackName: 'test-stack',
-                Outputs: []
+                Outputs: [],
             };
 
             const mockResources = [
-                { LogicalResourceId: 'FriggLambdaRouteTable', PhysicalResourceId: 'rtb-lambda', ResourceType: 'AWS::EC2::RouteTable' },
-                { LogicalResourceId: 'FriggVPC', PhysicalResourceId: 'vpc-456', ResourceType: 'AWS::EC2::VPC' }
+                {
+                    LogicalResourceId: 'FriggLambdaRouteTable',
+                    PhysicalResourceId: 'rtb-lambda',
+                    ResourceType: 'AWS::EC2::RouteTable',
+                },
+                {
+                    LogicalResourceId: 'FriggVPC',
+                    PhysicalResourceId: 'vpc-456',
+                    ResourceType: 'AWS::EC2::VPC',
+                },
             ];
 
             const sendMock = jest.fn();
             sendMock
                 // External reference extraction: route table with 0 subnet associations
                 .mockResolvedValueOnce({
-                    RouteTables: [{
-                        RouteTableId: 'rtb-lambda',
-                        VpcId: 'vpc-456',
-                        Associations: [
-                            { RouteTableAssociationId: 'rtbassoc-main', Main: true }
-                        ],
-                        Routes: [{ NatGatewayId: 'nat-789', DestinationCidrBlock: '0.0.0.0/0' }]
-                    }]
+                    RouteTables: [
+                        {
+                            RouteTableId: 'rtb-lambda',
+                            VpcId: 'vpc-456',
+                            Associations: [
+                                {
+                                    RouteTableAssociationId: 'rtbassoc-main',
+                                    Main: true,
+                                },
+                            ],
+                            Routes: [
+                                {
+                                    NatGatewayId: 'nat-789',
+                                    DestinationCidrBlock: '0.0.0.0/0',
+                                },
+                            ],
+                        },
+                    ],
                 })
                 // DescribeSecurityGroupsCommand — default SG
-                .mockResolvedValueOnce({ SecurityGroups: [{ GroupId: 'sg-default' }] })
+                .mockResolvedValueOnce({
+                    SecurityGroups: [{ GroupId: 'sg-default' }],
+                })
                 // Frigg-managed subnet query returns nothing, forcing the fallback path to run
                 .mockResolvedValueOnce({
-                    Subnets: []
+                    Subnets: [],
                 })
                 // Fallback VPC-wide subnet query — 3 subnets (1 public, 2 private)
                 .mockResolvedValueOnce({
                     Subnets: [
-                        { SubnetId: 'subnet-public', VpcId: 'vpc-456', MapPublicIpOnLaunch: true, AvailabilityZone: 'us-east-1a' },
-                        { SubnetId: 'subnet-priv-1', VpcId: 'vpc-456', MapPublicIpOnLaunch: false, AvailabilityZone: 'us-east-1b' },
-                        { SubnetId: 'subnet-priv-2', VpcId: 'vpc-456', MapPublicIpOnLaunch: false, AvailabilityZone: 'us-east-1c' },
-                    ]
+                        {
+                            SubnetId: 'subnet-public',
+                            VpcId: 'vpc-456',
+                            MapPublicIpOnLaunch: true,
+                            AvailabilityZone: 'us-east-1a',
+                        },
+                        {
+                            SubnetId: 'subnet-priv-1',
+                            VpcId: 'vpc-456',
+                            MapPublicIpOnLaunch: false,
+                            AvailabilityZone: 'us-east-1b',
+                        },
+                        {
+                            SubnetId: 'subnet-priv-2',
+                            VpcId: 'vpc-456',
+                            MapPublicIpOnLaunch: false,
+                            AvailabilityZone: 'us-east-1c',
+                        },
+                    ],
                 })
                 // Fallback route table query — lambda route table still has 0 subnet associations
                 .mockResolvedValueOnce({
-                    RouteTables: [{
-                        RouteTableId: 'rtb-lambda',
-                        Associations: [
-                            { RouteTableAssociationId: 'rtbassoc-main', Main: true }
-                        ]
-                    }]
+                    RouteTables: [
+                        {
+                            RouteTableId: 'rtb-lambda',
+                            Associations: [
+                                {
+                                    RouteTableAssociationId: 'rtbassoc-main',
+                                    Main: true,
+                                },
+                            ],
+                        },
+                    ],
                 });
 
             mockProvider.describeStack.mockResolvedValue(mockStack);
             mockProvider.listStackResources.mockResolvedValue(mockResources);
-            mockProvider.getEC2Client = jest.fn().mockReturnValue({ send: sendMock });
+            mockProvider.getEC2Client = jest
+                .fn()
+                .mockReturnValue({ send: sendMock });
 
             const result = await cfDiscovery.discoverFromStack('test-stack');
 
@@ -1021,45 +1246,69 @@ describe('CloudFormationDiscovery', () => {
         it('should handle VPC with only 1 associated subnet (use second as fallback)', async () => {
             const mockStack = {
                 StackName: 'test-stack',
-                Outputs: []
+                Outputs: [],
             };
 
             const mockResources = [
-                { LogicalResourceId: 'FriggLambdaRouteTable', PhysicalResourceId: 'rtb-123', ResourceType: 'AWS::EC2::RouteTable' },
-                { LogicalResourceId: 'FriggVPC', PhysicalResourceId: 'vpc-456', ResourceType: 'AWS::EC2::VPC' }
+                {
+                    LogicalResourceId: 'FriggLambdaRouteTable',
+                    PhysicalResourceId: 'rtb-123',
+                    ResourceType: 'AWS::EC2::RouteTable',
+                },
+                {
+                    LogicalResourceId: 'FriggVPC',
+                    PhysicalResourceId: 'vpc-456',
+                    ResourceType: 'AWS::EC2::VPC',
+                },
             ];
 
             const sendMock = jest.fn();
             sendMock
                 .mockResolvedValueOnce({
-                    RouteTables: [{
-                        RouteTableId: 'rtb-123',
-                        VpcId: 'vpc-456',
-                        Associations: [],
-                        Routes: [{ NatGatewayId: 'nat-789', DestinationCidrBlock: '0.0.0.0/0' }]
-                    }]
+                    RouteTables: [
+                        {
+                            RouteTableId: 'rtb-123',
+                            VpcId: 'vpc-456',
+                            Associations: [],
+                            Routes: [
+                                {
+                                    NatGatewayId: 'nat-789',
+                                    DestinationCidrBlock: '0.0.0.0/0',
+                                },
+                            ],
+                        },
+                    ],
                 })
-                .mockResolvedValueOnce({ SecurityGroups: [{ GroupId: 'sg-default' }] })
+                .mockResolvedValueOnce({
+                    SecurityGroups: [{ GroupId: 'sg-default' }],
+                })
                 .mockResolvedValueOnce({
                     Subnets: [
                         { SubnetId: 'subnet-aaa', VpcId: 'vpc-456' },
-                        { SubnetId: 'subnet-bbb', VpcId: 'vpc-456' }
-                    ]
+                        { SubnetId: 'subnet-bbb', VpcId: 'vpc-456' },
+                    ],
                 })
                 .mockResolvedValueOnce({
-                    RouteTables: [{
-                        RouteTableId: 'rtb-123',
-                        Associations: [
-                            { RouteTableAssociationId: 'rtbassoc-111', SubnetId: 'subnet-aaa' }
-                        ]
-                    }]
+                    RouteTables: [
+                        {
+                            RouteTableId: 'rtb-123',
+                            Associations: [
+                                {
+                                    RouteTableAssociationId: 'rtbassoc-111',
+                                    SubnetId: 'subnet-aaa',
+                                },
+                            ],
+                        },
+                    ],
                 });
-            
+
             const mockEC2Client = { send: sendMock };
 
             mockProvider.describeStack.mockResolvedValue(mockStack);
             mockProvider.listStackResources.mockResolvedValue(mockResources);
-            mockProvider.getEC2Client = jest.fn().mockReturnValue(mockEC2Client);
+            mockProvider.getEC2Client = jest
+                .fn()
+                .mockReturnValue(mockEC2Client);
 
             const result = await cfDiscovery.discoverFromStack('test-stack');
 
@@ -1069,4 +1318,3 @@ describe('CloudFormationDiscovery', () => {
         });
     });
 });
-

--- a/packages/devtools/infrastructure/domains/shared/resource-discovery.js
+++ b/packages/devtools/infrastructure/domains/shared/resource-discovery.js
@@ -118,6 +118,29 @@ async function gatherDiscoveredResources(appDefinition) {
                                appDefinition.vpcIsolation === 'isolated';
 
         if (stackResources && hasSomeUsefulData) {
+            // Self-heal: if route table exists but has 0 subnet associations, fix via EC2 API
+            if (appDefinition.vpc?.selfHeal &&
+                stackResources.routeTableId &&
+                stackResources.routeTableAssociationCount === 0 &&
+                stackResources.privateSubnetId1 && stackResources.privateSubnetId2) {
+
+                console.log('  ⚠️  Route table has 0 subnet associations - self-healing...');
+                try {
+                    const { AssociateRouteTableCommand } = require('@aws-sdk/client-ec2');
+                    const ec2 = provider.getEC2Client();
+
+                    for (const subnetId of [stackResources.privateSubnetId1, stackResources.privateSubnetId2]) {
+                        await ec2.send(new AssociateRouteTableCommand({
+                            RouteTableId: stackResources.routeTableId,
+                            SubnetId: subnetId,
+                        }));
+                        console.log(`  ✓ Self-healed: associated ${subnetId} with ${stackResources.routeTableId}`);
+                    }
+                } catch (error) {
+                    console.warn(`  ⚠️  Self-heal failed: ${error.message}`);
+                }
+            }
+
             console.log('  ✓ Discovered resources from existing CloudFormation stack');
             console.log('✅ Cloud resource discovery completed successfully!');
             return stackResources;

--- a/packages/devtools/infrastructure/domains/shared/resource-discovery.js
+++ b/packages/devtools/infrastructure/domains/shared/resource-discovery.js
@@ -125,19 +125,19 @@ async function gatherDiscoveredResources(appDefinition) {
                 stackResources.privateSubnetId1 && stackResources.privateSubnetId2) {
 
                 console.log('  ⚠️  Route table has 0 subnet associations - self-healing...');
-                try {
-                    const { AssociateRouteTableCommand } = require('@aws-sdk/client-ec2');
-                    const ec2 = provider.getEC2Client();
+                const { AssociateRouteTableCommand } = require('@aws-sdk/client-ec2');
+                const ec2 = provider.getEC2Client();
 
-                    for (const subnetId of [stackResources.privateSubnetId1, stackResources.privateSubnetId2]) {
-                        await ec2.send(new AssociateRouteTableCommand({
+                for (const subnetId of [stackResources.privateSubnetId1, stackResources.privateSubnetId2]) {
+                    try {
+                        const response = await ec2.send(new AssociateRouteTableCommand({
                             RouteTableId: stackResources.routeTableId,
                             SubnetId: subnetId,
                         }));
-                        console.log(`  ✓ Self-healed: associated ${subnetId} with ${stackResources.routeTableId}`);
+                        console.log(`  ✓ Self-healed: associated ${subnetId} → ${stackResources.routeTableId} (${response.AssociationId})`);
+                    } catch (error) {
+                        console.warn(`  ⚠️  Self-heal failed for ${subnetId}: ${error.message}`);
                     }
-                } catch (error) {
-                    console.warn(`  ⚠️  Self-heal failed: ${error.message}`);
                 }
             }
 

--- a/packages/devtools/infrastructure/domains/shared/resource-discovery.test.js
+++ b/packages/devtools/infrastructure/domains/shared/resource-discovery.test.js
@@ -12,12 +12,18 @@ jest.mock('../networking/vpc-discovery');
 jest.mock('../security/kms-discovery');
 jest.mock('../database/aurora-discovery');
 jest.mock('../parameters/ssm-discovery');
+jest.mock('./cloudformation-discovery');
+jest.mock('@aws-sdk/client-ec2', () => ({
+    AssociateRouteTableCommand: jest.fn().mockImplementation((params) => params),
+}));
 
 const { CloudProviderFactory } = require('./providers/provider-factory');
 const { VpcDiscovery } = require('../networking/vpc-discovery');
 const { KmsDiscovery } = require('../security/kms-discovery');
 const { AuroraDiscovery } = require('../database/aurora-discovery');
 const { SsmDiscovery } = require('../parameters/ssm-discovery');
+const { CloudFormationDiscovery } = require('./cloudformation-discovery');
+const { AssociateRouteTableCommand } = require('@aws-sdk/client-ec2');
 
 describe('Resource Discovery', () => {
     let mockProvider;
@@ -31,6 +37,7 @@ describe('Resource Discovery', () => {
         delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
         delete process.env.CLOUD_PROVIDER;
         delete process.env.AWS_REGION;
+        delete process.env.SLS_STAGE;
 
         // Create mock provider
         mockProvider = {
@@ -64,6 +71,9 @@ describe('Resource Discovery', () => {
         };
 
         // Mock factory and discovery constructors
+        CloudFormationDiscovery.mockImplementation(() => ({
+            discoverFromStack: jest.fn().mockResolvedValue(null),
+        }));
         CloudProviderFactory.create = jest.fn().mockReturnValue(mockProvider);
         VpcDiscovery.mockImplementation(() => mockVpcDiscovery);
         KmsDiscovery.mockImplementation(() => mockKmsDiscovery);
@@ -377,8 +387,6 @@ describe('Resource Discovery', () => {
         });
 
         it('should default stage to dev', async () => {
-            delete process.env.SLS_STAGE;
-
             const appDefinition = {
                 vpc: { enable: true },
             };
@@ -411,8 +419,6 @@ describe('Resource Discovery', () => {
                     stage: 'qa',
                 })
             );
-
-            delete process.env.SLS_STAGE;
         });
 
         it('should recognize routing infrastructure as useful data', async () => {
@@ -423,8 +429,7 @@ describe('Resource Discovery', () => {
 
             process.env.SLS_STAGE = 'production';
 
-            // Mock CloudFormation discovery to return routing infrastructure but no VPC resource
-            const mockCloudFormationDiscovery = {
+            CloudFormationDiscovery.mockImplementation(() => ({
                 discoverFromStack: jest.fn().mockResolvedValue({
                     fromCloudFormationStack: true,
                     routeTableId: 'rtb-123',
@@ -434,20 +439,13 @@ describe('Resource Discovery', () => {
                         dynamodb: 'vpce-ddb'
                     },
                     existingLogicalIds: ['FriggLambdaRouteTable', 'FriggNATRoute']
-                    // NO defaultVpcId, NO defaultKmsKeyId, NO auroraClusterId
                 })
-            };
-
-            const { CloudFormationDiscovery } = require('./cloudformation-discovery');
-            CloudFormationDiscovery.mockImplementation(() => mockCloudFormationDiscovery);
+            }));
 
             const result = await gatherDiscoveredResources(appDefinition);
 
-            // Should use CloudFormation data without falling back to AWS API
             expect(result.routeTableId).toBe('rtb-123');
             expect(result.vpcEndpoints.s3).toBe('vpce-s3');
-            
-            // Should NOT call AWS API discovery
             expect(mockVpcDiscovery.discover).not.toHaveBeenCalled();
         });
 
@@ -468,11 +466,8 @@ describe('Resource Discovery', () => {
 
     describe('Isolated Mode Discovery', () => {
         beforeEach(() => {
-            // Mock CloudFormation discovery
-            jest.mock('./cloudformation-discovery');
-            const { CloudFormationDiscovery } = require('./cloudformation-discovery');
             CloudFormationDiscovery.mockImplementation(() => ({
-                discoverFromStack: jest.fn().mockResolvedValue({}), // No stack found
+                discoverFromStack: jest.fn().mockResolvedValue({}),
             }));
         });
 
@@ -506,12 +501,6 @@ describe('Resource Discovery', () => {
         });
 
         it('should return empty if no KMS found in isolated mode (fresh infrastructure)', async () => {
-            const { CloudFormationDiscovery } = require('./cloudformation-discovery');
-
-            // Mock that CF stack exists but we still want fresh resources
-            CloudFormationDiscovery.mockImplementation(() => ({
-                discoverFromStack: jest.fn().mockResolvedValue({}), // Stack exists but empty
-            }));
 
             const appDefinition = {
                 name: 'test-app',
@@ -584,5 +573,185 @@ describe('Resource Discovery', () => {
             });
         });
     });
-});
 
+    describe('VPC Self-Heal', () => {
+        let mockEc2Send;
+
+        beforeEach(() => {
+            AssociateRouteTableCommand.mockClear();
+            mockEc2Send = jest.fn().mockResolvedValue({ AssociationId: 'rtbassoc-new-123' });
+
+            CloudFormationDiscovery.mockImplementation(() => ({
+                discoverFromStack: jest.fn().mockResolvedValue({
+                    fromCloudFormationStack: true,
+                    routeTableId: 'rtb-123',
+                    routeTableAssociationCount: 0,
+                    privateSubnetId1: 'subnet-priv-1',
+                    privateSubnetId2: 'subnet-priv-2',
+                    defaultVpcId: 'vpc-123',
+                }),
+            }));
+
+            mockProvider.getEC2Client = jest.fn().mockReturnValue({
+                send: mockEc2Send,
+            });
+        });
+
+        it('should self-heal when route table has 0 associations and selfHeal is enabled', async () => {
+            const appDefinition = {
+                name: 'test-app',
+                vpc: { enable: true, selfHeal: true },
+            };
+
+            process.env.SLS_STAGE = 'production';
+
+            const result = await gatherDiscoveredResources(appDefinition);
+
+            expect(mockEc2Send).toHaveBeenCalledTimes(2);
+            expect(AssociateRouteTableCommand).toHaveBeenCalledWith({
+                RouteTableId: 'rtb-123',
+                SubnetId: 'subnet-priv-1',
+            });
+            expect(AssociateRouteTableCommand).toHaveBeenCalledWith({
+                RouteTableId: 'rtb-123',
+                SubnetId: 'subnet-priv-2',
+            });
+            expect(result.routeTableId).toBe('rtb-123');
+        });
+
+        it('should only associate private subnets with lambda route table (not public subnet)', async () => {
+            // Simulates CF discovery output for: 3 subnets in VPC (1 public, 2 private),
+            // IGW route table has all 3, Frigg lambda route table has 0 associations.
+            // CF discovery already filtered by !MapPublicIpOnLaunch, so only private IDs arrive here.
+            CloudFormationDiscovery.mockImplementation(() => ({
+                discoverFromStack: jest.fn().mockResolvedValue({
+                    fromCloudFormationStack: true,
+                    routeTableId: 'rtb-lambda',
+                    routeTableAssociationCount: 0,
+                    privateSubnetId1: 'subnet-priv-1',
+                    privateSubnetId2: 'subnet-priv-2',
+                    defaultVpcId: 'vpc-123',
+                }),
+            }));
+
+            const appDefinition = {
+                name: 'test-app',
+                vpc: { enable: true, selfHeal: true },
+            };
+
+            process.env.SLS_STAGE = 'production';
+
+            await gatherDiscoveredResources(appDefinition);
+
+            // Self-heal should associate ONLY the 2 private subnets
+            expect(mockEc2Send).toHaveBeenCalledTimes(2);
+            expect(AssociateRouteTableCommand).toHaveBeenCalledWith({
+                RouteTableId: 'rtb-lambda',
+                SubnetId: 'subnet-priv-1',
+            });
+            expect(AssociateRouteTableCommand).toHaveBeenCalledWith({
+                RouteTableId: 'rtb-lambda',
+                SubnetId: 'subnet-priv-2',
+            });
+
+            // Public subnet (subnet-public) should never appear in any AssociateRouteTableCommand call
+            const allCalls = AssociateRouteTableCommand.mock.calls.map(c => c[0].SubnetId);
+            expect(allCalls).not.toContain('subnet-public');
+        });
+
+        it('should not self-heal when selfHeal is disabled', async () => {
+            const appDefinition = {
+                name: 'test-app',
+                vpc: { enable: true, selfHeal: false },
+            };
+
+            process.env.SLS_STAGE = 'production';
+
+            await gatherDiscoveredResources(appDefinition);
+
+            expect(mockEc2Send).not.toHaveBeenCalled();
+        });
+
+        it('should not self-heal when routeTableAssociationCount is not 0', async () => {
+            CloudFormationDiscovery.mockImplementation(() => ({
+                discoverFromStack: jest.fn().mockResolvedValue({
+                    fromCloudFormationStack: true,
+                    routeTableId: 'rtb-123',
+                    routeTableAssociationCount: 2,
+                    privateSubnetId1: 'subnet-priv-1',
+                    privateSubnetId2: 'subnet-priv-2',
+                    defaultVpcId: 'vpc-123',
+                }),
+            }));
+
+            const appDefinition = {
+                name: 'test-app',
+                vpc: { enable: true, selfHeal: true },
+            };
+
+            process.env.SLS_STAGE = 'production';
+
+            await gatherDiscoveredResources(appDefinition);
+
+            expect(mockEc2Send).not.toHaveBeenCalled();
+        });
+
+        it('should continue associating subnet 2 if subnet 1 fails', async () => {
+            mockEc2Send
+                .mockRejectedValueOnce(new Error('Resource.AlreadyAssociated'))
+                .mockResolvedValueOnce({ AssociationId: 'rtbassoc-456' });
+
+            const appDefinition = {
+                name: 'test-app',
+                vpc: { enable: true, selfHeal: true },
+            };
+
+            process.env.SLS_STAGE = 'production';
+
+            const result = await gatherDiscoveredResources(appDefinition);
+
+            expect(mockEc2Send).toHaveBeenCalledTimes(2);
+            expect(result.routeTableId).toBe('rtb-123');
+        });
+
+        it('should handle both subnet associations failing gracefully', async () => {
+            mockEc2Send.mockRejectedValue(new Error('AccessDenied'));
+
+            const appDefinition = {
+                name: 'test-app',
+                vpc: { enable: true, selfHeal: true },
+            };
+
+            process.env.SLS_STAGE = 'production';
+
+            const result = await gatherDiscoveredResources(appDefinition);
+
+            expect(mockEc2Send).toHaveBeenCalledTimes(2);
+            expect(result.routeTableId).toBe('rtb-123');
+        });
+
+        it('should not self-heal when privateSubnetId2 is missing', async () => {
+            CloudFormationDiscovery.mockImplementation(() => ({
+                discoverFromStack: jest.fn().mockResolvedValue({
+                    fromCloudFormationStack: true,
+                    routeTableId: 'rtb-123',
+                    routeTableAssociationCount: 0,
+                    privateSubnetId1: 'subnet-priv-1',
+                    // privateSubnetId2 missing
+                    defaultVpcId: 'vpc-123',
+                }),
+            }));
+
+            const appDefinition = {
+                name: 'test-app',
+                vpc: { enable: true, selfHeal: true },
+            };
+
+            process.env.SLS_STAGE = 'production';
+
+            await gatherDiscoveredResources(appDefinition);
+
+            expect(mockEc2Send).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

This PR fixes a production networking drift issue where Frigg correctly discovered the Lambda route table, but that route table had lost its subnet associations. As a result, Lambda subnets silently fell back to the VPC's main route table instead of using the NAT-backed Lambda route table, which broke outbound connectivity to external APIs.

The fix adds explicit drift detection and self-healing during infrastructure discovery so deployments can repair this state automatically before CloudFormation runs.

## Problem

In the affected AWS topology:

- the Frigg Lambda route table still existed
- the NAT route still existed
- the VPC endpoints still existed
- but the Lambda route table had **0 subnet associations**

When that happens, the subnets use the VPC's main route table instead. For Lambdas running inside the VPC, that means they no longer use the intended NAT egress path and can time out when calling external services.

This is especially tricky because the stack can appear healthy from CloudFormation's perspective even though the real routing state in AWS is broken.

## Root cause

A previous `@friggframework` update changed the logical IDs for `SubnetRouteTableAssociation` resources. CloudFormation did not automatically repair the missing physical associations on later no-op deployments, so the route table remained detached from the Lambda subnets.

## What this PR changes

### 1. Detect route table association drift

CloudFormation discovery now records the number of subnet associations on the discovered route table via `routeTableAssociationCount`.

This makes the broken state explicit instead of treating the route table as healthy just because it exists.

### 2. Self-heal missing subnet associations before CloudFormation runs

When:

- `vpc.selfHeal` is enabled
- a Lambda route table is discovered
- that route table has `0` subnet associations
- and candidate Lambda subnets are available

Frigg now re-associates the subnets to the correct route table using the EC2 API before CloudFormation continues.

That restores the intended NAT-based routing path automatically during deployment.

### 3. Fix subnet association rebuilding in `VpcBuilder`

`VpcBuilder` was calling `ensureSubnetAssociations()` with `{}` instead of the actual `discoveredResources`, which prevented it from using the real physical subnet IDs in some paths.

This PR fixes that bug so subnet association logic uses the discovered AWS resources correctly.

## Why this matters

This is not a cosmetic infrastructure cleanup. It fixes a real failure mode where:

- the stack still exists
- the route table still exists
- CloudFormation does not recreate anything
- but Lambda outbound networking is broken in production

With this fix, Frigg can now detect and repair that drift automatically instead of leaving Lambdas attached to the wrong route table.

## Impact

This PR makes deployments more resilient by allowing Frigg to recover from route-table/subnet-association drift that CloudFormation alone was not correcting.

In practice, it restores outbound connectivity for VPC Lambdas that depend on NAT routing to reach external APIs.

## Test plan

- deploy with `vpc.selfHeal: true`
- confirm logs show the route table drift being detected
- confirm the missing subnet associations are recreated automatically
- verify the Lambda route table ends up with the expected subnet associations
- verify Lambdas can again reach external APIs through NAT
- verify healthy deployments remain no-op

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.74`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/devtools`
    - fix(infra): self-heal VPC subnet-route table association drift [#548](https://github.com/friggframework/frigg/pull/548) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - refactor: replace mongodb dependency by bson [#547](https://github.com/friggframework/frigg/pull/547) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
