### PR TITLE
fix(core): gracefully handle webhooks for deleted integrations

### DIFF
--- a/packages/core/handlers/backend-utils.js
+++ b/packages/core/handlers/backend-utils.js
@@ -88,9 +88,16 @@ const loadIntegrationForWebhook = async (integrationId) => {
         moduleFactory,
     });
 
-    const integrationRecord = await integrationRepository.findIntegrationById(
-        integrationId
-    );
+    let integrationRecord;
+    try {
+        integrationRecord =
+            await integrationRepository.findIntegrationById(integrationId);
+    } catch (error) {
+        if (error.message?.includes('not found')) {
+            return null;
+        }
+        throw error;
+    }
 
     const instance = await getIntegrationInstance.execute(
         integrationId,
@@ -151,6 +158,12 @@ const createQueueWorker = (integrationClass) => {
                     integrationInstance = await loadIntegrationForWebhook(
                         params.data.integrationId
                     );
+                    if (!integrationInstance) {
+                        console.warn(
+                            `[${integrationClass.Definition.name}] Integration ${params.data.integrationId} no longer exists. Discarding ${params.event} webhook.`
+                        );
+                        return;
+                    }
                 } else {
                     // Instantiates a DRY integration class without database records.
                     // There will be cases where we need to use helpers that the api modules can export.

--- a/packages/core/handlers/backend-utils.js
+++ b/packages/core/handlers/backend-utils.js
@@ -160,7 +160,7 @@ const createQueueWorker = (integrationClass) => {
                     );
                     if (!integrationInstance) {
                         console.warn(
-                            `[${integrationClass.Definition.name}] Integration ${params.data.integrationId} no longer exists. Discarding ${params.event} webhook.`
+                            `[${integrationClass.Definition.name}] Integration ${params.data.integrationId} no longer exists. Discarding ${params.event} message.`
                         );
                         return;
                     }

--- a/packages/core/handlers/workers/integration-defined-workers.test.js
+++ b/packages/core/handlers/workers/integration-defined-workers.test.js
@@ -179,6 +179,51 @@ describe('Webhook Queue Worker', () => {
             // but it proves the code path is attempted
             await expect(worker.run(sqsEvent, {})).rejects.toThrow();
         });
+
+        it('should discard message gracefully when integration no longer exists', async () => {
+            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+            let mockedCreateQueueWorker;
+            jest.isolateModules(() => {
+                jest.doMock('../../integrations/repositories/integration-repository-factory', () => ({
+                    createIntegrationRepository: () => ({
+                        findIntegrationById: jest.fn().mockRejectedValue(
+                            new Error('Integration with id 999 not found')
+                        ),
+                    }),
+                }));
+                jest.doMock('../../modules/repositories/module-repository-factory', () => ({
+                    createModuleRepository: () => ({}),
+                }));
+                jest.doMock('../app-definition-loader', () => ({
+                    loadAppDefinition: () => ({ integrations: [] }),
+                }));
+                mockedCreateQueueWorker = require('../backend-utils').createQueueWorker;
+            });
+
+            const QueueWorker = mockedCreateQueueWorker(TestWebhookIntegration);
+            const worker = new QueueWorker();
+
+            const params = {
+                event: 'ON_WEBHOOK',
+                data: {
+                    integrationId: '999',
+                    body: { webhookEvent: 'updated' },
+                },
+            };
+
+            const sqsEvent = {
+                Records: [{ body: JSON.stringify(params) }],
+            };
+
+            await expect(worker.run(sqsEvent, {})).resolves.not.toThrow();
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Integration 999 no longer exists')
+            );
+
+            consoleSpy.mockRestore();
+        });
     });
 
     describe('Integration Hydration for ANY event with integrationId', () => {


### PR DESCRIPTION
## Summary
- When an integration is hard-deleted from the database without cancelling webhooks, incoming webhook messages no longer cause unhandled exceptions and infinite SQS retries
- `loadIntegrationForWebhook` now returns `null` (instead of throwing) when the integration is not found
- `QueueWorker._run` detects the `null` and logs a clean warning before consuming the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.550.b8b9a2b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.550.b8b9a2b.0
  npm install @friggframework/devtools@2.0.0--canary.550.b8b9a2b.0
  npm install @friggframework/eslint-config@2.0.0--canary.550.b8b9a2b.0
  npm install @friggframework/prettier-config@2.0.0--canary.550.b8b9a2b.0
  npm install @friggframework/schemas@2.0.0--canary.550.b8b9a2b.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.550.b8b9a2b.0
  npm install @friggframework/test@2.0.0--canary.550.b8b9a2b.0
  npm install @friggframework/ui@2.0.0--canary.550.b8b9a2b.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.550.b8b9a2b.0
  yarn add @friggframework/devtools@2.0.0--canary.550.b8b9a2b.0
  yarn add @friggframework/eslint-config@2.0.0--canary.550.b8b9a2b.0
  yarn add @friggframework/prettier-config@2.0.0--canary.550.b8b9a2b.0
  yarn add @friggframework/schemas@2.0.0--canary.550.b8b9a2b.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.550.b8b9a2b.0
  yarn add @friggframework/test@2.0.0--canary.550.b8b9a2b.0
  yarn add @friggframework/ui@2.0.0--canary.550.b8b9a2b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.75`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/core`
    - fix(core): gracefully handle webhooks for deleted integrations [#550](https://github.com/friggframework/frigg/pull/550) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - fix(infra): self-heal VPC subnet-route table association drift [#548](https://github.com/friggframework/frigg/pull/548) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
