### PR TITLE
test(e2e): extract E2E tests, test package, and lockfile from PR #522

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@atomist/slack-messages": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@atomist/slack-messages/-/slack-messages-1.2.2.tgz",
@@ -5680,7 +5701,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.917.0.tgz",
       "integrity": "sha512-3L73mDCpH7G0koFv3p3WkkEKqC5wn2EznKtNMrJ6hczPIr2Cu6DJz8VHeTZp9wFZLPrIBmh3ZW1KiLujT5Fd2w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -6228,419 +6248,468 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/client-scheduler": {
-      "version": "3.1002.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-scheduler/-/client-scheduler-3.1002.0.tgz",
-      "integrity": "sha512-H1oZU7V2CiOrqAlkU67nUEcM6uaVMpyS9DJKgo4CUzSBS8QvMNkZh+xmd+W95RwXupVqdGh86pUVGVnQhUtWqQ==",
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-scheduler/-/client-scheduler-3.948.0.tgz",
+      "integrity": "sha512-UAMeFOGlXpF5OSIF+WDTD0oYtNWlLmkySqZWMldTFxMb3YSS3RsjQn/UvCNdjGXw9N/cHhtXDMEBpwUORN41SQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/credential-provider-node": "^3.972.16",
-        "@aws-sdk/middleware-host-header": "^3.972.6",
-        "@aws-sdk/middleware-logger": "^3.972.6",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
-        "@aws-sdk/middleware-user-agent": "^3.972.17",
-        "@aws-sdk/region-config-resolver": "^3.972.6",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
-        "@aws-sdk/util-user-agent-browser": "^3.972.6",
-        "@aws-sdk/util-user-agent-node": "^3.973.2",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.7",
-        "@smithy/fetch-http-handler": "^5.3.12",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.21",
-        "@smithy/middleware-retry": "^4.4.38",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.13",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.1",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.37",
-        "@smithy/util-defaults-mode-node": "^4.2.40",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/credential-provider-node": "3.948.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.948.0",
+        "@aws-sdk/middleware-user-agent": "3.947.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.947.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.7",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.14",
+        "@smithy/middleware-retry": "^4.4.14",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.13",
+        "@smithy/util-defaults-mode-node": "^4.2.16",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/client-sso": {
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.948.0.tgz",
+      "integrity": "sha512-iWjchXy8bIAVBUsKnbfKYXRwhLgRg3EqCQ5FTr3JbR+QR75rZm4ZOYXlvHGztVTmtAZ+PQVA1Y4zO7v7N87C0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.948.0",
+        "@aws-sdk/middleware-user-agent": "3.947.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.947.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.7",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.14",
+        "@smithy/middleware-retry": "^4.4.14",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.13",
+        "@smithy/util-defaults-mode-node": "^4.2.16",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/core": {
-      "version": "3.973.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.17.tgz",
-      "integrity": "sha512-VtgGP0TjbCeyp6DQpiBqJKbemTSIaN2bZc3UbeTDCani3lBCyxn75ouJYD6koSSp0bh7rKLEbUpiFsNCI7tr0w==",
+      "version": "3.947.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.947.0.tgz",
+      "integrity": "sha512-Khq4zHhuAkvCFuFbgcy3GrZTzfSX7ZIjIcW1zRDxXRLZKRtuhnZdonqTUfaWi5K42/4OmxkYNpsO7X7trQOeHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/xml-builder": "^3.972.9",
-        "@smithy/core": "^3.23.7",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/signature-v4": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.1",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.7",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.15.tgz",
-      "integrity": "sha512-RhHQG1lhkWHL4tK1C/KDjaOeis+9U0tAMnWDiwiSVQZMC7CsST9Xin+sK89XywJ5g/tyABtb7TvFePJ4Te5XSQ==",
+      "version": "3.947.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.947.0.tgz",
+      "integrity": "sha512-VR2V6dRELmzwAsCpK4GqxUi6UW5WNhAXS9F9AzWi5jvijwJo3nH92YNJUP4quMpgFZxJHEWyXLWgPjh9u0zYOA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.17.tgz",
-      "integrity": "sha512-b/bDL76p51+yQ+0O9ZDH5nw/ioE0sRYkjwjOwFWAWZXo6it2kQZUOXhVpjohx3ldKyUxt/SwAivjUu1Nr/PWlQ==",
+      "version": "3.947.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.947.0.tgz",
+      "integrity": "sha512-inF09lh9SlHj63Vmr5d+LmwPXZc2IbK8lAruhOr3KLsZAIHEgHgGPXWDC2ukTEMzg0pkexQ6FOhXXad6klK4RA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/fetch-http-handler": "^5.3.12",
-        "@smithy/node-http-handler": "^4.4.13",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.1",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.16",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.15.tgz",
-      "integrity": "sha512-qWnM+wB8MmU2kKY7f4KowKjOjkwRosaFxrtseEEIefwoXn1SjN+CbHzXBVdTAQxxkbBiqhPgJ/WHiPtES4grRQ==",
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.948.0.tgz",
+      "integrity": "sha512-Cl//Qh88e8HBL7yYkJNpF5eq76IO6rq8GsatKcfVBm7RFVxCqYEPSSBtkHdbtNwQdRQqAMXc6E/lEB/CZUDxnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/credential-provider-env": "^3.972.15",
-        "@aws-sdk/credential-provider-http": "^3.972.17",
-        "@aws-sdk/credential-provider-login": "^3.972.15",
-        "@aws-sdk/credential-provider-process": "^3.972.15",
-        "@aws-sdk/credential-provider-sso": "^3.972.15",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.15",
-        "@aws-sdk/nested-clients": "^3.996.5",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/credential-provider-imds": "^4.2.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/credential-provider-env": "3.947.0",
+        "@aws-sdk/credential-provider-http": "3.947.0",
+        "@aws-sdk/credential-provider-login": "3.948.0",
+        "@aws-sdk/credential-provider-process": "3.947.0",
+        "@aws-sdk/credential-provider-sso": "3.948.0",
+        "@aws-sdk/credential-provider-web-identity": "3.948.0",
+        "@aws-sdk/nested-clients": "3.948.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.16.tgz",
-      "integrity": "sha512-7mlt14Ee4rPFAFUVgpWE7+0CBhetJJyzVFqfIsMp7sgyOSm9Y/+qHZOWAuK5I4JNc+Y5PltvJ9kssTzRo92iXQ==",
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.948.0.tgz",
+      "integrity": "sha512-ep5vRLnrRdcsP17Ef31sNN4g8Nqk/4JBydcUJuFRbGuyQtrZZrVT81UeH2xhz6d0BK6ejafDB9+ZpBjXuWT5/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.15",
-        "@aws-sdk/credential-provider-http": "^3.972.17",
-        "@aws-sdk/credential-provider-ini": "^3.972.15",
-        "@aws-sdk/credential-provider-process": "^3.972.15",
-        "@aws-sdk/credential-provider-sso": "^3.972.15",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.15",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/credential-provider-imds": "^4.2.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/credential-provider-env": "3.947.0",
+        "@aws-sdk/credential-provider-http": "3.947.0",
+        "@aws-sdk/credential-provider-ini": "3.948.0",
+        "@aws-sdk/credential-provider-process": "3.947.0",
+        "@aws-sdk/credential-provider-sso": "3.948.0",
+        "@aws-sdk/credential-provider-web-identity": "3.948.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.15.tgz",
-      "integrity": "sha512-PrH3iTeD18y/8uJvQD2s/T87BTGhsdS/1KZU7ReWHXsplBwvCqi7AbnnNbML1pFlQwRWCE2RdSZFWDVId3CvkA==",
+      "version": "3.947.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.947.0.tgz",
+      "integrity": "sha512-WpanFbHe08SP1hAJNeDdBDVz9SGgMu/gc0XJ9u3uNpW99nKZjDpvPRAdW7WLA4K6essMjxWkguIGNOpij6Do2Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.15.tgz",
-      "integrity": "sha512-M/+LBHTPKZxxXckM6m4dnJeR+jlm9NynH9b2YDswN4Zj2St05SK/crdL3Wy3WfJTZootnnhm3oTh87Usl7PS7w==",
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.948.0.tgz",
+      "integrity": "sha512-gqLhX1L+zb/ZDnnYbILQqJ46j735StfWV5PbDjxRzBKS7GzsiYoaf6MyHseEopmWrez5zl5l6aWzig7UpzSeQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/nested-clients": "^3.996.5",
-        "@aws-sdk/token-providers": "3.1002.0",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/client-sso": "3.948.0",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/token-providers": "3.948.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.15.tgz",
-      "integrity": "sha512-QTH6k93v+UOfFam/ado8zc71tH+enTVyuvLy9uEWXX1x894dN5ovtf/MdBDgFwq3g6c9mbtgVJ4B+yBqDtXvdA==",
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.948.0.tgz",
+      "integrity": "sha512-MvYQlXVoJyfF3/SmnNzOVEtANRAiJIObEUYYyjTqKZTmcRIVVky0tPuG26XnB8LmTYgtESwJIZJj/Eyyc9WURQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/nested-clients": "^3.996.5",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/nested-clients": "3.948.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.6.tgz",
-      "integrity": "sha512-5XHwjPH1lHB+1q4bfC7T8Z5zZrZXfaLcjSMwTd1HPSPrCmPFMbg3UQ5vgNWcVj0xoX4HWqTGkSf2byrjlnRg5w==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
+      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.6.tgz",
-      "integrity": "sha512-iFnaMFMQdljAPrvsCVKYltPt2j40LQqukAbXvW7v0aL5I+1GO7bZ/W8m12WxW3gwyK5p5u1WlHg8TSAizC5cZw==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
+      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.6.tgz",
-      "integrity": "sha512-dY4v3of5EEMvik6+UDwQ96KfUFDk8m1oZDdkSc5lwi4o7rFrjnv0A+yTV+gu230iybQZnKgDLg/rt2P3H+Vscw==",
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.948.0.tgz",
+      "integrity": "sha512-Qa8Zj+EAqA0VlAVvxpRnpBpIWJI9KUwaioY1vkeNVwXPlNaz9y9zCKVM9iU9OZ5HXpoUg6TnhATAHXHAE8+QsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "3.936.0",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.17.tgz",
-      "integrity": "sha512-HHArkgWzomuwufXwheQqkddu763PWCpoNTq1dGjqXzJT/lojX3VlOqjNSR2Xvb6/T9ISfwYcMOcbFgUp4EWxXA==",
+      "version": "3.947.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.947.0.tgz",
+      "integrity": "sha512-7rpKV8YNgCP2R4F9RjWZFcD2R+SO/0R4VHIbY9iZJdH2MzzJ8ZG7h8dZ2m8QkQd1fjx4wrFJGGPJUTYXPV3baA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
-        "@smithy/core": "^3.23.7",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@smithy/core": "^3.18.7",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.5.tgz",
-      "integrity": "sha512-zn0WApcULn7Rtl6T+KP2CQTZo/7wOa2YV1yHQnbijTQoi4YXQHM8s21JcJzt33/mqPh8AdvWX1f+83KvKuxlZw==",
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.948.0.tgz",
+      "integrity": "sha512-zcbJfBsB6h254o3NuoEkf0+UY1GpE9ioiQdENWv7odo69s8iaGBEQ4BDpsIMqcuiiUXw1uKIVNxCB1gUGYz8lw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/middleware-host-header": "^3.972.6",
-        "@aws-sdk/middleware-logger": "^3.972.6",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
-        "@aws-sdk/middleware-user-agent": "^3.972.17",
-        "@aws-sdk/region-config-resolver": "^3.972.6",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
-        "@aws-sdk/util-user-agent-browser": "^3.972.6",
-        "@aws-sdk/util-user-agent-node": "^3.973.2",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.7",
-        "@smithy/fetch-http-handler": "^5.3.12",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.21",
-        "@smithy/middleware-retry": "^4.4.38",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.13",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.1",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.37",
-        "@smithy/util-defaults-mode-node": "^4.2.40",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.948.0",
+        "@aws-sdk/middleware-user-agent": "3.947.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.947.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.7",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.14",
+        "@smithy/middleware-retry": "^4.4.14",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.13",
+        "@smithy/util-defaults-mode-node": "^4.2.16",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.6.tgz",
-      "integrity": "sha512-Aa5PusHLXAqLTX1UKDvI3pHQJtIsF7Q+3turCHqfz/1F61/zDMWfbTC8evjhrrYVAtz9Vsv3SJ/waSUeu7B6gw==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
+      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1002.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1002.0.tgz",
-      "integrity": "sha512-x972uKOydFn4Rb0PZJzLdNW59rH0KWC78Q2JbQzZpGlGt0DxjYdDRwBG6F42B1MyaEwHGqO/tkGc4r3/PRFfMw==",
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.948.0.tgz",
+      "integrity": "sha512-V487/kM4Teq5dcr1t5K6eoUKuqlGr9FRWL3MIMukMERJXHZvio6kox60FZ/YtciRHRI75u14YUqm2Dzddcu3+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/nested-clients": "^3.996.5",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/nested-clients": "3.948.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/types": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.4.tgz",
-      "integrity": "sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.3.tgz",
-      "integrity": "sha512-yWIQSNiCjykLL+ezN5A+DfBb1gfXTytBxm57e64lYmwxDHNmInYHRJYYRAGWG1o77vKEiWaw4ui28e3yb1k5aQ==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
+      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-endpoints": "^3.3.1",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.6.tgz",
-      "integrity": "sha512-Fwr/llD6GOrFgQnKaI2glhohdGuBDfHfora6iG9qsBBBR8xv1SdCSwbtf5CWlUdCw5X7g76G/9Hf0Inh0EmoxA==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
+      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.2.tgz",
-      "integrity": "sha512-lpaIuekdkpw7VRiik0IZmd6TyvEUcuLgKZ5fKRGpCA3I4PjrD/XH15sSwW+OptxQjNU4DEzSxag70spC9SluvA==",
+      "version": "3.947.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.947.0.tgz",
+      "integrity": "sha512-+vhHoDrdbb+zerV4noQk1DHaUMNzWFWPpPYjVTwW2186k5BEJIecAMChYkghRrBVJ3KPWP1+JnZwOd72F3d4rQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.17",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/middleware-user-agent": "3.947.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -6652,45 +6721,26 @@
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.9.tgz",
-      "integrity": "sha512-ItnlMgSqkPrUfJs7EsvU/01zw5UeIb2tNPhD09LBLHbg+g+HDiKibSLwpkuz/ZIlz4F2IMn+5XgE4AK/pfPuog==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "fast-xml-parser": "5.4.1",
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
         "tslib": "^2.6.2"
       },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
-      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-scheduler/node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
+      "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-scheduler/node_modules/tslib": {
@@ -8514,231 +8564,231 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.15.tgz",
-      "integrity": "sha512-x92FJy34/95wgu+qOGD8SHcgh1hZ9Qx2uFtQEGn4m9Ljou8ICIv3Ybq5yxdB7A60S8ZGCQB0mIopmjJwiLbh5g==",
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.948.0.tgz",
+      "integrity": "sha512-gcKO2b6eeTuZGp3Vvgr/9OxajMrD3W+FZ2FCyJox363ZgMoYJsyNid1vuZrEuAGkx0jvveLXfwiVS0UXyPkgtw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/nested-clients": "^3.996.5",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/nested-clients": "3.948.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/core": {
-      "version": "3.973.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.17.tgz",
-      "integrity": "sha512-VtgGP0TjbCeyp6DQpiBqJKbemTSIaN2bZc3UbeTDCani3lBCyxn75ouJYD6koSSp0bh7rKLEbUpiFsNCI7tr0w==",
+      "version": "3.947.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.947.0.tgz",
+      "integrity": "sha512-Khq4zHhuAkvCFuFbgcy3GrZTzfSX7ZIjIcW1zRDxXRLZKRtuhnZdonqTUfaWi5K42/4OmxkYNpsO7X7trQOeHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/xml-builder": "^3.972.9",
-        "@smithy/core": "^3.23.7",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/signature-v4": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.1",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.7",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.6.tgz",
-      "integrity": "sha512-5XHwjPH1lHB+1q4bfC7T8Z5zZrZXfaLcjSMwTd1HPSPrCmPFMbg3UQ5vgNWcVj0xoX4HWqTGkSf2byrjlnRg5w==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
+      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.6.tgz",
-      "integrity": "sha512-iFnaMFMQdljAPrvsCVKYltPt2j40LQqukAbXvW7v0aL5I+1GO7bZ/W8m12WxW3gwyK5p5u1WlHg8TSAizC5cZw==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
+      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.6.tgz",
-      "integrity": "sha512-dY4v3of5EEMvik6+UDwQ96KfUFDk8m1oZDdkSc5lwi4o7rFrjnv0A+yTV+gu230iybQZnKgDLg/rt2P3H+Vscw==",
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.948.0.tgz",
+      "integrity": "sha512-Qa8Zj+EAqA0VlAVvxpRnpBpIWJI9KUwaioY1vkeNVwXPlNaz9y9zCKVM9iU9OZ5HXpoUg6TnhATAHXHAE8+QsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "3.936.0",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.17.tgz",
-      "integrity": "sha512-HHArkgWzomuwufXwheQqkddu763PWCpoNTq1dGjqXzJT/lojX3VlOqjNSR2Xvb6/T9ISfwYcMOcbFgUp4EWxXA==",
+      "version": "3.947.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.947.0.tgz",
+      "integrity": "sha512-7rpKV8YNgCP2R4F9RjWZFcD2R+SO/0R4VHIbY9iZJdH2MzzJ8ZG7h8dZ2m8QkQd1fjx4wrFJGGPJUTYXPV3baA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
-        "@smithy/core": "^3.23.7",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@smithy/core": "^3.18.7",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.5.tgz",
-      "integrity": "sha512-zn0WApcULn7Rtl6T+KP2CQTZo/7wOa2YV1yHQnbijTQoi4YXQHM8s21JcJzt33/mqPh8AdvWX1f+83KvKuxlZw==",
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.948.0.tgz",
+      "integrity": "sha512-zcbJfBsB6h254o3NuoEkf0+UY1GpE9ioiQdENWv7odo69s8iaGBEQ4BDpsIMqcuiiUXw1uKIVNxCB1gUGYz8lw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.17",
-        "@aws-sdk/middleware-host-header": "^3.972.6",
-        "@aws-sdk/middleware-logger": "^3.972.6",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
-        "@aws-sdk/middleware-user-agent": "^3.972.17",
-        "@aws-sdk/region-config-resolver": "^3.972.6",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
-        "@aws-sdk/util-user-agent-browser": "^3.972.6",
-        "@aws-sdk/util-user-agent-node": "^3.973.2",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.7",
-        "@smithy/fetch-http-handler": "^5.3.12",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.21",
-        "@smithy/middleware-retry": "^4.4.38",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.13",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.1",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.37",
-        "@smithy/util-defaults-mode-node": "^4.2.40",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.948.0",
+        "@aws-sdk/middleware-user-agent": "3.947.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.947.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.7",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.14",
+        "@smithy/middleware-retry": "^4.4.14",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.13",
+        "@smithy/util-defaults-mode-node": "^4.2.16",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.6.tgz",
-      "integrity": "sha512-Aa5PusHLXAqLTX1UKDvI3pHQJtIsF7Q+3turCHqfz/1F61/zDMWfbTC8evjhrrYVAtz9Vsv3SJ/waSUeu7B6gw==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
+      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.4.tgz",
-      "integrity": "sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.3.tgz",
-      "integrity": "sha512-yWIQSNiCjykLL+ezN5A+DfBb1gfXTytBxm57e64lYmwxDHNmInYHRJYYRAGWG1o77vKEiWaw4ui28e3yb1k5aQ==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
+      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-endpoints": "^3.3.1",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.6.tgz",
-      "integrity": "sha512-Fwr/llD6GOrFgQnKaI2glhohdGuBDfHfora6iG9qsBBBR8xv1SdCSwbtf5CWlUdCw5X7g76G/9Hf0Inh0EmoxA==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
+      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.2.tgz",
-      "integrity": "sha512-lpaIuekdkpw7VRiik0IZmd6TyvEUcuLgKZ5fKRGpCA3I4PjrD/XH15sSwW+OptxQjNU4DEzSxag70spC9SluvA==",
+      "version": "3.947.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.947.0.tgz",
+      "integrity": "sha512-+vhHoDrdbb+zerV4noQk1DHaUMNzWFWPpPYjVTwW2186k5BEJIecAMChYkghRrBVJ3KPWP1+JnZwOd72F3d4rQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.17",
-        "@aws-sdk/types": "^3.973.4",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/middleware-user-agent": "3.947.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -8750,45 +8800,26 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.9.tgz",
-      "integrity": "sha512-ItnlMgSqkPrUfJs7EsvU/01zw5UeIb2tNPhD09LBLHbg+g+HDiKibSLwpkuz/ZIlz4F2IMn+5XgE4AK/pfPuog==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "fast-xml-parser": "5.4.1",
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
         "tslib": "^2.6.2"
       },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
-      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-login/node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
+      "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/tslib": {
@@ -9873,7 +9904,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -10389,6 +10419,121 @@
         "node": ">=12"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@date-io/core": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@date-io/core/-/core-3.2.0.tgz",
@@ -10416,7 +10561,6 @@
       "integrity": "sha512-FAORK6KoMQbd2VyLq/BMwcViy1txYd7XD9eYd5IGrXFpoOgWrSjp4zaSDlFPIEGgm68+n8fN0RelkbuMHCkSsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "find-my-way-ts": "^0.1.5",
         "multipasta": "^0.2.5"
@@ -10500,7 +10644,6 @@
       "deprecated": "this package has been merged into the main effect package",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-check": "^3.21.0"
       },
@@ -10558,6 +10701,7 @@
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
       "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -10575,12 +10719,14 @@
     "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "peer": true
     },
     "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10592,6 +10738,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10617,6 +10764,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
       "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
@@ -10699,6 +10847,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
       "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "peer": true,
       "peerDependencies": {
         "react": ">=16.8.0"
       }
@@ -11041,6 +11190,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11073,6 +11223,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11105,6 +11256,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11312,12 +11464,24 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
     },
+    "node_modules/@friggframework/admin-scripts": {
+      "resolved": "packages/admin-scripts",
+      "link": true
+    },
+    "node_modules/@friggframework/ai-agents": {
+      "resolved": "packages/ai-agents",
+      "link": true
+    },
     "node_modules/@friggframework/core": {
       "resolved": "packages/core",
       "link": true
     },
     "node_modules/@friggframework/devtools": {
       "resolved": "packages/devtools",
+      "link": true
+    },
+    "node_modules/@friggframework/e2e": {
+      "resolved": "packages/e2e",
       "link": true
     },
     "node_modules/@friggframework/eslint-config": {
@@ -12840,6 +13004,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.2.0.tgz",
       "integrity": "sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==",
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "chalk": "^4.1.2",
@@ -12854,6 +13019,7 @@
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
       "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -12865,6 +13031,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
       "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -12881,7 +13048,8 @@
     "node_modules/@jest/snapshot-utils/node_modules/@sinclair/typebox": {
       "version": "0.34.41",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
-      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "peer": true
     },
     "node_modules/@jest/source-map": {
       "version": "29.6.3",
@@ -13166,7 +13334,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@jsonforms/react/-/react-3.6.0.tgz",
       "integrity": "sha512-dor7FYltCkNkAM+SVZGtabjpUhGlj0/coAqx7GIZ8h+leET+d1sLEAc8kfxxh6gZBq9C4KAErb0Pj3uHedOs9Q==",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -13180,6 +13347,7 @@
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
       "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "debug": "^4.1.1"
       }
@@ -13188,7 +13356,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@lerna/create": {
       "version": "8.1.9",
@@ -13286,7 +13455,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -13924,7 +14092,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
       "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/core-downloads-tracker": "^6.5.0",
@@ -14076,6 +14243,7 @@
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.3.tgz",
       "integrity": "sha512-OJM+9nj5JIyPUvsZ5ZjaeC9PfktmK+W5YaVLToLR8L0lB/DGmv1gcKE43ssNLSvpoW71Hct0necfade6+kW3zQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/utils": "^7.3.3",
@@ -14102,6 +14270,7 @@
       "version": "7.4.7",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.7.tgz",
       "integrity": "sha512-8vVje9rdEr1rY8oIkYgP+Su5Kwl6ik7O3jQ0wl78JGSmiZhRHV+vkjooGdKD8pbtZbutXFVTWQYshu2b3sG9zw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -14118,6 +14287,7 @@
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.3.tgz",
       "integrity": "sha512-kwNAUh7bLZ7mRz9JZ+6qfRnnxbE4Zuc+RzXnhSpRSxjTlSTj7b4JxRLXpG+MVtPVtqks5k/XC8No1Vs3x4Z2gg==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/types": "^7.4.7",
@@ -14146,12 +14316,14 @@
     "node_modules/@mui/private-theming/node_modules/react-is": {
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA=="
+      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "peer": true
     },
     "node_modules/@mui/styled-engine": {
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.3.tgz",
       "integrity": "sha512-CmFxvRJIBCEaWdilhXMw/5wFJ1+FT9f3xt+m2pPXhHPeVIbBg9MnMvNSJjdALvnQJMPw8jLhrUtXmN7QAZV2fw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@emotion/cache": "^11.14.0",
@@ -14185,6 +14357,7 @@
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.3.tgz",
       "integrity": "sha512-Lqq3emZr5IzRLKaHPuMaLBDVaGvxoh6z7HMWd1RPKawBM5uMRaQ4ImsmmgXWtwJdfZux5eugfDhXJUo2mliS8Q==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/private-theming": "^7.3.3",
@@ -14224,6 +14397,7 @@
       "version": "7.4.7",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.7.tgz",
       "integrity": "sha512-8vVje9rdEr1rY8oIkYgP+Su5Kwl6ik7O3jQ0wl78JGSmiZhRHV+vkjooGdKD8pbtZbutXFVTWQYshu2b3sG9zw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -14240,6 +14414,7 @@
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.3.tgz",
       "integrity": "sha512-kwNAUh7bLZ7mRz9JZ+6qfRnnxbE4Zuc+RzXnhSpRSxjTlSTj7b4JxRLXpG+MVtPVtqks5k/XC8No1Vs3x4Z2gg==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/types": "^7.4.7",
@@ -14268,7 +14443,8 @@
     "node_modules/@mui/system/node_modules/react-is": {
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA=="
+      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "peer": true
     },
     "node_modules/@mui/types": {
       "version": "7.2.24",
@@ -14387,6 +14563,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
       "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.7",
         "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
@@ -15225,7 +15402,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -16758,6 +16934,7 @@
       "resolved": "https://registry.npmjs.org/@serverless/dashboard-plugin/-/dashboard-plugin-7.2.3.tgz",
       "integrity": "sha512-Vu4TKJLEQ5F8ZipfCvd8A/LMIdH8kNGe448sX9mT4/Z0JVUaYmMc3BwkQ+zkNIh3QdBKAhocGn45TYjHV6uPWQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.410.0",
         "@aws-sdk/client-sts": "^3.410.0",
@@ -16792,6 +16969,7 @@
       "resolved": "https://registry.npmjs.org/child-process-ext/-/child-process-ext-3.0.2.tgz",
       "integrity": "sha512-oBePsLbQpTJFxzwyCvs9yWWF0OEM6vGGepHwt1stqmX7QQqOuDc8j2ywdvAs9Tvi44TT7d9ackqhR4Q10l1u8w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "es5-ext": "^0.10.62",
@@ -16808,6 +16986,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -16832,6 +17011,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -16847,6 +17027,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -16867,6 +17048,7 @@
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
       "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -16883,6 +17065,7 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -16895,6 +17078,7 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -16904,6 +17088,7 @@
       "resolved": "https://registry.npmjs.org/@serverless/event-mocks/-/event-mocks-1.1.1.tgz",
       "integrity": "sha512-YAV5V/y+XIOfd+HEVeXfPWZb8C6QLruFk9tBivoX2roQLWVq145s4uxf8D0QioCueuRzkukHUS4JIj+KVoS34A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/lodash": "^4.14.123",
         "lodash": "^4.17.11"
@@ -16914,6 +17099,7 @@
       "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.5.1.tgz",
       "integrity": "sha512-XltmO/029X76zi0LUFmhsnanhE2wnqH1xf+WBt5K8gumQA9LnrfwLgPxj+VA+mm6wQhy+PCp7H5SS0ZPu7F2Cw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "adm-zip": "^0.5.5",
         "archiver": "^5.3.0",
@@ -16940,6 +17126,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -16949,6 +17136,7 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -16958,6 +17146,7 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -16972,6 +17161,7 @@
       "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -17289,12 +17479,12 @@
       "dev": true
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
-      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
+      "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17344,16 +17534,16 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
-      "integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
+      "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17366,20 +17556,20 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.8.tgz",
-      "integrity": "sha512-f7uPeBi7ehmLT4YF2u9j3qx6lSnurG1DLXOsTtJrIRNDF7VXio4BGHQ+SQteN/BrUVudbkuL4v7oOsRCzq4BqA==",
+      "version": "3.18.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.7.tgz",
+      "integrity": "sha512-axG9MvKhMWOhFbvf5y2DuyTxQueO0dkedY9QC3mAfndLosRI/9LJv8WaL0mw7ubNhsO4IuXX9/9dYGPFvHrqlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-stream": "^4.5.17",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17392,15 +17582,15 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
-      "integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
+      "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17510,15 +17700,15 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
-      "integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
+      "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/querystring-builder": "^4.2.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.2",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17552,14 +17742,14 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz",
-      "integrity": "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
+      "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17592,12 +17782,12 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz",
-      "integrity": "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
+      "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17610,10 +17800,9 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
-      "license": "Apache-2.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -17675,13 +17864,13 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz",
-      "integrity": "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
+      "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17694,18 +17883,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.22",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.22.tgz",
-      "integrity": "sha512-sc81w1o4Jy+/MAQlY3sQ8C7CmSpcvIi3TAzXblUv2hjG11BBSJi/Cw8vDx5BxMxapuH2I+Gc+45vWsgU07WZRQ==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.14.tgz",
+      "integrity": "sha512-v0q4uTKgBM8dsqGjqsabZQyH85nFaTnFcgpWU1uydKFsdyyMzfvOkNum9G7VK+dOP01vUnoZxIeRiJ6uD0kjIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.8",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/core": "^3.18.7",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-middleware": "^4.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17718,19 +17907,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.39",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.39.tgz",
-      "integrity": "sha512-MCVCxaCzuZgiHtHGV2Ke44nh6t4+8/tO+rTYOzrr2+G4nMLU/qbzNCWKBX54lyEaVcGQrfOJiG2f8imtiw+nIQ==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.14.tgz",
+      "integrity": "sha512-Z2DG8Ej7FyWG1UA+7HceINtSLzswUgs2np3sZX0YBBxCt+CXG4QUxv88ZDS3+2/1ldW7LqtSY1UO/6VQ1pND8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/service-error-classification": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
-        "@smithy/uuid": "^1.1.2",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/service-error-classification": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17743,13 +17932,13 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
-      "integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
+      "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17762,12 +17951,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
-      "integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
+      "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17780,14 +17969,14 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
-      "integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
+      "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17800,15 +17989,15 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
-      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
+      "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/querystring-builder": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17821,12 +18010,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
-      "integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
+      "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17839,12 +18028,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
-      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
+      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17857,13 +18046,13 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
-      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
+      "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17876,12 +18065,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
-      "integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
+      "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17895,24 +18084,24 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
-      "integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
+      "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0"
+        "@smithy/types": "^4.9.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
-      "integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
+      "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17925,18 +18114,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
-      "integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
+      "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17949,17 +18138,17 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.2.tgz",
-      "integrity": "sha512-HezY3UuG0k4T+4xhFKctLXCA5N2oN+Rtv+mmL8Gt7YmsUY2yhmcLyW75qrSzldfj75IsCW/4UhY3s20KcFnZqA==",
+      "version": "4.9.10",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.10.tgz",
+      "integrity": "sha512-Jaoz4Jw1QYHc1EFww/E6gVtNjhoDU+gwRKqXP6C3LKYqqH2UQhP8tMP3+t/ePrhaze7fhLE8vS2q6vVxBANFTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.8",
-        "@smithy/middleware-endpoint": "^4.4.22",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.17",
+        "@smithy/core": "^3.18.7",
+        "@smithy/middleware-endpoint": "^4.3.14",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17972,9 +18161,9 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
-      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
+      "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -17989,13 +18178,13 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
-      "integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
+      "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/querystring-parser": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18008,13 +18197,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "license": "Apache-2.0",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18027,10 +18215,9 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
-      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
-      "license": "Apache-2.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -18044,10 +18231,9 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
-      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
-      "license": "Apache-2.0",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -18061,12 +18247,11 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
-      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
-      "license": "Apache-2.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/is-array-buffer": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18076,14 +18261,12 @@
     "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
-      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
-      "license": "Apache-2.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -18097,14 +18280,14 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.38",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.38.tgz",
-      "integrity": "sha512-c8P1mFLNxcsdAMabB8/VUQUbWzFmgujWi4bAXSggcqLYPc8V4U5abqFqOyn+dK4YT+q8UyCVkTO8807t4t2syA==",
+      "version": "4.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.13.tgz",
+      "integrity": "sha512-hlVLdAGrVfyNei+pKIgqDTxfu/ZI2NSyqj4IDxKd5bIsIqwR/dSlkxlPaYxFiIaDVrBy0he8orsFy+Cz119XvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18117,17 +18300,17 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.41",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.41.tgz",
-      "integrity": "sha512-/UG+9MT3UZAR0fLzOtMJMfWGcjjHvgggq924x/CRy8vRbL+yFf3Z6vETlvq8vDH92+31P/1gSOFoo7303wN8WQ==",
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.16.tgz",
+      "integrity": "sha512-F1t22IUiJLHrxW9W1CQ6B9PN+skZ9cqSuzB18Eh06HrJPbjsyZ7ZHecAKw80DQtyGTRcVfeukKaCRYebFwclbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/smithy-client": "^4.12.2",
-        "@smithy/types": "^4.13.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18140,13 +18323,13 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
-      "integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
+      "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18159,10 +18342,9 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
-      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
-      "license": "Apache-2.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -18176,12 +18358,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
-      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
+      "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18194,13 +18376,13 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
-      "integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
+      "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/service-error-classification": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18213,18 +18395,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
-      "integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
+      "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18237,10 +18419,9 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-      "license": "Apache-2.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -18254,12 +18435,11 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "license": "Apache-2.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18291,10 +18471,9 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
-      "license": "Apache-2.0",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -18547,7 +18726,8 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "peer": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -18602,7 +18782,6 @@
       "version": "24.7.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.0.tgz",
       "integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -18627,7 +18806,6 @@
       "version": "18.3.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -18638,7 +18816,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -18990,7 +19167,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
       "version": "1.11.1",
@@ -19002,7 +19180,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
@@ -19014,7 +19193,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.11.1",
@@ -19026,7 +19206,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
       "version": "1.11.1",
@@ -19038,7 +19219,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.11.1",
@@ -19050,7 +19232,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.11.1",
@@ -19062,7 +19245,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
       "version": "1.11.1",
@@ -19074,7 +19258,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
       "version": "1.11.1",
@@ -19086,7 +19271,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
       "version": "1.11.1",
@@ -19098,7 +19284,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
       "version": "1.11.1",
@@ -19110,7 +19297,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
       "version": "1.11.1",
@@ -19122,7 +19310,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
       "version": "1.11.1",
@@ -19134,7 +19323,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.11.1",
@@ -19146,7 +19336,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
       "version": "1.11.1",
@@ -19158,7 +19349,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
       "version": "1.11.1",
@@ -19168,6 +19360,7 @@
         "wasm32"
       ],
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^0.2.11"
       },
@@ -19180,6 +19373,7 @@
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
@@ -19191,6 +19385,7 @@
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -19199,7 +19394,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
       "version": "1.11.1",
@@ -19211,7 +19407,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
       "version": "1.11.1",
@@ -19223,7 +19420,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.11.1",
@@ -19235,7 +19433,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -19325,6 +19524,56 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
@@ -19335,6 +19584,110 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/spy": {
@@ -19477,7 +19830,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -19516,6 +19868,7 @@
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
       "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12.0"
       }
@@ -20435,6 +20788,7 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
@@ -20869,7 +21223,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -20977,7 +21330,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/byte-size": {
       "version": "8.1.1",
@@ -21034,6 +21388,16 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cacache": {
@@ -21364,6 +21728,7 @@
       "resolved": "https://registry.npmjs.org/child-process-ext/-/child-process-ext-2.1.1.tgz",
       "integrity": "sha512-0UQ55f51JBkOFa+fvR76ywRzxiPwQS3Xe8oe5bZRphpv+dIMeerW5Zn5e4cUy4COJwVtJyU0R79RMnw+aCqmGA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^6.0.5",
         "es5-ext": "^0.10.53",
@@ -21377,6 +21742,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
       "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -21393,6 +21759,7 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -21402,6 +21769,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -21411,6 +21779,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -21423,6 +21792,7 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21432,6 +21802,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -22355,7 +22726,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
       "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
-      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -22472,6 +22842,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -22497,6 +22888,57 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -22567,8 +23009,7 @@
     "node_modules/dayjs": {
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
-      "peer": true
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -22619,6 +23060,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-uri-component": {
       "version": "0.4.1",
@@ -23355,7 +23803,6 @@
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
       "integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
@@ -23412,6 +23859,27 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -23624,6 +24092,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -23753,7 +24228,6 @@
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -23813,7 +24287,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -24521,6 +24994,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -24624,6 +25107,16 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -24826,18 +25319,6 @@
           "url": "https://opencollective.com/fastify"
         }
       ]
-    },
-    "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
@@ -25142,7 +25623,8 @@
     "node_modules/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "peer": true
     },
     "node_modules/find-up": {
       "version": "4.1.0",
@@ -25300,8 +25782,7 @@
       "version": "2.16.11",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.11.tgz",
       "integrity": "sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/fraction.js": {
       "version": "4.3.7",
@@ -26171,6 +26652,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -26178,7 +26660,8 @@
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
@@ -26190,6 +26673,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/html-escaper": {
@@ -27015,6 +27511,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -27238,6 +27741,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "dev": true,
+      "peer": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -28008,6 +28512,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.2.0.tgz",
       "integrity": "sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==",
+      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "pretty-format": "30.2.0"
@@ -28020,6 +28525,7 @@
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
       "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -28030,12 +28536,14 @@
     "node_modules/jest-leak-detector/node_modules/@sinclair/typebox": {
       "version": "0.34.41",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
-      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "peer": true
     },
     "node_modules/jest-leak-detector/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -28047,6 +28555,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
       "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
@@ -28370,6 +28879,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.2.0.tgz",
       "integrity": "sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==",
+      "peer": true,
       "dependencies": {
         "@jest/console": "30.2.0",
         "@jest/environment": "30.2.0",
@@ -28414,6 +28924,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.2.0.tgz",
       "integrity": "sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==",
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -28430,6 +28941,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
       "integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+      "peer": true,
       "dependencies": {
         "@jest/fake-timers": "30.2.0",
         "@jest/types": "30.2.0",
@@ -28444,6 +28956,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.2.0.tgz",
       "integrity": "sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==",
+      "peer": true,
       "dependencies": {
         "expect": "30.2.0",
         "jest-snapshot": "30.2.0"
@@ -28456,6 +28969,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
       "integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@sinonjs/fake-timers": "^13.0.0",
@@ -28472,6 +28986,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
       "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "30.2.0",
         "@jest/expect": "30.2.0",
@@ -28486,6 +29001,7 @@
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
       "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -28497,6 +29013,7 @@
       "version": "30.0.1",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
       "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "callsites": "^3.1.0",
@@ -28510,6 +29027,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.2.0.tgz",
       "integrity": "sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==",
+      "peer": true,
       "dependencies": {
         "@jest/console": "30.2.0",
         "@jest/types": "30.2.0",
@@ -28524,6 +29042,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.2.0.tgz",
       "integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.2.0",
@@ -28549,6 +29068,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
       "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -28566,6 +29086,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -28574,12 +29095,14 @@
     "node_modules/jest-runner/node_modules/@sinclair/typebox": {
       "version": "0.34.41",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
-      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "peer": true
     },
     "node_modules/jest-runner/node_modules/@sinonjs/fake-timers": {
       "version": "13.0.5",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
       "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
@@ -28588,6 +29111,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -28599,6 +29123,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
       "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "peer": true,
       "workspaces": [
         "test/babel-8"
       ],
@@ -28617,6 +29142,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -28625,6 +29151,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -28635,12 +29162,14 @@
     "node_modules/jest-runner/node_modules/cjs-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA=="
+      "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
+      "peer": true
     },
     "node_modules/jest-runner/node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -28660,6 +29189,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
       "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+      "peer": true,
       "dependencies": {
         "@jest/diff-sequences": "30.0.1",
         "@jest/get-type": "30.1.0",
@@ -28674,6 +29204,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.2.0.tgz",
       "integrity": "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "30.2.0",
         "@jest/fake-timers": "30.2.0",
@@ -28691,6 +29222,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.2.0.tgz",
       "integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -28714,6 +29246,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.2.0.tgz",
       "integrity": "sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
@@ -28732,6 +29265,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.2.0.tgz",
       "integrity": "sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "30.2.0",
         "@jest/fake-timers": "30.2.0",
@@ -28764,6 +29298,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.2.0.tgz",
       "integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@babel/generator": "^7.27.5",
@@ -28795,6 +29330,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.2.0.tgz",
       "integrity": "sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==",
+      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "@jest/types": "30.2.0",
@@ -28811,6 +29347,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.2.0.tgz",
       "integrity": "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg==",
+      "peer": true,
       "dependencies": {
         "@jest/test-result": "30.2.0",
         "@jest/types": "30.2.0",
@@ -28829,6 +29366,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.2.0.tgz",
       "integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
@@ -28844,6 +29382,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -28858,6 +29397,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -28872,6 +29412,7 @@
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
       "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
@@ -28885,6 +29426,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -28893,6 +29435,7 @@
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -28902,6 +29445,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -28910,6 +29454,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -29389,12 +29934,135 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsep": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -29459,6 +30127,7 @@
       "resolved": "https://registry.npmjs.org/json-colorizer/-/json-colorizer-2.2.2.tgz",
       "integrity": "sha512-56oZtwV1piXrQnRNTtJeqRv+B9Y/dXAYLqBBaYl/COcUdoZxgLBLAO88+CnkbT6MxNs0c5E9mPBIb2sFcNz3vw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "chalk": "^2.4.1",
         "lodash.get": "^4.4.2"
@@ -29469,6 +30138,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -29481,6 +30151,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -29495,6 +30166,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -29503,13 +30175,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/json-colorizer/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -29519,6 +30193,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -29815,7 +30490,16 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
       "integrity": "sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/kareem": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -30000,7 +30684,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -30835,7 +31518,6 @@
       "resolved": "https://registry.npmjs.org/log/-/log-6.3.2.tgz",
       "integrity": "sha512-ek8NRg/OPvS9ISOJNWNAz5vZcpYacWNFDWNJjj5OXsc6YuKacfey6wF04cXz/tOJIVrZ2nGSkHpAY5qKtF6ISg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "d": "^1.0.2",
         "duration": "^0.2.2",
@@ -30970,6 +31652,16 @@
       "devOptional": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -31380,10 +32072,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -31713,6 +32404,63 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "node_modules/mongoose": {
+      "version": "6.11.6",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.11.6.tgz",
+      "integrity": "sha512-CuVbeJrEbnxkPUNNFvXJhjVyqa5Ip7lkz6EJX6g7Lb3aFMTJ+LHOlUrncxzC3r20dqasaVIiwcA6Y5qC8PWQ7w==",
+      "dependencies": {
+        "bson": "^4.7.2",
+        "kareem": "2.5.1",
+        "mongodb": "4.16.0",
+        "mpath": "0.9.0",
+        "mquery": "4.0.3",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/mongodb": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
+      "integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
+      "dependencies": {
+        "bson": "^4.7.2",
+        "mongodb-connection-string-url": "^2.5.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "saslprep": "^1.0.3"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
+      "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -31878,7 +32626,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/nise": {
       "version": "5.1.9",
@@ -31941,6 +32690,7 @@
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
       "integrity": "sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "minimatch": "^3.0.2"
       },
@@ -32271,6 +33021,7 @@
       "resolved": "https://registry.npmjs.org/npm-registry-utilities/-/npm-registry-utilities-1.0.0.tgz",
       "integrity": "sha512-9xYfSJy2IFQw1i6462EJzjChL9e65EfSo2Cw6kl0EFeDp05VvU+anrQk3Fc0d1MbVCq7rWIxeer89O9SUQ/uOg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ext": "^1.6.0",
         "fs2": "^0.3.9",
@@ -32289,6 +33040,7 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "builtins": "^1.0.3"
       }
@@ -32305,13 +33057,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nx": {
       "version": "20.3.2",
       "resolved": "https://registry.npmjs.org/nx/-/nx-20.3.2.tgz",
       "integrity": "sha512-VWUHX0uCn8ACFbpBTpgucDzwe4q/a/UU3AYOhzKCvTzb3kQiyvoxLjORSze93ZNEqgor0PMkCQgcoMBUjxJfzQ==",
       "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -33392,6 +34150,32 @@
         "parse-path": "^7.0.0"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -33476,7 +34260,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path2/-/path2-0.1.0.tgz",
       "integrity": "sha512-TX+cz8Jk+ta7IvRy2FAej8rdlbrP0+uBIkP/5DTODez/AuL/vSb30KuAdDxGVREXzn8QfAiu5mJYJ1XjbOhEPA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -33715,7 +34500,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -33876,7 +34660,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.17.0",
         "@prisma/engines": "6.17.0"
@@ -34228,7 +35011,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -34240,7 +35022,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -35019,6 +35800,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -35069,6 +35857,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "peer": true,
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -35167,11 +35956,36 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
       "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -35816,6 +36630,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -35824,13 +36639,15 @@
       "version": "1.11.18",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
       "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/serverless/node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -35843,6 +36660,7 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -35855,6 +36673,7 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
       "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -35864,6 +36683,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -35878,6 +36698,7 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -35898,6 +36719,7 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -35907,6 +36729,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -35927,6 +36750,7 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -35936,6 +36760,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -35955,6 +36780,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -36121,6 +36947,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sift": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -36237,6 +37075,7 @@
       "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
       "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
@@ -36523,6 +37362,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -36530,6 +37376,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -36560,6 +37413,7 @@
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
       "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.10.0"
       }
@@ -36808,16 +37662,15 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/strong-log-transformer": {
       "version": "2.1.0",
@@ -36968,6 +37821,72 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/supertest/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest/node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -37002,6 +37921,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/synckit": {
       "version": "0.11.11",
@@ -37063,7 +37989,6 @@
       "version": "3.4.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -37158,7 +38083,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -37232,6 +38156,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/tapable": {
@@ -37387,7 +38324,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -37417,6 +38355,13 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
@@ -37428,6 +38373,16 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
       "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
       "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
     },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",
@@ -37446,6 +38401,26 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -37513,6 +38488,19 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -37523,6 +38511,7 @@
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.11.tgz",
       "integrity": "sha512-vxXDZg8/+p3gblxB6BhhG5yWVn1kGRlaL8O78UDXc3wRnPizB5g83dcvWV1jpDMIPnjZjOFuxlMmE82XJ4407w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "gopd": "^1.2.0",
         "typedarray.prototype.slice": "^1.0.5",
@@ -37621,7 +38610,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -37711,6 +38699,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37727,6 +38716,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37743,6 +38733,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37759,6 +38750,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37775,6 +38767,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37791,6 +38784,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37807,6 +38801,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37823,6 +38818,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37839,6 +38835,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37855,6 +38852,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37871,6 +38869,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37887,6 +38886,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37903,6 +38903,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37919,6 +38920,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37935,6 +38937,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37951,6 +38954,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37967,6 +38971,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37983,6 +38988,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37999,6 +39005,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38015,6 +39022,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38031,6 +39039,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38047,6 +39056,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38063,6 +39073,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38257,6 +39268,7 @@
       "resolved": "https://registry.npmjs.org/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.5.tgz",
       "integrity": "sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
@@ -38279,7 +39291,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -38702,7 +39713,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -38757,6 +39767,250 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/vitest/node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/vscode-json-languageservice": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.2.1.tgz",
@@ -38789,6 +40043,19 @@
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walk-up-path": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-3.0.1.tgz",
@@ -38816,6 +40083,43 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -38929,6 +40233,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {
@@ -39190,7 +40511,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -39205,6 +40525,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/xml2js": {
@@ -39228,6 +40558,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -39269,6 +40606,7 @@
       "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
       "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "glob": "^7.0.5"
@@ -39283,6 +40621,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -39431,6 +40770,66 @@
         "node": ">= 10"
       }
     },
+    "packages/admin-scripts": {
+      "name": "@friggframework/admin-scripts",
+      "version": "2.0.0-next.0",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-scheduler": "^3.588.0",
+        "@friggframework/core": "^2.0.0-next.0",
+        "express": "^4.18.2",
+        "serverless-http": "^3.2.0"
+      },
+      "devDependencies": {
+        "@friggframework/eslint-config": "^2.0.0-next.0",
+        "@friggframework/prettier-config": "^2.0.0-next.0",
+        "@friggframework/test": "^2.0.0-next.0",
+        "eslint": "^8.22.0",
+        "jest": "^29.7.0",
+        "prettier": "^2.7.1",
+        "supertest": "^7.1.4"
+      }
+    },
+    "packages/admin-scripts/node_modules/serverless-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.2.0.tgz",
+      "integrity": "sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "packages/ai-agents": {
+      "name": "@friggframework/ai-agents",
+      "version": "2.0.0-next.0",
+      "license": "MIT",
+      "dependencies": {
+        "@friggframework/schemas": "^2.0.0-next.0"
+      },
+      "devDependencies": {
+        "@friggframework/eslint-config": "^2.0.0-next.0",
+        "@friggframework/prettier-config": "^2.0.0-next.0",
+        "eslint": "^8.22.0",
+        "jest": "^29.7.0",
+        "prettier": "^2.7.1"
+      },
+      "peerDependencies": {
+        "@ai-sdk/openai": ">=1.0.0",
+        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
+        "ai": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/openai": {
+          "optional": true
+        },
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        }
+      }
+    },
     "packages/core": {
       "name": "@friggframework/core",
       "version": "2.0.0-next.0",
@@ -39439,7 +40838,6 @@
         "@aws-sdk/client-apigatewaymanagementapi": "^3.588.0",
         "@aws-sdk/client-kms": "^3.588.0",
         "@aws-sdk/client-lambda": "^3.714.0",
-        "@aws-sdk/client-scheduler": "^3.1002.0",
         "@aws-sdk/client-sqs": "^3.588.0",
         "@hapi/boom": "^10.0.1",
         "bcryptjs": "^2.4.3",
@@ -39452,9 +40850,10 @@
         "express-async-handler": "^1.2.0",
         "form-data": "^4.0.0",
         "fs-extra": "^11.2.0",
+        "js-yaml": "^4.1.0",
         "lodash": "4.17.21",
         "lodash.get": "^4.4.2",
-        "mongodb": "^4.17.0",
+        "mongoose": "6.11.6",
         "node-fetch": "^2.6.7",
         "serverless-http": "^2.7.0",
         "uuid": "^9.0.1"
@@ -39475,6 +40874,7 @@
         "prettier": "^2.7.1",
         "prisma": "^6.17.0",
         "sinon": "^16.1.1",
+        "supertest": "^7.1.4",
         "typescript": "^5.0.2"
       },
       "peerDependencies": {
@@ -39563,6 +40963,7 @@
         "@friggframework/prettier-config": "^2.0.0-next.0",
         "aws-sdk-client-mock": "^4.1.0",
         "aws-sdk-client-mock-jest": "^4.1.0",
+        "exit-x": "^0.2.2",
         "jest": "^30.1.3",
         "osls": "^3.40.1",
         "prettier": "^2.7.1",
@@ -40729,6 +42130,71 @@
         "node": ">=12"
       }
     },
+    "packages/e2e": {
+      "name": "@friggframework/e2e",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@friggframework/core": "*"
+      },
+      "devDependencies": {
+        "@friggframework/test": "*",
+        "jest": "^29.7.0",
+        "mongodb-memory-server": "^8.9.0",
+        "supertest": "^6.3.3"
+      }
+    },
+    "packages/e2e/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "packages/e2e/node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "packages/e2e/node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
     "packages/eslint-config": {
       "name": "@friggframework/eslint-config",
       "version": "2.0.0-next.0",
@@ -40811,12 +42277,14 @@
       "license": "MIT",
       "dependencies": {
         "@babel/eslint-parser": "^7.18.9",
+        "@hapi/boom": "^10.0.1",
         "eslint": "^8.22.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-json": "^3.1.0",
         "eslint-plugin-markdown": "^3.0.0",
         "eslint-plugin-no-only-tests": "^3.0.0",
         "eslint-plugin-yaml": "^0.5.0",
+        "express": "^4.21.2",
         "jest-runner-groups": "^2.2.0",
         "mongodb-memory-server": "^8.9.0",
         "open": "^8.4.2"
@@ -40825,7 +42293,67 @@
         "@friggframework/eslint-config": "^2.0.0-next.0",
         "@friggframework/prettier-config": "^2.0.0-next.0",
         "jest": "^29.7.0",
-        "prettier": "^2.7.1"
+        "prettier": "^2.7.1",
+        "supertest": "^6.3.3"
+      },
+      "peerDependencies": {
+        "supertest": ">=6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "supertest": {
+          "optional": true
+        }
+      }
+    },
+    "packages/test/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "packages/test/node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "packages/test/node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "packages/ui": {
@@ -40858,9 +42386,11 @@
         "eslint-plugin-react": "^7.34.3",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.7",
+        "jsdom": "^25.0.0",
         "postcss": "^8.4.41",
         "tailwindcss": "^3.4.10",
-        "vite": "^5.3.4"
+        "vite": "^5.3.4",
+        "vitest": "^2.1.0"
       }
     },
     "packages/ui/node_modules/node-fetch": {

--- a/packages/devtools/jest.config.js
+++ b/packages/devtools/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  projects: [
+    '<rootDir>/frigg-cli/jest.config.js',
+    '<rootDir>/infrastructure/jest.config.js',
+  ],
+};

--- a/packages/e2e/__tests__/edge-cases/error-scenarios.test.js
+++ b/packages/e2e/__tests__/edge-cases/error-scenarios.test.js
@@ -1,0 +1,204 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('Error Scenarios', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('Authentication Errors', () => {
+        it('should return 401 for missing authorization header', async () => {
+            const res = await request(app).get('/api/integrations');
+            expect(res.status).toBe(401);
+        });
+
+        it('should return 401 for invalid token format', async () => {
+            const res = await request(app)
+                .get('/api/integrations')
+                .set('Authorization', 'InvalidFormat');
+            expect(res.status).toBe(401);
+        });
+
+        it('should return 401 for nonexistent user token', async () => {
+            const res = await request(app)
+                .get('/api/integrations')
+                .set('Authorization', 'Bearer nonexistent-user-id');
+            expect(res.status).toBe(401);
+        });
+    });
+
+    describe('Authorization Errors', () => {
+        it('should reject unknown entity type', async () => {
+            const { userId, token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/authorize')
+                .query({ entityType: 'unknown-entity-type' })
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(400);
+        });
+
+        it('should reject authorization without entity type', async () => {
+            const { userId, token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('Integration Errors', () => {
+        it('should reject creating integration without entities', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entities: [],
+                    config: { type: 'oauth-integration' },
+                });
+
+            expect(res.status).toBe(400);
+        });
+
+        it('should reject creating integration with nonexistent entity', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entities: ['nonexistent-entity-id'],
+                    config: { type: 'oauth-integration' },
+                });
+
+            expect(res.status).toBe(400);
+        });
+
+        it('should reject creating integration without config type', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entities: [entityId],
+                    config: {},
+                });
+
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('Resource Not Found', () => {
+        it('should return 404 for nonexistent integration', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/integrations/507f1f77bcf86cd799439011')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+
+        it('should return 404 for nonexistent entity', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/entities/507f1f77bcf86cd799439011')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('Malformed Requests', () => {
+        it('should handle malformed JSON body gracefully', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${token}`)
+                .set('Content-Type', 'application/json')
+                .send('{invalid json}');
+
+            expect(res.status).toBe(400);
+        });
+
+        it('should handle empty body gracefully', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .patch(`/api/integrations/${entityId}`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({});
+
+            expect([200, 400]).toContain(res.status);
+        });
+    });
+
+    describe('Concurrent Operations', () => {
+        it('should handle concurrent entity creation', async () => {
+            const { userId, token } = await fixture.createUser();
+
+            const promises = Array(5).fill(null).map(() =>
+                request(app)
+                    .post('/api/authorize')
+                    .set('Authorization', `Bearer ${token}`)
+                    .send({
+                        entityType: 'oauth2-mock',
+                        data: { code: `code-${Date.now()}-${Math.random()}` },
+                    })
+            );
+
+            const results = await Promise.all(promises);
+            results.forEach((res) => {
+                expect(res.status).toBe(200);
+            });
+        });
+
+        it('should handle concurrent integration creation', async () => {
+            const { userId, token } = await fixture.createUser();
+
+            const entities = await Promise.all(
+                Array(3).fill(null).map(() => fixture.createOAuthEntity(userId))
+            );
+
+            const promises = entities.map(({ entityId }) =>
+                request(app)
+                    .post('/api/integrations')
+                    .set('Authorization', `Bearer ${token}`)
+                    .send({
+                        entities: [entityId],
+                        config: { type: 'oauth-integration' },
+                    })
+            );
+
+            const results = await Promise.all(promises);
+            results.forEach((res) => {
+                expect(res.status).toBe(201);
+            });
+        });
+    });
+});

--- a/packages/e2e/__tests__/edge-cases/user-scenarios.test.js
+++ b/packages/e2e/__tests__/edge-cases/user-scenarios.test.js
@@ -1,0 +1,143 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('User Scenarios', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('User Creation', () => {
+        it('should create a new user', async () => {
+            const res = await request(app)
+                .post('/user/create')
+                .send({
+                    username: `newuser-${Date.now()}@example.com`,
+                    password: 'securepass123',
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('user');
+            expect(res.body.user).toHaveProperty('id');
+        });
+
+        it('should reject duplicate username', async () => {
+            const username = `duplicate-${Date.now()}@example.com`;
+
+            await request(app)
+                .post('/user/create')
+                .send({ username, password: 'password123' });
+
+            const res = await request(app)
+                .post('/user/create')
+                .send({ username, password: 'password456' });
+
+            expect(res.status).toBe(400);
+        });
+
+        it('should reject missing username', async () => {
+            const res = await request(app)
+                .post('/user/create')
+                .send({ password: 'password123' });
+
+            expect(res.status).toBe(400);
+        });
+
+        it('should reject missing password', async () => {
+            const res = await request(app)
+                .post('/user/create')
+                .send({ username: 'test@example.com' });
+
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('User Login', () => {
+        it('should login with correct credentials', async () => {
+            const username = `login-${Date.now()}@example.com`;
+            const password = 'correctpassword';
+
+            await request(app)
+                .post('/user/create')
+                .send({ username, password });
+
+            const res = await request(app)
+                .post('/user/login')
+                .send({ username, password });
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('token');
+        });
+
+        it('should reject incorrect password', async () => {
+            const username = `wrongpass-${Date.now()}@example.com`;
+
+            await request(app)
+                .post('/user/create')
+                .send({ username, password: 'correctpassword' });
+
+            const res = await request(app)
+                .post('/user/login')
+                .send({ username, password: 'wrongpassword' });
+
+            expect(res.status).toBe(401);
+        });
+
+        it('should reject nonexistent user', async () => {
+            const res = await request(app)
+                .post('/user/login')
+                .send({
+                    username: 'nonexistent@example.com',
+                    password: 'anypassword',
+                });
+
+            expect(res.status).toBe(401);
+        });
+    });
+
+    describe('User Session', () => {
+        it('should maintain user context across requests', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const getEntitiesRes = await request(app)
+                .get('/api/entities')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(getEntitiesRes.status).toBe(200);
+            expect(getEntitiesRes.body.entities.some((e) => e.id === entityId)).toBe(true);
+        });
+
+        it('should isolate user data between users', async () => {
+            const { userId: user1Id, token: token1 } = await fixture.createUser();
+            const { token: token2 } = await fixture.createUser();
+
+            await fixture.createOAuthEntity(user1Id);
+
+            const user1Entities = await request(app)
+                .get('/api/entities')
+                .set('Authorization', `Bearer ${token1}`);
+
+            const user2Entities = await request(app)
+                .get('/api/entities')
+                .set('Authorization', `Bearer ${token2}`);
+
+            expect(user1Entities.body.entities.length).toBeGreaterThan(0);
+            expect(user2Entities.body.entities).toHaveLength(0);
+        });
+    });
+});

--- a/packages/e2e/__tests__/helpers/db-cleanup.js
+++ b/packages/e2e/__tests__/helpers/db-cleanup.js
@@ -1,0 +1,46 @@
+const mongoose = require('mongoose');
+
+async function cleanupDatabase() {
+    if (!mongoose.connection || mongoose.connection.readyState !== 1) {
+        return;
+    }
+
+    const collections = mongoose.connection.collections;
+    const promises = Object.values(collections).map((collection) =>
+        collection.deleteMany({})
+    );
+
+    await Promise.all(promises);
+}
+
+async function cleanupCollection(collectionName) {
+    if (!mongoose.connection || mongoose.connection.readyState !== 1) {
+        return;
+    }
+
+    const collection = mongoose.connection.collections[collectionName];
+    if (collection) {
+        await collection.deleteMany({});
+    }
+}
+
+async function getCollectionCounts() {
+    if (!mongoose.connection || mongoose.connection.readyState !== 1) {
+        return {};
+    }
+
+    const collections = mongoose.connection.collections;
+    const counts = {};
+
+    for (const [name, collection] of Object.entries(collections)) {
+        counts[name] = await collection.countDocuments();
+    }
+
+    return counts;
+}
+
+module.exports = {
+    cleanupDatabase,
+    cleanupCollection,
+    getCollectionCounts,
+};

--- a/packages/e2e/__tests__/helpers/fixtures.js
+++ b/packages/e2e/__tests__/helpers/fixtures.js
@@ -1,0 +1,161 @@
+const request = require('supertest');
+
+class TestFixture {
+    constructor(app) {
+        this.app = app;
+        this.createdUsers = [];
+        this.createdEntities = [];
+        this.createdIntegrations = [];
+    }
+
+    async createUser(overrides = {}) {
+        const timestamp = Date.now();
+        const defaults = {
+            username: `testuser-${timestamp}@example.com`,
+            password: 'testpass123',
+        };
+
+        const userData = { ...defaults, ...overrides };
+
+        const res = await request(this.app)
+            .post('/user/create')
+            .send(userData);
+
+        if (res.body.user?.id) {
+            this.createdUsers.push(res.body.user.id);
+        }
+
+        return {
+            userId: res.body.user?.id,
+            token: res.body.token,
+            response: res,
+        };
+    }
+
+    async authenticateEntity(userId, entityType, authData) {
+        const res = await request(this.app)
+            .post('/api/authorize')
+            .set('Authorization', `Bearer ${userId}`)
+            .send({ entityType, data: authData });
+
+        if (res.body.entity?.id) {
+            this.createdEntities.push(res.body.entity.id);
+        }
+
+        return {
+            entityId: res.body.entity?.id,
+            entity: res.body.entity,
+            response: res,
+        };
+    }
+
+    async createOAuthEntity(userId) {
+        return this.authenticateEntity(userId, 'oauth2-mock', {
+            code: `mock-code-${Date.now()}`,
+        });
+    }
+
+    async createFormBasedEntity(userId) {
+        const step1Res = await request(this.app)
+            .post('/api/authorize')
+            .set('Authorization', `Bearer ${userId}`)
+            .send({
+                entityType: 'form-based-mock',
+                data: { apiKey: `api-key-${Date.now()}` },
+                step: 1,
+            });
+
+        const sessionId = step1Res.body.sessionId;
+
+        const step2Res = await request(this.app)
+            .post('/api/authorize')
+            .set('Authorization', `Bearer ${userId}`)
+            .send({
+                entityType: 'form-based-mock',
+                data: { workspaceId: `workspace-${Date.now()}` },
+                step: 2,
+                sessionId,
+            });
+
+        if (step2Res.body.entity?.id) {
+            this.createdEntities.push(step2Res.body.entity.id);
+        }
+
+        return {
+            entityId: step2Res.body.entity?.id,
+            entity: step2Res.body.entity,
+            response: step2Res,
+        };
+    }
+
+    async createWebhookEntity(userId) {
+        return this.authenticateEntity(userId, 'webhook-mock', {
+            apiKey: `webhook-key-${Date.now()}`,
+        });
+    }
+
+    async createIntegration(userId, entityId, integrationType) {
+        const res = await request(this.app)
+            .post('/api/integrations')
+            .set('Authorization', `Bearer ${userId}`)
+            .send({
+                entities: [entityId],
+                config: { type: integrationType },
+            });
+
+        if (res.body.id) {
+            this.createdIntegrations.push(res.body.id);
+        }
+
+        return {
+            integrationId: res.body.id,
+            integration: res.body,
+            response: res,
+        };
+    }
+
+    async createOAuthIntegration(userId) {
+        const { entityId } = await this.createOAuthEntity(userId);
+        return this.createIntegration(userId, entityId, 'oauth-integration');
+    }
+
+    async createFormBasedIntegration(userId) {
+        const { entityId } = await this.createFormBasedEntity(userId);
+        return this.createIntegration(userId, entityId, 'form-based-integration');
+    }
+
+    async createWebhookIntegration(userId) {
+        const { entityId } = await this.createWebhookEntity(userId);
+        return this.createIntegration(userId, entityId, 'webhook-integration');
+    }
+
+    async createFullOAuthSetup() {
+        const { userId, token } = await this.createUser();
+        const { entityId } = await this.createOAuthEntity(userId);
+        const { integrationId } = await this.createIntegration(
+            userId,
+            entityId,
+            'oauth-integration'
+        );
+
+        return { userId, token, entityId, integrationId };
+    }
+
+    async createFullWebhookSetup() {
+        const { userId, token } = await this.createUser();
+        const { entityId } = await this.createWebhookEntity(userId);
+        const { integrationId } = await this.createIntegration(
+            userId,
+            entityId,
+            'webhook-integration'
+        );
+
+        return { userId, token, entityId, integrationId };
+    }
+}
+
+function createFixture(app) {
+    return new TestFixture(app);
+}
+
+module.exports = { TestFixture, createFixture };

--- a/packages/e2e/__tests__/helpers/setup.js
+++ b/packages/e2e/__tests__/helpers/setup.js
@@ -1,0 +1,21 @@
+const { TestMongo } = require('@friggframework/test');
+const { cleanupDatabase } = require('./db-cleanup');
+
+let mongoServer;
+
+beforeAll(async () => {
+    mongoServer = new TestMongo();
+    await mongoServer.start();
+    process.env.STAGE = 'test';
+    process.env.HEALTH_API_KEY = 'test-key';
+});
+
+afterEach(async () => {
+    await cleanupDatabase();
+});
+
+afterAll(async () => {
+    if (mongoServer) {
+        await mongoServer.stop();
+    }
+});

--- a/packages/e2e/__tests__/helpers/test-server.js
+++ b/packages/e2e/__tests__/helpers/test-server.js
@@ -1,0 +1,95 @@
+const path = require('path');
+
+class TestServer {
+    constructor() {
+        this.app = null;
+        this.server = null;
+        this.port = null;
+        this.originalCwd = null;
+        this.isStarted = false;
+    }
+
+    async start() {
+        if (this.isStarted) {
+            throw new Error('TestServer is already started');
+        }
+
+        this.originalCwd = process.cwd();
+        const testAppPath = path.resolve(__dirname, '../../test-app');
+        process.chdir(testAppPath);
+
+        const express = require('express');
+        const bodyParser = require('body-parser');
+        const cors = require('cors');
+        const Boom = require('@hapi/boom');
+
+        const { createIntegrationRouter } = require('@friggframework/core');
+        const loadUserManager = require('@friggframework/core/handlers/routers/middleware/loadUser');
+        const { router: healthRouter } = require('@friggframework/core/handlers/routers/health');
+        const { router: userRouter } = require('@friggframework/core/handlers/routers/user');
+
+        this.app = express();
+
+        this.app.use(bodyParser.json({ limit: '10mb' }));
+        this.app.use(bodyParser.urlencoded({ extended: true }));
+        this.app.use(cors({ origin: '*', credentials: true }));
+        this.app.use(loadUserManager);
+
+        this.app.use(healthRouter);
+        this.app.use(userRouter);
+        this.app.use('/api', createIntegrationRouter());
+
+        this.app.use((err, req, res, next) => {
+            const boomError = err.isBoom ? err : Boom.boomify(err);
+            const { output: { statusCode = 500 } } = boomError;
+            if (statusCode >= 500) {
+                console.error(err);
+                res.status(statusCode).json({ error: 'Internal Server Error' });
+            } else {
+                res.status(statusCode).json({ error: err.message });
+            }
+        });
+
+        return new Promise((resolve, reject) => {
+            this.server = this.app.listen(0, () => {
+                this.port = this.server.address().port;
+                this.isStarted = true;
+                resolve();
+            });
+
+            this.server.on('error', (err) => {
+                reject(err);
+            });
+        });
+    }
+
+    async stop() {
+        if (!this.isStarted) {
+            return;
+        }
+
+        if (this.server) {
+            await new Promise((resolve) => this.server.close(resolve));
+            this.server = null;
+        }
+
+        if (this.originalCwd) {
+            process.chdir(this.originalCwd);
+            this.originalCwd = null;
+        }
+
+        this.isStarted = false;
+        this.app = null;
+        this.port = null;
+    }
+
+    getBaseUrl() {
+        return `http://localhost:${this.port}`;
+    }
+
+    getApp() {
+        return this.app;
+    }
+}
+
+module.exports = { TestServer };

--- a/packages/e2e/__tests__/lifecycle/form-auth-flow.test.js
+++ b/packages/e2e/__tests__/lifecycle/form-auth-flow.test.js
@@ -1,0 +1,146 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('Form-Based Authentication Lifecycle', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('Step 1: API Key Form', () => {
+        it('should get form fields for step 1', async () => {
+            const { userId } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/authorize')
+                .query({ entityType: 'form-based-mock', step: 1 })
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('type', 'form');
+            expect(res.body).toHaveProperty('fields');
+            expect(res.body.fields).toContainEqual(
+                expect.objectContaining({ name: 'apiKey', type: 'password' })
+            );
+        });
+
+        it('should process step 1 and return next step info', async () => {
+            const { userId } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'form-based-mock',
+                    data: { apiKey: 'valid-api-key-123456' },
+                    step: 1,
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('nextStep', 2);
+        });
+
+        it('should reject invalid API key', async () => {
+            const { userId } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'form-based-mock',
+                    data: { apiKey: 'bad' },
+                    step: 1,
+                });
+
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('Step 2: Workspace Selection', () => {
+        it('should get form fields for step 2 after step 1 completes', async () => {
+            const { userId } = await fixture.createUser();
+
+            const step1Res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'form-based-mock',
+                    data: { apiKey: 'valid-api-key-123456' },
+                    step: 1,
+                });
+
+            const sessionId = step1Res.body.sessionId;
+
+            const step2FieldsRes = await request(app)
+                .get('/api/authorize')
+                .query({ entityType: 'form-based-mock', step: 2, sessionId })
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(step2FieldsRes.status).toBe(200);
+            expect(step2FieldsRes.body).toHaveProperty('fields');
+            expect(step2FieldsRes.body.fields).toContainEqual(
+                expect.objectContaining({ name: 'workspaceId' })
+            );
+        });
+    });
+
+    describe('Complete Multi-Step Flow', () => {
+        it('should complete full multi-step auth flow', async () => {
+            const { userId } = await fixture.createUser();
+
+            const step1Res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'form-based-mock',
+                    data: { apiKey: 'complete-flow-key' },
+                    step: 1,
+                });
+            expect(step1Res.status).toBe(200);
+            const sessionId = step1Res.body.sessionId;
+
+            const step2Res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'form-based-mock',
+                    data: { workspaceId: 'workspace-123' },
+                    step: 2,
+                    sessionId,
+                });
+            expect(step2Res.status).toBe(200);
+            expect(step2Res.body).toHaveProperty('entity');
+            expect(step2Res.body.entity).toHaveProperty('id');
+        });
+
+        it('should create integration after completing form auth', async () => {
+            const { userId } = await fixture.createUser();
+            const { entityId } = await fixture.createFormBasedEntity(userId);
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entities: [entityId],
+                    config: { type: 'form-based-integration' },
+                });
+
+            expect(res.status).toBe(201);
+            expect(res.body).toHaveProperty('id');
+        });
+    });
+});

--- a/packages/e2e/__tests__/lifecycle/oauth-flow.test.js
+++ b/packages/e2e/__tests__/lifecycle/oauth-flow.test.js
@@ -1,0 +1,149 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('OAuth Integration Lifecycle', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('Authorization Requirements', () => {
+        it('should get authorization requirements for oauth module', async () => {
+            const { userId } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/authorize')
+                .query({ entityType: 'oauth2-mock' })
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('type', 'oauth2');
+            expect(res.body).toHaveProperty('url');
+        });
+    });
+
+    describe('Entity Creation', () => {
+        it('should create entity after successful oauth callback', async () => {
+            const { userId } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'oauth2-mock',
+                    data: { code: 'mock-auth-code' },
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('entity');
+            expect(res.body.entity).toHaveProperty('id');
+        });
+    });
+
+    describe('Integration Creation', () => {
+        it('should create integration with valid entity', async () => {
+            const { userId } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entities: [entityId],
+                    config: { type: 'oauth-integration' },
+                });
+
+            expect(res.status).toBe(201);
+            expect(res.body).toHaveProperty('id');
+        });
+    });
+
+    describe('Integration Auth Test', () => {
+        it('should test integration auth successfully', async () => {
+            const { userId, integrationId } = await fixture.createFullOAuthSetup();
+
+            const res = await request(app)
+                .get(`/api/integrations/${integrationId}/test-auth`)
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('status', 'ok');
+        });
+    });
+
+    describe('Integration Deletion', () => {
+        it('should delete integration', async () => {
+            const { userId, integrationId } = await fixture.createFullOAuthSetup();
+
+            const res = await request(app)
+                .delete(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(204);
+        });
+
+        it('should return 404 after deletion', async () => {
+            const { userId, integrationId } = await fixture.createFullOAuthSetup();
+
+            await request(app)
+                .delete(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${userId}`);
+
+            const res = await request(app)
+                .get(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${userId}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('Complete OAuth Flow', () => {
+        it('should complete full lifecycle: authorize -> create -> test -> delete', async () => {
+            const { userId } = await fixture.createUser();
+
+            const authRes = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'oauth2-mock',
+                    data: { code: 'full-flow-code' },
+                });
+            expect(authRes.status).toBe(200);
+            const entityId = authRes.body.entity.id;
+
+            const createRes = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entities: [entityId],
+                    config: { type: 'oauth-integration' },
+                });
+            expect(createRes.status).toBe(201);
+            const integrationId = createRes.body.id;
+
+            const testRes = await request(app)
+                .get(`/api/integrations/${integrationId}/test-auth`)
+                .set('Authorization', `Bearer ${userId}`);
+            expect(testRes.status).toBe(200);
+
+            const deleteRes = await request(app)
+                .delete(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${userId}`);
+            expect(deleteRes.status).toBe(204);
+        });
+    });
+});

--- a/packages/e2e/__tests__/lifecycle/webhook-flow.test.js
+++ b/packages/e2e/__tests__/lifecycle/webhook-flow.test.js
@@ -1,0 +1,169 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('Webhook Integration Lifecycle', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('Webhook Entity Creation', () => {
+        it('should create webhook entity with API key', async () => {
+            const { userId } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entityType: 'webhook-mock',
+                    data: { apiKey: 'webhook-api-key' },
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('entity');
+            expect(res.body.entity).toHaveProperty('id');
+        });
+    });
+
+    describe('Webhook Integration Creation', () => {
+        it('should create webhook integration', async () => {
+            const { userId } = await fixture.createUser();
+            const { entityId } = await fixture.createWebhookEntity(userId);
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${userId}`)
+                .send({
+                    entities: [entityId],
+                    config: { type: 'webhook-integration' },
+                });
+
+            expect(res.status).toBe(201);
+            expect(res.body).toHaveProperty('id');
+        });
+    });
+
+    describe('Webhook Signature Validation', () => {
+        it('should receive webhook and validate signature', async () => {
+            const { userId, integrationId } = await fixture.createFullWebhookSetup();
+            const payload = {
+                event: 'item.created',
+                data: { id: '123', name: 'Test Item' },
+            };
+
+            const res = await request(app)
+                .post(`/api/webhook-integration/webhooks/${integrationId}`)
+                .set('X-Webhook-Signature', 'valid-signature')
+                .send(payload);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('received', true);
+        });
+
+        it('should reject webhook with invalid signature', async () => {
+            const { integrationId } = await fixture.createFullWebhookSetup();
+            const payload = {
+                event: 'item.created',
+                data: { id: '123' },
+            };
+
+            const res = await request(app)
+                .post(`/api/webhook-integration/webhooks/${integrationId}`)
+                .set('X-Webhook-Signature', 'invalid-signature')
+                .send(payload);
+
+            expect(res.status).toBe(401);
+        });
+
+        it('should reject webhook with missing signature', async () => {
+            const { integrationId } = await fixture.createFullWebhookSetup();
+            const payload = {
+                event: 'item.created',
+                data: { id: '123' },
+            };
+
+            const res = await request(app)
+                .post(`/api/webhook-integration/webhooks/${integrationId}`)
+                .send(payload);
+
+            expect(res.status).toBe(401);
+        });
+    });
+
+    describe('Webhook Event Processing', () => {
+        it('should process item.created event', async () => {
+            const { integrationId } = await fixture.createFullWebhookSetup();
+            const payload = {
+                event: 'item.created',
+                data: { id: '456', name: 'New Item' },
+            };
+
+            const res = await request(app)
+                .post(`/api/webhook-integration/webhooks/${integrationId}`)
+                .set('X-Webhook-Signature', 'valid-signature')
+                .send(payload);
+
+            expect(res.status).toBe(200);
+        });
+
+        it('should process item.updated event', async () => {
+            const { integrationId } = await fixture.createFullWebhookSetup();
+            const payload = {
+                event: 'item.updated',
+                data: { id: '456', name: 'Updated Item' },
+            };
+
+            const res = await request(app)
+                .post(`/api/webhook-integration/webhooks/${integrationId}`)
+                .set('X-Webhook-Signature', 'valid-signature')
+                .send(payload);
+
+            expect(res.status).toBe(200);
+        });
+
+        it('should process item.deleted event', async () => {
+            const { integrationId } = await fixture.createFullWebhookSetup();
+            const payload = {
+                event: 'item.deleted',
+                data: { id: '456' },
+            };
+
+            const res = await request(app)
+                .post(`/api/webhook-integration/webhooks/${integrationId}`)
+                .set('X-Webhook-Signature', 'valid-signature')
+                .send(payload);
+
+            expect(res.status).toBe(200);
+        });
+    });
+
+    describe('Invalid Integration Webhook', () => {
+        it('should return 404 for nonexistent integration', async () => {
+            const payload = {
+                event: 'item.created',
+                data: { id: '123' },
+            };
+
+            const res = await request(app)
+                .post('/api/webhook-integration/webhooks/nonexistent-id')
+                .set('X-Webhook-Signature', 'valid-signature')
+                .send(payload);
+
+            expect(res.status).toBe(404);
+        });
+    });
+});

--- a/packages/e2e/__tests__/management-api/entities.test.js
+++ b/packages/e2e/__tests__/management-api/entities.test.js
@@ -1,0 +1,182 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('Management API - Entities', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('GET /api/entities', () => {
+        it('should require authentication', async () => {
+            const res = await request(app).get('/api/entities');
+            expect(res.status).toBe(401);
+        });
+
+        it('should return empty list for new user', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/entities')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('entities');
+            expect(res.body.entities).toHaveLength(0);
+        });
+
+        it('should return entities for user with existing entities', async () => {
+            const { userId, token } = await fixture.createUser();
+            await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .get('/api/entities')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body.entities.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('GET /api/entities/:id', () => {
+        it('should return entity details', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .get(`/api/entities/${entityId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('id', entityId);
+        });
+
+        it('should return 404 for nonexistent entity', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/entities/nonexistent-id')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+
+        it('should not allow access to other user entities', async () => {
+            const { userId: user1Id } = await fixture.createUser();
+            const { token: user2Token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(user1Id);
+
+            const res = await request(app)
+                .get(`/api/entities/${entityId}`)
+                .set('Authorization', `Bearer ${user2Token}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('GET /api/entities/:id/test-auth', () => {
+        it('should test entity authentication', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .get(`/api/entities/${entityId}/test-auth`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('status', 'ok');
+        });
+
+        it('should return 404 for nonexistent entity', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/entities/nonexistent-id/test-auth')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('DELETE /api/entities/:id', () => {
+        it('should delete entity', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .delete(`/api/entities/${entityId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(204);
+        });
+
+        it('should return 404 after deletion', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            await request(app)
+                .delete(`/api/entities/${entityId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            const res = await request(app)
+                .get(`/api/entities/${entityId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('Entity Types', () => {
+        it('should support oauth2-mock entity type', async () => {
+            const { userId, token } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entityType: 'oauth2-mock',
+                    data: { code: 'test-code' },
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body.entity).toHaveProperty('type', 'oauth2-mock');
+        });
+
+        it('should support form-based-mock entity type', async () => {
+            const { userId } = await fixture.createUser();
+            const { entity, response } = await fixture.createFormBasedEntity(userId);
+
+            expect(response.status).toBe(200);
+            expect(entity).toHaveProperty('type', 'form-based-mock');
+        });
+
+        it('should support webhook-mock entity type', async () => {
+            const { userId, token } = await fixture.createUser();
+
+            const res = await request(app)
+                .post('/api/authorize')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entityType: 'webhook-mock',
+                    data: { apiKey: 'test-key' },
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body.entity).toHaveProperty('type', 'webhook-mock');
+        });
+    });
+});

--- a/packages/e2e/__tests__/management-api/health.test.js
+++ b/packages/e2e/__tests__/management-api/health.test.js
@@ -1,0 +1,78 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+
+describe('Management API - Health Checks', () => {
+    let server;
+    let app;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    describe('GET /health', () => {
+        it('should return basic health status', async () => {
+            const res = await request(app).get('/health');
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('status', 'ok');
+            expect(res.body).toHaveProperty('timestamp');
+        });
+    });
+
+    describe('GET /health/live', () => {
+        it('should require API key for liveness check', async () => {
+            const res = await request(app).get('/health/live');
+            expect(res.status).toBe(401);
+        });
+
+        it('should return liveness status with valid API key', async () => {
+            const res = await request(app)
+                .get('/health/live')
+                .set('x-frigg-health-api-key', process.env.HEALTH_API_KEY || 'test-key');
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('status', 'alive');
+        });
+    });
+
+    describe('GET /health/ready', () => {
+        it('should return readiness response with checks', async () => {
+            const res = await request(app)
+                .get('/health/ready')
+                .set('x-frigg-health-api-key', process.env.HEALTH_API_KEY || 'test-key');
+
+            expect([200, 503]).toContain(res.status);
+            expect(res.body).toHaveProperty('ready');
+            expect(res.body).toHaveProperty('checks');
+        });
+
+        it('should require API key', async () => {
+            const res = await request(app).get('/health/ready');
+            expect(res.status).toBe(401);
+        });
+    });
+
+    describe('GET /health/detailed', () => {
+        it('should return detailed health information', async () => {
+            const res = await request(app)
+                .get('/health/detailed')
+                .set('x-frigg-health-api-key', process.env.HEALTH_API_KEY || 'test-key');
+
+            expect([200, 503]).toContain(res.status);
+            expect(res.body).toHaveProperty('status');
+            expect(res.body).toHaveProperty('checks');
+            expect(res.body.checks).toHaveProperty('database');
+        });
+
+        it('should require API key', async () => {
+            const res = await request(app).get('/health/detailed');
+            expect(res.status).toBe(401);
+        });
+    });
+});

--- a/packages/e2e/__tests__/management-api/integrations.test.js
+++ b/packages/e2e/__tests__/management-api/integrations.test.js
@@ -1,0 +1,227 @@
+const request = require('supertest');
+const { TestServer } = require('../helpers/test-server');
+const { createFixture } = require('../helpers/fixtures');
+
+describe('Management API - Integrations', () => {
+    let server;
+    let app;
+    let fixture;
+
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.start();
+        app = server.getApp();
+    });
+
+    afterAll(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        fixture = createFixture(app);
+    });
+
+    describe('GET /api/integrations/options', () => {
+        it('should return available integration types', async () => {
+            const res = await request(app).get('/api/integrations/options');
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('integrations');
+            expect(Array.isArray(res.body.integrations)).toBe(true);
+        });
+
+        it('should include oauth, form-based, and webhook integrations', async () => {
+            const res = await request(app).get('/api/integrations/options');
+
+            const names = res.body.integrations.map((i) => i.name);
+            expect(names).toContain('oauth-integration');
+            expect(names).toContain('form-based-integration');
+            expect(names).toContain('webhook-integration');
+        });
+    });
+
+    describe('GET /api/integrations', () => {
+        it('should require authentication', async () => {
+            const res = await request(app).get('/api/integrations');
+            expect(res.status).toBe(401);
+        });
+
+        it('should return empty list for new user', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/integrations')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('integrations');
+            expect(res.body.integrations).toHaveLength(0);
+        });
+
+        it('should return integrations for user with existing integrations', async () => {
+            const { userId, token } = await fixture.createUser();
+            await fixture.createOAuthIntegration(userId);
+
+            const res = await request(app)
+                .get('/api/integrations')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body.integrations.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('POST /api/integrations', () => {
+        it('should require authentication', async () => {
+            const res = await request(app)
+                .post('/api/integrations')
+                .send({ entities: ['some-id'], config: { type: 'oauth-integration' } });
+
+            expect(res.status).toBe(401);
+        });
+
+        it('should create integration with valid entity', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entities: [entityId],
+                    config: { type: 'oauth-integration' },
+                });
+
+            expect(res.status).toBe(201);
+            expect(res.body).toHaveProperty('id');
+            expect(res.body).toHaveProperty('status');
+        });
+
+        it('should reject invalid integration type', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { entityId } = await fixture.createOAuthEntity(userId);
+
+            const res = await request(app)
+                .post('/api/integrations')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    entities: [entityId],
+                    config: { type: 'nonexistent-integration' },
+                });
+
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('GET /api/integrations/:id', () => {
+        it('should return integration details', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { integrationId } = await fixture.createOAuthIntegration(userId);
+
+            const res = await request(app)
+                .get(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('id', integrationId);
+            expect(res.body).toHaveProperty('config');
+            expect(res.body).toHaveProperty('entities');
+        });
+
+        it('should return 404 for nonexistent integration', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .get('/api/integrations/nonexistent-id')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+
+        it('should not allow access to other user integrations', async () => {
+            const { userId: user1Id } = await fixture.createUser();
+            const { token: user2Token } = await fixture.createUser();
+            const { integrationId } = await fixture.createOAuthIntegration(user1Id);
+
+            const res = await request(app)
+                .get(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${user2Token}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('PATCH /api/integrations/:id', () => {
+        it('should update integration config', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { integrationId } = await fixture.createOAuthIntegration(userId);
+
+            const res = await request(app)
+                .patch(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    config: { customSetting: 'value' },
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body.config).toHaveProperty('customSetting', 'value');
+        });
+
+        it('should preserve existing config when updating', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { integrationId } = await fixture.createOAuthIntegration(userId);
+
+            await request(app)
+                .patch(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({ config: { setting1: 'value1' } });
+
+            const res = await request(app)
+                .patch(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({ config: { setting2: 'value2' } });
+
+            expect(res.status).toBe(200);
+            expect(res.body.config).toHaveProperty('setting1', 'value1');
+            expect(res.body.config).toHaveProperty('setting2', 'value2');
+        });
+    });
+
+    describe('DELETE /api/integrations/:id', () => {
+        it('should delete integration', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { integrationId } = await fixture.createOAuthIntegration(userId);
+
+            const res = await request(app)
+                .delete(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(204);
+        });
+
+        it('should return 404 after deletion', async () => {
+            const { userId, token } = await fixture.createUser();
+            const { integrationId } = await fixture.createOAuthIntegration(userId);
+
+            await request(app)
+                .delete(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            const res = await request(app)
+                .get(`/api/integrations/${integrationId}`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+
+        it('should return 404 for nonexistent integration', async () => {
+            const { token } = await fixture.createUser();
+
+            const res = await request(app)
+                .delete('/api/integrations/nonexistent-id')
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(404);
+        });
+    });
+});

--- a/packages/e2e/jest.config.js
+++ b/packages/e2e/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+    displayName: 'e2e',
+    testEnvironment: 'node',
+    testMatch: ['**/__tests__/**/*.test.js'],
+    testTimeout: 30000,
+    setupFilesAfterEnv: ['<rootDir>/__tests__/helpers/setup.js'],
+    collectCoverageFrom: [
+        'test-app/**/*.js',
+        '!**/__tests__/**',
+    ],
+};

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@friggframework/e2e",
+  "version": "1.0.0",
+  "private": true,
+  "description": "End-to-end test suite for Frigg Framework",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:ci": "jest --ci --coverage",
+    "test:management-api": "jest --testPathPattern=management-api",
+    "test:cli": "jest --testPathPattern=cli",
+    "test:lifecycle": "jest --testPathPattern=lifecycle"
+  },
+  "dependencies": {
+    "@friggframework/core": "*"
+  },
+  "devDependencies": {
+    "@friggframework/test": "*",
+    "jest": "^29.7.0",
+    "mongodb-memory-server": "^8.9.0",
+    "supertest": "^6.3.3"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/packages/e2e/test-app/backend/api-modules/formBasedMockModule.js
+++ b/packages/e2e/test-app/backend/api-modules/formBasedMockModule.js
@@ -1,0 +1,97 @@
+const { ApiKeyRequester } = require('@friggframework/core');
+
+class FormBasedMockApi extends ApiKeyRequester {
+    constructor(params = {}) {
+        super(params);
+        this.baseUrl = 'https://mock-form-api.example.com';
+        this.workspaceId = params.workspaceId || null;
+    }
+
+    getAuthorizationRequirements(step = 1) {
+        if (step === 1) {
+            return {
+                type: 'form',
+                fields: [
+                    { name: 'apiKey', label: 'API Key', type: 'password', required: true },
+                ],
+            };
+        }
+        return {
+            type: 'form',
+            fields: [
+                { name: 'workspaceId', label: 'Workspace ID', type: 'text', required: true },
+            ],
+        };
+    }
+
+    async validateApiKey(apiKey) {
+        return apiKey && apiKey.length > 5;
+    }
+
+    async getWorkspaces() {
+        return [
+            { id: 'ws-1', name: 'Workspace 1' },
+            { id: 'ws-2', name: 'Workspace 2' },
+        ];
+    }
+
+    async getUserDetails() {
+        return {
+            id: 'form-user-123',
+            email: 'formuser@example.com',
+            workspaceId: this.workspaceId,
+        };
+    }
+}
+
+const Definition = {
+    API: FormBasedMockApi,
+    getName: () => 'form-based-mock',
+    moduleName: 'form-based-mock',
+    modelName: 'FormBasedMock',
+    authType: 'form',
+    isMultiStep: true,
+    requiredAuthMethods: {
+        getAuthorizationRequirements: (api, step) => {
+            return api.getAuthorizationRequirements(step);
+        },
+        processStep: async (api, step, data) => {
+            if (step === 1) {
+                const isValid = await api.validateApiKey(data.apiKey);
+                if (!isValid) {
+                    throw new Error('Invalid API key');
+                }
+                api.setApiKey(data.apiKey);
+                return { nextStep: 2 };
+            }
+            if (step === 2) {
+                api.workspaceId = data.workspaceId;
+                return { complete: true };
+            }
+        },
+        getEntityDetails: async (api, callbackParams, tokenResponse, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: { externalId: userDetails.id, user: userId },
+                details: { workspaceId: userDetails.workspaceId },
+            };
+        },
+        apiPropertiesToPersist: {
+            credential: ['api_key'],
+            entity: ['workspaceId'],
+        },
+        getCredentialDetails: async (api, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: { externalId: userDetails.id, user: userId },
+                details: {},
+            };
+        },
+        testAuthRequest: async (api) => {
+            return api.getUserDetails();
+        },
+    },
+    env: {},
+};
+
+module.exports = { Definition, FormBasedMockApi };

--- a/packages/e2e/test-app/backend/api-modules/oauth2MockModule.js
+++ b/packages/e2e/test-app/backend/api-modules/oauth2MockModule.js
@@ -1,0 +1,75 @@
+const { OAuth2Requester } = require('@friggframework/core');
+
+class OAuth2MockApi extends OAuth2Requester {
+    constructor(params = {}) {
+        super(params);
+        this.baseUrl = 'https://mock-oauth-api.example.com';
+        this.tokenUri = 'https://mock-oauth-api.example.com/oauth/token';
+        this.authorizationUri = `https://mock-oauth-api.example.com/oauth/authorize?client_id=${this.client_id}&redirect_uri=${this.redirect_uri}`;
+    }
+
+    getAuthorizationRequirements() {
+        return {
+            url: this.authorizationUri,
+            type: 'oauth2',
+        };
+    }
+
+    async getTokenFromCode(code) {
+        return {
+            access_token: `mock-access-token-${Date.now()}`,
+            refresh_token: `mock-refresh-token-${Date.now()}`,
+            expires_in: 3600,
+        };
+    }
+
+    async getUserDetails() {
+        return {
+            id: 'mock-user-123',
+            email: 'mockuser@example.com',
+            name: 'Mock User',
+        };
+    }
+}
+
+const Definition = {
+    API: OAuth2MockApi,
+    getName: () => 'oauth2-mock',
+    moduleName: 'oauth2-mock',
+    modelName: 'OAuth2Mock',
+    requiredAuthMethods: {
+        getToken: async (api, params) => {
+            const code = params.data?.code;
+            return api.getTokenFromCode(code);
+        },
+        getEntityDetails: async (api, callbackParams, tokenResponse, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: { externalId: userDetails.id, user: userId },
+                details: { name: userDetails.name, email: userDetails.email },
+            };
+        },
+        apiPropertiesToPersist: {
+            credential: ['access_token', 'refresh_token'],
+            entity: [],
+        },
+        getCredentialDetails: async (api, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: { externalId: userDetails.id, user: userId },
+                details: {},
+            };
+        },
+        testAuthRequest: async (api) => {
+            return api.getUserDetails();
+        },
+    },
+    env: {
+        client_id: 'mock-client-id',
+        client_secret: 'mock-client-secret',
+        redirect_uri: 'http://localhost:3000/redirect/oauth2-mock',
+        scope: 'read write',
+    },
+};
+
+module.exports = { Definition, OAuth2MockApi };

--- a/packages/e2e/test-app/backend/api-modules/webhookMockModule.js
+++ b/packages/e2e/test-app/backend/api-modules/webhookMockModule.js
@@ -1,0 +1,81 @@
+const { ApiKeyRequester } = require('@friggframework/core');
+const crypto = require('crypto');
+
+class WebhookMockApi extends ApiKeyRequester {
+    constructor(params = {}) {
+        super(params);
+        this.baseUrl = 'https://mock-webhook-api.example.com';
+        this.webhookSecret = params.webhookSecret || 'default-webhook-secret';
+    }
+
+    getAuthorizationRequirements() {
+        return {
+            type: 'form',
+            fields: [
+                { name: 'apiKey', label: 'API Key', type: 'password', required: true },
+            ],
+        };
+    }
+
+    async getUserDetails() {
+        return {
+            id: 'webhook-user-123',
+            email: 'webhookuser@example.com',
+        };
+    }
+
+    async registerWebhook(url, events) {
+        return {
+            id: `webhook-${Date.now()}`,
+            url,
+            events,
+            active: true,
+        };
+    }
+
+    validateWebhookSignature(payload, signature) {
+        if (signature === 'valid-signature') return true;
+        const expectedSignature = crypto
+            .createHmac('sha256', this.webhookSecret)
+            .update(JSON.stringify(payload))
+            .digest('hex');
+        return signature === expectedSignature;
+    }
+}
+
+const Definition = {
+    API: WebhookMockApi,
+    getName: () => 'webhook-mock',
+    moduleName: 'webhook-mock',
+    modelName: 'WebhookMock',
+    requiredAuthMethods: {
+        getToken: async (api, params) => {
+            api.setApiKey(params.data?.apiKey);
+            return { api_key: params.data?.apiKey };
+        },
+        getEntityDetails: async (api, callbackParams, tokenResponse, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: { externalId: userDetails.id, user: userId },
+                details: { email: userDetails.email },
+            };
+        },
+        apiPropertiesToPersist: {
+            credential: ['api_key'],
+            entity: [],
+        },
+        getCredentialDetails: async (api, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: { externalId: userDetails.id, user: userId },
+                details: {},
+            };
+        },
+        testAuthRequest: async (api) => {
+            return api.getUserDetails();
+        },
+    },
+    env: {},
+};
+
+module.exports = { Definition, WebhookMockApi };

--- a/packages/e2e/test-app/backend/index.js
+++ b/packages/e2e/test-app/backend/index.js
@@ -1,0 +1,21 @@
+const { OAuthIntegration } = require('./integrations/oauthIntegration');
+const { FormBasedIntegration } = require('./integrations/formBasedIntegration');
+const { WebhookIntegration } = require('./integrations/webhookIntegration');
+
+const Definition = {
+    integrations: [
+        OAuthIntegration,
+        FormBasedIntegration,
+        WebhookIntegration,
+    ],
+    database: {
+        mongoDB: {
+            enable: true,
+        },
+    },
+    user: {
+        model: 'mongoose',
+    },
+};
+
+module.exports = { Definition };

--- a/packages/e2e/test-app/backend/integrations/formBasedIntegration.js
+++ b/packages/e2e/test-app/backend/integrations/formBasedIntegration.js
@@ -1,0 +1,52 @@
+const { IntegrationBase } = require('@friggframework/core');
+const { Definition: FormBasedMockDefinition } = require('../api-modules/formBasedMockModule');
+
+class FormBasedIntegration extends IntegrationBase {
+    static Definition = {
+        name: 'form-based-integration',
+        version: '1.0.0',
+        supportedVersions: ['>=1.0.0'],
+        modules: {
+            formBasedMock: {
+                definition: FormBasedMockDefinition,
+                options: {},
+            },
+        },
+        display: {
+            name: 'Form-Based Integration',
+            description: 'Test integration using form-based multi-step authentication',
+            icon: 'form-icon',
+        },
+    };
+
+    async onCreate({ integrationId }) {
+        await this.updateIntegrationStatus.execute(integrationId, 'NEEDS_CONFIG');
+    }
+
+    async getConfigOptions() {
+        return {
+            jsonSchema: {
+                type: 'object',
+                properties: {
+                    defaultWorkspace: { type: 'string', title: 'Default Workspace' },
+                },
+                required: ['defaultWorkspace'],
+            },
+            uiSchema: {},
+        };
+    }
+
+    async testAuth() {
+        let success = true;
+        if (this.formBasedMock) {
+            try {
+                await this.formBasedMock.testAuth();
+            } catch {
+                success = false;
+            }
+        }
+        return success;
+    }
+}
+
+module.exports = { FormBasedIntegration };

--- a/packages/e2e/test-app/backend/integrations/oauthIntegration.js
+++ b/packages/e2e/test-app/backend/integrations/oauthIntegration.js
@@ -1,0 +1,52 @@
+const { IntegrationBase } = require('@friggframework/core');
+const { Definition: OAuth2MockDefinition } = require('../api-modules/oauth2MockModule');
+
+class OAuthIntegration extends IntegrationBase {
+    static Definition = {
+        name: 'oauth-integration',
+        version: '1.0.0',
+        supportedVersions: ['>=1.0.0'],
+        modules: {
+            oauth2Mock: {
+                definition: OAuth2MockDefinition,
+                options: {},
+            },
+        },
+        display: {
+            name: 'OAuth Integration',
+            description: 'Test integration using OAuth2 authentication',
+            icon: 'oauth-icon',
+        },
+    };
+
+    async onCreate({ integrationId }) {
+        await this.updateIntegrationStatus.execute(integrationId, 'ENABLED');
+    }
+
+    async getConfigOptions() {
+        return {
+            jsonSchema: {
+                type: 'object',
+                properties: {
+                    syncEnabled: { type: 'boolean', title: 'Enable Sync' },
+                    syncInterval: { type: 'number', title: 'Sync Interval (minutes)' },
+                },
+            },
+            uiSchema: {},
+        };
+    }
+
+    async testAuth() {
+        let success = true;
+        if (this.oauth2Mock) {
+            try {
+                await this.oauth2Mock.testAuth();
+            } catch {
+                success = false;
+            }
+        }
+        return success;
+    }
+}
+
+module.exports = { OAuthIntegration };

--- a/packages/e2e/test-app/backend/integrations/webhookIntegration.js
+++ b/packages/e2e/test-app/backend/integrations/webhookIntegration.js
@@ -1,0 +1,75 @@
+const { IntegrationBase } = require('@friggframework/core');
+const { Definition: WebhookMockDefinition } = require('../api-modules/webhookMockModule');
+
+class WebhookIntegration extends IntegrationBase {
+    static Definition = {
+        name: 'webhook-integration',
+        version: '1.0.0',
+        supportedVersions: ['>=1.0.0'],
+        modules: {
+            webhookMock: {
+                definition: WebhookMockDefinition,
+                options: {},
+            },
+        },
+        display: {
+            name: 'Webhook Integration',
+            description: 'Test integration with webhook support',
+            icon: 'webhook-icon',
+        },
+    };
+
+    async onCreate({ integrationId }) {
+        await this.updateIntegrationStatus.execute(integrationId, 'ENABLED');
+    }
+
+    async getConfigOptions() {
+        return {
+            jsonSchema: {
+                type: 'object',
+                properties: {
+                    webhookEvents: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        title: 'Webhook Events to Subscribe',
+                    },
+                },
+            },
+            uiSchema: {},
+        };
+    }
+
+    async onWebhookReceived({ req, res }) {
+        const signature = req.headers['x-webhook-signature'];
+        const payload = req.body;
+
+        if (!this.webhookMock) {
+            return res.status(500).json({ error: 'Module not loaded' });
+        }
+
+        const isValid = this.webhookMock.api.validateWebhookSignature(payload, signature);
+        if (!isValid) {
+            return res.status(401).json({ error: 'Invalid signature' });
+        }
+
+        res.status(200).json({ received: true });
+    }
+
+    async onWebhook({ data }) {
+        return { processed: true, event: data.body?.event };
+    }
+
+    async testAuth() {
+        let success = true;
+        if (this.webhookMock) {
+            try {
+                await this.webhookMock.testAuth();
+            } catch {
+                success = false;
+            }
+        }
+        return success;
+    }
+}
+
+module.exports = { WebhookIntegration };

--- a/packages/e2e/test-app/backend/package.json
+++ b/packages/e2e/test-app/backend/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@friggframework/e2e-test-app",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/packages/test/index.js
+++ b/packages/test/index.js
@@ -5,7 +5,22 @@ const {
 } = require('./override-environment');
 const globalTeardown = require('./jest-global-teardown');
 const globalSetup = require('./jest-global-setup');
-const Authenticator = require('./Authenticator')
+const Authenticator = require('./Authenticator');
+
+// Router test utilities are loaded lazily to avoid jest.fn() errors during
+// global setup (when Jest globals aren't available yet)
+let _routerTestUtils = null;
+
+/**
+ * Lazily load router test utilities (only when called from test context)
+ * @returns {Object} Router test utilities
+ */
+const getRouterTestUtils = () => {
+    if (!_routerTestUtils) {
+        _routerTestUtils = require('./router-test-utils');
+    }
+    return _routerTestUtils;
+};
 
 module.exports = {
     TestMongo,
@@ -13,5 +28,8 @@ module.exports = {
     restoreEnvironment,
     globalTeardown,
     globalSetup,
-    Authenticator
+    Authenticator,
+    // Router test utilities - use getRouterTestUtils() for lazy loading
+    getRouterTestUtils,
+    // Direct import path is available: require('@friggframework/test/router-test-utils')
 };

--- a/packages/test/jest-global-setup.js
+++ b/packages/test/jest-global-setup.js
@@ -1,10 +1,20 @@
 const { TestMongo } = require('./mongodb');
-const {overrideEnvironment} = require('./override-environment');
+const { overrideEnvironment } = require('./override-environment');
 
 module.exports = async function () {
     if (!process.env.STAGE) {
         overrideEnvironment({ STAGE: 'dev' });
     }
-    global.testMongo = new TestMongo();
-    await global.testMongo.start();
+
+    // Only start MongoDB for integration tests
+    // Unit tests should not depend on MongoDB
+    const isIntegrationTest =
+        process.argv.includes('--group=integration') || process.env.TEST_TYPE === 'integration';
+
+    if (isIntegrationTest || (!process.argv.includes('--group=unit') && !process.env.TEST_TYPE)) {
+        global.testMongo = new TestMongo();
+        await global.testMongo.start();
+    } else {
+        console.log('Skipping MongoDB setup for unit tests');
+    }
 };

--- a/packages/test/jest-global-teardown.js
+++ b/packages/test/jest-global-teardown.js
@@ -1,5 +1,10 @@
-const { restoreEnvironment } = require('./override-environment')
+const { restoreEnvironment } = require('./override-environment');
+
 module.exports = async function () {
     restoreEnvironment();
-    await global.testMongo.stop();
+
+    // Only stop MongoDB if it was started
+    if (global.testMongo) {
+        await global.testMongo.stop();
+    }
 };

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -4,12 +4,14 @@
   "version": "2.0.0-next.0",
   "dependencies": {
     "@babel/eslint-parser": "^7.18.9",
+    "@hapi/boom": "^10.0.1",
     "eslint": "^8.22.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-markdown": "^3.0.0",
     "eslint-plugin-no-only-tests": "^3.0.0",
     "eslint-plugin-yaml": "^0.5.0",
+    "express": "^4.21.2",
     "jest-runner-groups": "^2.2.0",
     "mongodb-memory-server": "^8.9.0",
     "open": "^8.4.2"
@@ -18,7 +20,16 @@
     "@friggframework/eslint-config": "^2.0.0-next.0",
     "@friggframework/prettier-config": "^2.0.0-next.0",
     "jest": "^29.7.0",
-    "prettier": "^2.7.1"
+    "prettier": "^2.7.1",
+    "supertest": "^6.3.3"
+  },
+  "peerDependencies": {
+    "supertest": ">=6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "supertest": {
+      "optional": true
+    }
   },
   "scripts": {
     "lint:fix": "prettier --write --loglevel error . && eslint . --fix",

--- a/packages/test/router-test-utils/index.js
+++ b/packages/test/router-test-utils/index.js
@@ -1,0 +1,535 @@
+/**
+ * @file Router Test Utilities
+ * @description Shared test utilities for Express router testing in Frigg Framework
+ *
+ * These utilities reduce boilerplate and ensure consistency across router tests.
+ * Use these helpers to:
+ * - Create mock repositories with standard interfaces
+ * - Set up Express apps with authentication middleware
+ * - Handle Boom errors properly in test environments
+ * - Generate consistent test data
+ *
+ * @example
+ * const { createTestApp, createMockRepositories, mockData } = require('@friggframework/test/router-test-utils');
+ *
+ * describe('My Router', () => {
+ *     let app, mocks;
+ *
+ *     beforeEach(() => {
+ *         mocks = createMockRepositories();
+ *         app = createTestApp({ router: myRouter, mocks });
+ *     });
+ * });
+ */
+
+const express = require('express');
+const Boom = require('@hapi/boom');
+
+// ============================================================================
+// Mock Data Generators
+// ============================================================================
+
+/**
+ * Helper to safely get jest.fn() - returns a real mock in test context, noop otherwise
+ * @returns {Function} Jest mock function or noop
+ */
+const createMockFn = (implementation) => {
+    if (typeof jest !== 'undefined' && jest.fn) {
+        return implementation ? jest.fn(implementation) : jest.fn();
+    }
+    // Return a noop function with mock properties for non-Jest environments
+    const fn = implementation || (() => {});
+    fn.mockReturnValue = (val) => {
+        fn._mockReturnValue = val;
+        return fn;
+    };
+    fn.mockResolvedValue = (val) => {
+        fn._mockResolvedValue = val;
+        return fn;
+    };
+    fn.mockImplementation = (impl) => {
+        fn._mockImplementation = impl;
+        return fn;
+    };
+    return fn;
+};
+
+/**
+ * Default mock user object
+ * @type {Object}
+ */
+const createMockUser = (overrides = {}) => ({
+    id: 'user-123',
+    appUserId: 'app-user-123',
+    username: 'testuser',
+    email: 'test@example.com',
+    getId: createMockFn(() => overrides.id || 'user-123'),
+    ...overrides,
+});
+
+/**
+ * Default mock credential object
+ * @type {Object}
+ */
+const createMockCredential = (overrides = {}) => ({
+    id: 'cred-123',
+    type: 'hubspot',
+    userId: 'user-123',
+    authIsValid: true,
+    status: 'AUTHORIZED',
+    externalId: 'ext-123',
+    entityCount: 2,
+    createdAt: '2025-01-25T10:00:00.000Z',
+    updatedAt: '2025-01-25T10:00:00.000Z',
+    data: {
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+    },
+    ...overrides,
+});
+
+/**
+ * Default mock entity object
+ * @type {Object}
+ */
+const createMockEntity = (overrides = {}) => ({
+    id: 'entity-123',
+    entityType: 'ACCOUNT',
+    credential: 'cred-123',
+    credentialId: 'cred-123',
+    userId: 'user-123',
+    externalId: 'ext-account-123',
+    name: 'Test Account',
+    authIsValid: true,
+    type: 'hubspot',
+    ...overrides,
+});
+
+/**
+ * Default mock integration object
+ * @type {Object}
+ */
+const createMockIntegration = (overrides = {}) => ({
+    id: 'integration-123',
+    name: 'Test Integration',
+    userId: 'user-123',
+    config: {},
+    entities: ['entity-123'],
+    createdAt: '2025-01-25T10:00:00.000Z',
+    updatedAt: '2025-01-25T10:00:00.000Z',
+    ...overrides,
+});
+
+/**
+ * Default mock module definition object
+ * @type {Object}
+ */
+const createMockModuleDefinition = (overrides = {}) => {
+    const defaults = {
+        moduleName: 'hubspot',
+        definition: {
+            getDisplayName: () => overrides.displayName || 'HubSpot',
+            getDescription: () => overrides.description || 'Connect to HubSpot CRM',
+            getAuthType: () => overrides.authType || 'oauth2',
+            getAuthStepCount: () => overrides.stepCount || 1,
+            getCapabilities: () => overrides.capabilities || ['contacts', 'companies', 'deals'],
+            getAuthRequirementsForStep: jest.fn().mockResolvedValue({
+                type: overrides.authType || 'oauth2',
+                data: {
+                    url: 'https://app.hubspot.com/oauth/authorize?client_id=test',
+                    scopes: ['crm.objects.contacts.read', 'crm.objects.companies.read'],
+                },
+            }),
+            processAuthorizationStep: jest.fn(),
+        },
+        apiClass: jest.fn(),
+    };
+
+    return {
+        ...defaults,
+        ...overrides,
+        definition: {
+            ...defaults.definition,
+            ...(overrides.definition || {}),
+        },
+    };
+};
+
+/**
+ * Collection of mock data generators
+ */
+const mockData = {
+    createMockUser,
+    createMockCredential,
+    createMockEntity,
+    createMockIntegration,
+    createMockModuleDefinition,
+
+    // Pre-created instances for quick use
+    user: createMockUser(),
+    credential: createMockCredential(),
+    entity: createMockEntity(),
+    integration: createMockIntegration(),
+};
+
+// ============================================================================
+// Mock Repository Factories
+// ============================================================================
+
+/**
+ * Create a mock user repository with standard interface
+ * @param {Object} overrides - Method overrides
+ * @returns {Object} Mock user repository
+ */
+const createMockUserRepository = (overrides = {}) => ({
+    findById: jest.fn().mockResolvedValue(mockData.user),
+    findOne: jest.fn().mockResolvedValue(mockData.user),
+    findByToken: jest.fn().mockResolvedValue(mockData.user),
+    getSessionToken: jest.fn().mockResolvedValue({ user: 'user-123', token: 'valid-token' }),
+    findIndividualUserById: jest.fn().mockResolvedValue(mockData.user),
+    findOrganizationUserById: jest.fn().mockResolvedValue(null),
+    findByEmail: jest.fn().mockResolvedValue(mockData.user),
+    findUserById: jest.fn().mockResolvedValue(mockData.user),
+    save: jest.fn(),
+    update: jest.fn(),
+    ...overrides,
+});
+
+/**
+ * Create a mock credential repository with standard interface
+ * @param {Object} overrides - Method overrides
+ * @returns {Object} Mock credential repository
+ */
+const createMockCredentialRepository = (overrides = {}) => ({
+    findById: jest.fn(),
+    findByIdForUser: jest.fn(),
+    findCredential: jest.fn().mockResolvedValue([]),
+    findCredentialById: jest.fn(),
+    save: jest.fn(),
+    update: jest.fn(),
+    updateCredential: jest.fn(),
+    deleteCredentialById: jest.fn().mockResolvedValue({ deletedCount: 1 }),
+    ...overrides,
+});
+
+/**
+ * Create a mock module repository with standard interface
+ * @param {Object} overrides - Method overrides
+ * @returns {Object} Mock module repository
+ */
+const createMockModuleRepository = (overrides = {}) => ({
+    findById: jest.fn(),
+    findByIdForUser: jest.fn(),
+    findByUserId: jest.fn().mockResolvedValue([]),
+    findByUserIdAndType: jest.fn(),
+    findModuleById: jest.fn(),
+    save: jest.fn(),
+    update: jest.fn(),
+    ...overrides,
+});
+
+/**
+ * Create a mock integration repository with standard interface
+ * @param {Object} overrides - Method overrides
+ * @returns {Object} Mock integration repository
+ */
+const createMockIntegrationRepository = (overrides = {}) => ({
+    findById: jest.fn(),
+    findByIdForUser: jest.fn(),
+    findByUserId: jest.fn().mockResolvedValue([]),
+    save: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    ...overrides,
+});
+
+/**
+ * Create a mock authorization session repository
+ * @param {Object} overrides - Method overrides
+ * @returns {Object} Mock authorization session repository
+ */
+const createMockAuthorizationSessionRepository = (overrides = {}) => ({
+    findBySessionId: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    ...overrides,
+});
+
+/**
+ * Create all mock repositories at once
+ * @param {Object} overrides - Per-repository overrides
+ * @returns {Object} All mock repositories
+ */
+const createMockRepositories = (overrides = {}) => ({
+    userRepository: createMockUserRepository(overrides.user),
+    credentialRepository: createMockCredentialRepository(overrides.credential),
+    moduleRepository: createMockModuleRepository(overrides.module),
+    integrationRepository: createMockIntegrationRepository(overrides.integration),
+    authorizationSessionRepository: createMockAuthorizationSessionRepository(overrides.authorizationSession),
+});
+
+// ============================================================================
+// Mock API Requester
+// ============================================================================
+
+/**
+ * Create a mock API requester for proxy tests
+ * @param {Object} overrides - Method overrides
+ * @returns {Object} Mock API requester
+ */
+const createMockApiRequester = (overrides = {}) => ({
+    request: jest.fn().mockResolvedValue({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        data: { success: true },
+    }),
+    _get: jest.fn(),
+    _post: jest.fn(),
+    _put: jest.fn(),
+    _patch: jest.fn(),
+    _delete: jest.fn(),
+    addAuthHeaders: jest.fn().mockResolvedValue({}),
+    ...overrides,
+});
+
+/**
+ * Create a mock module factory
+ * @param {Object} apiRequester - Mock API requester to use
+ * @returns {Object} Mock module factory
+ */
+const createMockModuleFactory = (apiRequester = createMockApiRequester()) => ({
+    getModuleInstance: jest.fn().mockResolvedValue({
+        api: apiRequester,
+    }),
+});
+
+// ============================================================================
+// Express App Setup
+// ============================================================================
+
+/**
+ * Boom error handler middleware for Express
+ * Converts Boom errors to proper HTTP responses
+ * @param {Error} err - Error object
+ * @param {Object} req - Express request
+ * @param {Object} res - Express response
+ * @param {Function} next - Next middleware
+ */
+const boomErrorHandler = (err, req, res, next) => {
+    if (Boom.isBoom(err)) {
+        const { statusCode, payload } = err.output;
+        return res.status(statusCode).json({
+            error: payload.message,
+            message: payload.message,
+            statusCode: payload.statusCode,
+            ...err.data,
+        });
+    }
+
+    // Handle non-Boom errors
+    console.error('Unhandled error:', err);
+    return res.status(500).json({
+        error: 'Internal Server Error',
+        message: err.message,
+        statusCode: 500,
+    });
+};
+
+/**
+ * Create authentication middleware for testing
+ * @param {Object} options - Configuration options
+ * @param {Object} options.mockUser - User to inject on successful auth
+ * @param {string} options.validToken - Token that will be considered valid (default: 'valid-token')
+ * @returns {Function} Express middleware
+ */
+const createAuthMiddleware = ({ mockUser = mockData.user, validToken = 'valid-token' } = {}) => {
+    return (req, res, next) => {
+        const authHeader = req.headers.authorization;
+
+        if (!authHeader) {
+            return next(Boom.unauthorized('No authentication provided'));
+        }
+
+        const token = authHeader.replace('Bearer ', '');
+
+        if (token === validToken) {
+            req.user = mockUser;
+            return next();
+        }
+
+        return next(Boom.unauthorized('Invalid token'));
+    };
+};
+
+/**
+ * Create a test Express app with common configuration
+ * @param {Object} options - Configuration options
+ * @param {Object} options.router - Express router to mount
+ * @param {string} options.basePath - Base path for router (default: '/')
+ * @param {Object} options.mockUser - User to inject on auth (default: mockData.user)
+ * @param {boolean} options.useAuth - Whether to use auth middleware (default: true)
+ * @param {string} options.validToken - Valid token string (default: 'valid-token')
+ * @returns {Object} Express app instance
+ */
+const createTestApp = ({
+    router,
+    basePath = '/',
+    mockUser = mockData.user,
+    useAuth = true,
+    validToken = 'valid-token',
+} = {}) => {
+    const app = express();
+    app.use(express.json());
+
+    if (useAuth) {
+        app.use(createAuthMiddleware({ mockUser, validToken }));
+    }
+
+    if (router) {
+        app.use(basePath, router);
+    }
+
+    // Add Boom error handler (must be after routes)
+    app.use(boomErrorHandler);
+
+    return app;
+};
+
+// ============================================================================
+// Database Config Mock
+// ============================================================================
+
+/**
+ * Standard database config mock object
+ * Use this to mock '../database/config' in tests
+ */
+const databaseConfigMock = {
+    DB_TYPE: 'mongodb',
+    getDatabaseType: jest.fn(() => 'mongodb'),
+    PRISMA_LOG_LEVEL: 'error,warn',
+    PRISMA_QUERY_LOGGING: false,
+};
+
+// ============================================================================
+// App Definition Mock
+// ============================================================================
+
+/**
+ * Create a mock app definition
+ * @param {Object} overrides - Override specific properties
+ * @returns {Object} Mock app definition
+ */
+const createMockAppDefinition = (overrides = {}) => ({
+    integrations: overrides.integrations || [
+        createMockModuleDefinition({ moduleName: 'hubspot' }),
+        createMockModuleDefinition({
+            moduleName: 'salesforce',
+            displayName: 'Salesforce',
+            description: 'Connect to Salesforce CRM',
+            capabilities: ['accounts', 'contacts', 'opportunities'],
+        }),
+    ],
+    userConfig: {
+        usePassword: true,
+        primary: 'individual',
+        authModes: {
+            friggToken: true,
+        },
+        ...(overrides.userConfig || {}),
+    },
+    ...overrides,
+});
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/**
+ * Helper to make authenticated requests
+ * @param {Object} app - Express app
+ * @param {string} token - Auth token (default: 'valid-token')
+ * @returns {Object} Supertest agent with auth header set
+ */
+const authenticatedRequest = (request, token = 'valid-token') => {
+    return {
+        get: (url) => request.get(url).set('Authorization', `Bearer ${token}`),
+        post: (url) => request.post(url).set('Authorization', `Bearer ${token}`),
+        put: (url) => request.put(url).set('Authorization', `Bearer ${token}`),
+        patch: (url) => request.patch(url).set('Authorization', `Bearer ${token}`),
+        delete: (url) => request.delete(url).set('Authorization', `Bearer ${token}`),
+    };
+};
+
+/**
+ * Setup common jest mocks for repository factories
+ * Call this at the top of your test file after imports
+ * @param {Object} factoryMocks - Map of factory name to mock repository
+ */
+const setupRepositoryFactoryMocks = ({
+    createUserRepository,
+    createCredentialRepository,
+    createModuleRepository,
+    createIntegrationRepository,
+    createAuthorizationSessionRepository,
+    loadAppDefinition,
+    mocks,
+}) => {
+    if (createUserRepository && mocks.userRepository) {
+        createUserRepository.mockReturnValue(mocks.userRepository);
+    }
+    if (createCredentialRepository && mocks.credentialRepository) {
+        createCredentialRepository.mockReturnValue(mocks.credentialRepository);
+    }
+    if (createModuleRepository && mocks.moduleRepository) {
+        createModuleRepository.mockReturnValue(mocks.moduleRepository);
+    }
+    if (createIntegrationRepository && mocks.integrationRepository) {
+        createIntegrationRepository.mockReturnValue(mocks.integrationRepository);
+    }
+    if (createAuthorizationSessionRepository && mocks.authorizationSessionRepository) {
+        createAuthorizationSessionRepository.mockReturnValue(mocks.authorizationSessionRepository);
+    }
+    if (loadAppDefinition) {
+        loadAppDefinition.mockReturnValue(createMockAppDefinition());
+    }
+};
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+module.exports = {
+    // Mock data generators
+    mockData,
+    createMockUser,
+    createMockCredential,
+    createMockEntity,
+    createMockIntegration,
+    createMockModuleDefinition,
+
+    // Repository mocks
+    createMockUserRepository,
+    createMockCredentialRepository,
+    createMockModuleRepository,
+    createMockIntegrationRepository,
+    createMockAuthorizationSessionRepository,
+    createMockRepositories,
+
+    // API/Factory mocks
+    createMockApiRequester,
+    createMockModuleFactory,
+
+    // Express app utilities
+    createTestApp,
+    createAuthMiddleware,
+    boomErrorHandler,
+
+    // Config mocks
+    databaseConfigMock,
+    createMockAppDefinition,
+
+    // Test helpers
+    authenticatedRequest,
+    setupRepositoryFactoryMocks,
+};

--- a/packages/test/router-test-utils/index.test.js
+++ b/packages/test/router-test-utils/index.test.js
@@ -1,0 +1,350 @@
+/**
+ * @file Router Test Utilities - Unit Tests
+ * @description Tests for the shared router test utilities
+ */
+
+const request = require('supertest');
+const express = require('express');
+const Boom = require('@hapi/boom');
+
+const {
+    // Mock data generators
+    mockData,
+    createMockUser,
+    createMockCredential,
+    createMockEntity,
+    createMockIntegration,
+    createMockModuleDefinition,
+
+    // Repository mocks
+    createMockUserRepository,
+    createMockCredentialRepository,
+    createMockModuleRepository,
+    createMockIntegrationRepository,
+    createMockAuthorizationSessionRepository,
+    createMockRepositories,
+
+    // API/Factory mocks
+    createMockApiRequester,
+    createMockModuleFactory,
+
+    // Express app utilities
+    createTestApp,
+    createAuthMiddleware,
+    boomErrorHandler,
+
+    // Config mocks
+    databaseConfigMock,
+    createMockAppDefinition,
+} = require('./index');
+
+describe('Router Test Utilities', () => {
+    describe('Mock Data Generators', () => {
+        describe('createMockUser', () => {
+            it('should create user with default values', () => {
+                const user = createMockUser();
+                expect(user.id).toBe('user-123');
+                expect(user.username).toBe('testuser');
+                expect(user.email).toBe('test@example.com');
+            });
+
+            it('should allow overriding values', () => {
+                const user = createMockUser({ id: 'custom-id', username: 'custom' });
+                expect(user.id).toBe('custom-id');
+                expect(user.username).toBe('custom');
+                expect(user.email).toBe('test@example.com'); // Default preserved
+            });
+
+            it('should include getId function', () => {
+                const user = createMockUser({ id: 'test-id' });
+                expect(user.getId()).toBe('test-id');
+            });
+        });
+
+        describe('createMockCredential', () => {
+            it('should create credential with default values', () => {
+                const cred = createMockCredential();
+                expect(cred.id).toBe('cred-123');
+                expect(cred.type).toBe('hubspot');
+                expect(cred.authIsValid).toBe(true);
+                expect(cred.data.access_token).toBeDefined();
+            });
+
+            it('should allow overriding values', () => {
+                const cred = createMockCredential({ type: 'salesforce', authIsValid: false });
+                expect(cred.type).toBe('salesforce');
+                expect(cred.authIsValid).toBe(false);
+            });
+        });
+
+        describe('createMockEntity', () => {
+            it('should create entity with default values', () => {
+                const entity = createMockEntity();
+                expect(entity.id).toBe('entity-123');
+                expect(entity.userId).toBe('user-123');
+                expect(entity.credentialId).toBe('cred-123');
+            });
+        });
+
+        describe('createMockIntegration', () => {
+            it('should create integration with default values', () => {
+                const integration = createMockIntegration();
+                expect(integration.id).toBe('integration-123');
+                expect(integration.userId).toBe('user-123');
+            });
+        });
+
+        describe('createMockModuleDefinition', () => {
+            it('should create module definition with default values', () => {
+                const def = createMockModuleDefinition();
+                expect(def.moduleName).toBe('hubspot');
+                expect(def.definition.getDisplayName()).toBe('HubSpot');
+                expect(def.definition.getAuthType()).toBe('oauth2');
+            });
+
+            it('should allow customization', () => {
+                const def = createMockModuleDefinition({
+                    moduleName: 'custom',
+                    displayName: 'Custom Service',
+                    authType: 'api-key',
+                });
+                expect(def.moduleName).toBe('custom');
+                expect(def.definition.getDisplayName()).toBe('Custom Service');
+                expect(def.definition.getAuthType()).toBe('api-key');
+            });
+        });
+
+        describe('mockData convenience object', () => {
+            it('should provide pre-created instances', () => {
+                expect(mockData.user).toBeDefined();
+                expect(mockData.credential).toBeDefined();
+                expect(mockData.entity).toBeDefined();
+                expect(mockData.integration).toBeDefined();
+            });
+        });
+    });
+
+    describe('Mock Repository Factories', () => {
+        describe('createMockUserRepository', () => {
+            it('should create repository with all methods', () => {
+                const repo = createMockUserRepository();
+                expect(repo.findById).toBeDefined();
+                expect(repo.findByToken).toBeDefined();
+                expect(repo.getSessionToken).toBeDefined();
+                expect(repo.findIndividualUserById).toBeDefined();
+            });
+
+            it('should have working mock implementations', async () => {
+                const repo = createMockUserRepository();
+                const user = await repo.findById('test');
+                expect(user.id).toBe('user-123');
+            });
+        });
+
+        describe('createMockCredentialRepository', () => {
+            it('should create repository with all methods', () => {
+                const repo = createMockCredentialRepository();
+                expect(repo.findById).toBeDefined();
+                expect(repo.findCredential).toBeDefined();
+                expect(repo.deleteCredentialById).toBeDefined();
+            });
+        });
+
+        describe('createMockRepositories', () => {
+            it('should create all repositories at once', () => {
+                const repos = createMockRepositories();
+                expect(repos.userRepository).toBeDefined();
+                expect(repos.credentialRepository).toBeDefined();
+                expect(repos.moduleRepository).toBeDefined();
+                expect(repos.integrationRepository).toBeDefined();
+                expect(repos.authorizationSessionRepository).toBeDefined();
+            });
+        });
+    });
+
+    describe('Mock API/Factory Utilities', () => {
+        describe('createMockApiRequester', () => {
+            it('should create API requester with all methods', () => {
+                const api = createMockApiRequester();
+                expect(api.request).toBeDefined();
+                expect(api._get).toBeDefined();
+                expect(api._post).toBeDefined();
+            });
+
+            it('should have working request mock', async () => {
+                const api = createMockApiRequester();
+                const response = await api.request({ method: 'GET', path: '/test' });
+                expect(response.status).toBe(200);
+                expect(response.data.success).toBe(true);
+            });
+        });
+
+        describe('createMockModuleFactory', () => {
+            it('should create factory with getModuleInstance', () => {
+                const factory = createMockModuleFactory();
+                expect(factory.getModuleInstance).toBeDefined();
+            });
+
+            it('should return module with api property', async () => {
+                const factory = createMockModuleFactory();
+                const instance = await factory.getModuleInstance('entity-123', 'user-123');
+                expect(instance.api).toBeDefined();
+                expect(instance.api.request).toBeDefined();
+            });
+        });
+    });
+
+    describe('Express App Utilities', () => {
+        describe('boomErrorHandler', () => {
+            it('should handle Boom errors', async () => {
+                const app = express();
+                app.get('/error', (req, res, next) => {
+                    next(Boom.notFound('Resource not found'));
+                });
+                app.use(boomErrorHandler);
+
+                const response = await request(app).get('/error');
+                expect(response.status).toBe(404);
+                expect(response.body.error).toBe('Resource not found');
+            });
+
+            it('should handle non-Boom errors', async () => {
+                const app = express();
+                app.get('/error', () => {
+                    throw new Error('Something went wrong');
+                });
+                app.use(boomErrorHandler);
+
+                const response = await request(app).get('/error');
+                expect(response.status).toBe(500);
+                expect(response.body.error).toBe('Internal Server Error');
+            });
+        });
+
+        describe('createAuthMiddleware', () => {
+            it('should authenticate valid token', async () => {
+                const app = express();
+                app.use(createAuthMiddleware());
+                app.get('/test', (req, res) => res.json({ user: req.user }));
+                app.use(boomErrorHandler);
+
+                const response = await request(app)
+                    .get('/test')
+                    .set('Authorization', 'Bearer valid-token');
+
+                expect(response.status).toBe(200);
+                expect(response.body.user.id).toBe('user-123');
+            });
+
+            it('should reject missing token', async () => {
+                const app = express();
+                app.use(createAuthMiddleware());
+                app.get('/test', (req, res) => res.json({ user: req.user }));
+                app.use(boomErrorHandler);
+
+                const response = await request(app).get('/test');
+                expect(response.status).toBe(401);
+            });
+
+            it('should reject invalid token', async () => {
+                const app = express();
+                app.use(createAuthMiddleware());
+                app.get('/test', (req, res) => res.json({ user: req.user }));
+                app.use(boomErrorHandler);
+
+                const response = await request(app)
+                    .get('/test')
+                    .set('Authorization', 'Bearer invalid-token');
+
+                expect(response.status).toBe(401);
+            });
+
+            it('should use custom valid token', async () => {
+                const app = express();
+                app.use(createAuthMiddleware({ validToken: 'custom-token' }));
+                app.get('/test', (req, res) => res.json({ user: req.user }));
+                app.use(boomErrorHandler);
+
+                const response = await request(app)
+                    .get('/test')
+                    .set('Authorization', 'Bearer custom-token');
+
+                expect(response.status).toBe(200);
+            });
+        });
+
+        describe('createTestApp', () => {
+            it('should create app with JSON parsing', async () => {
+                const router = express.Router();
+                router.post('/test', (req, res) => res.json(req.body));
+
+                const app = createTestApp({ router, useAuth: false });
+
+                const response = await request(app)
+                    .post('/test')
+                    .send({ data: 'test' });
+
+                expect(response.status).toBe(200);
+                expect(response.body.data).toBe('test');
+            });
+
+            it('should include auth middleware by default', async () => {
+                const router = express.Router();
+                router.get('/test', (req, res) => res.json({ ok: true }));
+
+                const app = createTestApp({ router });
+
+                const response = await request(app).get('/test');
+                expect(response.status).toBe(401);
+            });
+
+            it('should mount router at custom base path', async () => {
+                const router = express.Router();
+                router.get('/resource', (req, res) => res.json({ ok: true }));
+
+                const app = createTestApp({ router, basePath: '/api', useAuth: false });
+
+                const response = await request(app).get('/api/resource');
+                expect(response.status).toBe(200);
+            });
+
+            it('should include Boom error handler', async () => {
+                const router = express.Router();
+                router.get('/error', (req, res, next) => {
+                    next(Boom.badRequest('Invalid input'));
+                });
+
+                const app = createTestApp({ router, useAuth: false });
+
+                const response = await request(app).get('/error');
+                expect(response.status).toBe(400);
+                expect(response.body.error).toBe('Invalid input');
+            });
+        });
+    });
+
+    describe('Config Mocks', () => {
+        describe('databaseConfigMock', () => {
+            it('should have expected properties', () => {
+                expect(databaseConfigMock.DB_TYPE).toBe('mongodb');
+                expect(databaseConfigMock.getDatabaseType()).toBe('mongodb');
+            });
+        });
+
+        describe('createMockAppDefinition', () => {
+            it('should create app definition with defaults', () => {
+                const def = createMockAppDefinition();
+                expect(def.integrations).toBeDefined();
+                expect(def.integrations.length).toBeGreaterThan(0);
+                expect(def.userConfig).toBeDefined();
+            });
+
+            it('should allow customization', () => {
+                const def = createMockAppDefinition({
+                    userConfig: { usePassword: false },
+                });
+                expect(def.userConfig.usePassword).toBe(false);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Split 9/9 of PR #522 (integration-router-v2)
- Adds the new `packages/e2e` package with E2E tests covering lifecycle flows (OAuth, form-based auth, webhooks), management API endpoints, and edge-case/error scenarios
- Updates `packages/test` with new `router-test-utils` and changes to jest global setup/teardown
- Updates root `package-lock.json` for all new dependencies introduced across the split PRs

## Depends on
All previous splits (1-8). **Merge last.**

## Test plan
- [ ] Verify E2E test suite runs against a local test server
- [ ] Confirm `packages/test` changes don't break existing test infrastructure
- [ ] Validate `package-lock.json` is consistent after `npm install`