### PR TITLE
fix(core): restore Integration status to ENABLED on successful re-auth

### DIFF
--- a/packages/core/integrations/integration-router.js
+++ b/packages/core/integrations/integration-router.js
@@ -190,6 +190,7 @@ function createIntegrationRouter() {
     const processAuthorizationCallback = new ProcessAuthorizationCallback({
         moduleRepository,
         credentialRepository,
+        integrationRepository,
         moduleDefinitions:
             getModulesDefinitionFromIntegrationClasses(integrationClasses),
     });

--- a/packages/core/integrations/repositories/integration-repository-documentdb.js
+++ b/packages/core/integrations/repositories/integration-repository-documentdb.js
@@ -26,6 +26,15 @@ class IntegrationRepositoryDocumentDB extends IntegrationRepositoryInterface {
         return records.map((doc) => this._mapIntegration(doc));
     }
 
+    async findIntegrationsByEntityId(entityId) {
+        const objectId = toObjectId(entityId);
+        if (!objectId) return [];
+        const records = await findMany(this.prisma, 'Integration', {
+            entityIds: objectId,
+        });
+        return records.map((doc) => this._mapIntegration(doc));
+    }
+
     async deleteIntegrationById(integrationId) {
         const objectId = toObjectId(integrationId);
         if (!objectId) return { acknowledged: true, deletedCount: 0 };

--- a/packages/core/integrations/repositories/integration-repository-interface.js
+++ b/packages/core/integrations/repositories/integration-repository-interface.js
@@ -122,6 +122,23 @@ class IntegrationRepositoryInterface {
     async updateIntegrationConfig(integrationId, config) {
         throw new Error('Method updateIntegrationConfig must be implemented by subclass');
     }
+
+    /**
+     * Find all integrations whose entity set includes the given entity ID.
+     *
+     * Used by the authorization callback flow to walk up from a re-authorized
+     * entity to its parent integrations so that any in a broken state (ERROR,
+     * DISABLED) can be restored to ENABLED.
+     *
+     * @param {string|number} entityId - Entity ID
+     * @returns {Promise<Array>} Array of integration objects (possibly empty)
+     * @abstract
+     */
+    async findIntegrationsByEntityId(entityId) {
+        throw new Error(
+            'Method findIntegrationsByEntityId must be implemented by subclass'
+        );
+    }
 }
 
 module.exports = { IntegrationRepositoryInterface };

--- a/packages/core/integrations/repositories/integration-repository-mongo.js
+++ b/packages/core/integrations/repositories/integration-repository-mongo.js
@@ -201,6 +201,33 @@ class IntegrationRepositoryMongo extends IntegrationRepositoryInterface {
     }
 
     /**
+     * Find all integrations whose entity set includes the given entity ID.
+     *
+     * @param {string} entityId - Entity ID (MongoDB ObjectId as string)
+     * @returns {Promise<Array>} Array of integration objects (possibly empty)
+     */
+    async findIntegrationsByEntityId(entityId) {
+        const integrations = await this.prisma.integration.findMany({
+            where: {
+                entityIds: { has: entityId },
+            },
+            include: {
+                entities: true,
+            },
+        });
+
+        return integrations.map((integration) => ({
+            id: integration.id,
+            entitiesIds: integration.entities.map((e) => e.id),
+            userId: integration.userId,
+            config: integration.config,
+            version: integration.version,
+            status: integration.status,
+            messages: integration.messages,
+        }));
+    }
+
+    /**
      * Create a new integration
      * Replaces: IntegrationModel.create({ entities, user, config })
      *

--- a/packages/core/integrations/repositories/integration-repository-postgres.js
+++ b/packages/core/integrations/repositories/integration-repository-postgres.js
@@ -347,6 +347,39 @@ class IntegrationRepositoryPostgres extends IntegrationRepositoryInterface {
             messages: converted.messages,
         };
     }
+
+    /**
+     * Find all integrations whose entity set includes the given entity ID.
+     *
+     * @param {string|number} entityId - Entity ID (string from application layer)
+     * @returns {Promise<Array>} Array of integration objects with string IDs (possibly empty)
+     */
+    async findIntegrationsByEntityId(entityId) {
+        const intEntityId = this._convertId(entityId);
+        const integrations = await this.prisma.integration.findMany({
+            where: {
+                entities: {
+                    some: { id: intEntityId },
+                },
+            },
+            include: {
+                entities: true,
+            },
+        });
+
+        return integrations.map((integration) => {
+            const converted = this._convertIntegrationIds(integration);
+            return {
+                id: converted.id,
+                entitiesIds: converted.entities.map((e) => e.id),
+                userId: converted.userId,
+                config: converted.config,
+                version: converted.version,
+                status: converted.status,
+                messages: converted.messages,
+            };
+        });
+    }
 }
 
 module.exports = { IntegrationRepositoryPostgres };

--- a/packages/core/integrations/tests/doubles/test-integration-repository.js
+++ b/packages/core/integrations/tests/doubles/test-integration-repository.js
@@ -46,6 +46,19 @@ class TestIntegrationRepository {
         return record || null;
     }
 
+    async findIntegrationsByEntityId(entityId) {
+        const target = String(entityId);
+        const results = Array.from(this.store.values()).filter((r) =>
+            (r.entitiesIds || []).map(String).includes(target)
+        );
+        this.operationHistory.push({
+            operation: 'findByEntityId',
+            entityId: target,
+            count: results.length,
+        });
+        return results;
+    }
+
     async updateIntegrationMessages(id, type, title, body, timestamp) {
         const rec = this.store.get(id);
         if (!rec) {

--- a/packages/core/modules/use-cases/__tests__/process-authorization-callback.test.js
+++ b/packages/core/modules/use-cases/__tests__/process-authorization-callback.test.js
@@ -1,0 +1,219 @@
+jest.mock('../../module', () => ({
+    Module: jest.fn().mockImplementation(({ userId, definition, entity }) => ({
+        userId,
+        entity,
+        credential: undefined,
+        definition,
+        apiClass: { requesterType: 'apiKey' },
+        api: { delegate: null },
+        testAuth: jest.fn().mockResolvedValue(true),
+        apiParamsFromCredential: jest.fn().mockReturnValue({}),
+        apiParamsFromEntity: jest.fn().mockReturnValue({}),
+        getName: jest.fn().mockReturnValue('testmodule'),
+    })),
+}));
+
+const {
+    ProcessAuthorizationCallback,
+} = require('../process-authorization-callback');
+const {
+    TestIntegrationRepository,
+} = require('../../../integrations/tests/doubles/test-integration-repository');
+
+describe('ProcessAuthorizationCallback — re-auth status restoration', () => {
+    let integrationRepository;
+    let moduleRepository;
+    let credentialRepository;
+    let moduleDefinitions;
+    let useCase;
+
+    beforeEach(() => {
+        integrationRepository = new TestIntegrationRepository();
+
+        moduleRepository = {
+            findEntity: jest.fn().mockResolvedValue({
+                id: 'entity-1',
+                userId: 'user-1',
+                moduleName: 'testmodule',
+                externalId: 'ext-1',
+                credential: 'cred-1',
+            }),
+            createEntity: jest.fn(),
+        };
+
+        credentialRepository = {
+            upsertCredential: jest.fn().mockResolvedValue({
+                id: 'cred-1',
+                userId: 'user-1',
+                authIsValid: true,
+            }),
+        };
+
+        moduleDefinitions = [
+            {
+                moduleName: 'testmodule',
+                modelName: 'TestModule',
+                API: class {},
+                requiredAuthMethods: {
+                    setAuthParams: jest.fn().mockResolvedValue({}),
+                    getCredentialDetails: jest.fn().mockResolvedValue({
+                        identifiers: {
+                            userId: 'user-1',
+                            externalId: 'cred-ext',
+                        },
+                        details: { api_key: 'secret' },
+                    }),
+                    getEntityDetails: jest.fn().mockResolvedValue({
+                        identifiers: {
+                            userId: 'user-1',
+                            externalId: 'ext-1',
+                        },
+                        details: { name: 'Workspace' },
+                    }),
+                },
+            },
+        ];
+
+        useCase = new ProcessAuthorizationCallback({
+            moduleRepository,
+            credentialRepository,
+            moduleDefinitions,
+            integrationRepository,
+        });
+    });
+
+    it('flips only broken integrations when a mix is linked to the entity', async () => {
+        const enabledInt = await integrationRepository.createIntegration(
+            ['entity-1'],
+            'user-1',
+            { type: 'testmodule' }
+        );
+        await integrationRepository.updateIntegrationStatus(
+            enabledInt.id,
+            'ENABLED'
+        );
+
+        const errorInt = await integrationRepository.createIntegration(
+            ['entity-1'],
+            'user-1',
+            { type: 'testmodule' }
+        );
+        await integrationRepository.updateIntegrationStatus(
+            errorInt.id,
+            'ERROR'
+        );
+
+        const disabledInt = await integrationRepository.createIntegration(
+            ['entity-1'],
+            'user-1',
+            { type: 'testmodule' }
+        );
+        await integrationRepository.updateIntegrationStatus(
+            disabledInt.id,
+            'DISABLED'
+        );
+
+        integrationRepository.clearHistory();
+
+        await useCase.execute('user-1', 'testmodule', { apiKey: 'new-key' });
+
+        const statusUpdates = integrationRepository
+            .getOperationHistory()
+            .filter((op) => op.operation === 'updateStatus');
+        expect(statusUpdates).toHaveLength(2);
+
+        const flippedIds = statusUpdates.map((op) => op.id).sort();
+        expect(flippedIds).toEqual([errorInt.id, disabledInt.id].sort());
+        expect(statusUpdates.every((op) => op.status === 'ENABLED')).toBe(
+            true
+        );
+
+        const enabledAfter = await integrationRepository.findIntegrationById(
+            enabledInt.id
+        );
+        expect(enabledAfter.status).toBe('ENABLED');
+    });
+
+    it('no-ops when no integration yet references the entity (first-time auth)', async () => {
+        integrationRepository.clearHistory();
+
+        await expect(
+            useCase.execute('user-1', 'testmodule', { apiKey: 'new-key' })
+        ).resolves.toBeDefined();
+
+        const statusUpdates = integrationRepository
+            .getOperationHistory()
+            .filter((op) => op.operation === 'updateStatus');
+        expect(statusUpdates).toHaveLength(0);
+    });
+
+    it('does not touch an integration that is already ENABLED', async () => {
+        const created = await integrationRepository.createIntegration(
+            ['entity-1'],
+            'user-1',
+            { type: 'testmodule' }
+        );
+        await integrationRepository.updateIntegrationStatus(
+            created.id,
+            'ENABLED'
+        );
+        integrationRepository.clearHistory();
+
+        await useCase.execute('user-1', 'testmodule', { apiKey: 'new-key' });
+
+        const statusUpdates = integrationRepository
+            .getOperationHistory()
+            .filter((op) => op.operation === 'updateStatus');
+        expect(statusUpdates).toHaveLength(0);
+    });
+
+    it('flips a DISABLED integration to ENABLED after successful re-auth', async () => {
+        const created = await integrationRepository.createIntegration(
+            ['entity-1'],
+            'user-1',
+            { type: 'testmodule' }
+        );
+        await integrationRepository.updateIntegrationStatus(
+            created.id,
+            'DISABLED'
+        );
+        integrationRepository.clearHistory();
+
+        await useCase.execute('user-1', 'testmodule', { apiKey: 'new-key' });
+
+        const updated = await integrationRepository.findIntegrationById(
+            created.id
+        );
+        expect(updated.status).toBe('ENABLED');
+    });
+
+    it('flips an ERROR integration to ENABLED after successful re-auth', async () => {
+        const created = await integrationRepository.createIntegration(
+            ['entity-1'],
+            'user-1',
+            { type: 'testmodule' }
+        );
+        await integrationRepository.updateIntegrationStatus(
+            created.id,
+            'ERROR'
+        );
+        integrationRepository.clearHistory();
+
+        await useCase.execute('user-1', 'testmodule', { apiKey: 'new-key' });
+
+        const updated = await integrationRepository.findIntegrationById(
+            created.id
+        );
+        expect(updated.status).toBe('ENABLED');
+
+        const statusUpdates = integrationRepository
+            .getOperationHistory()
+            .filter((op) => op.operation === 'updateStatus');
+        expect(statusUpdates).toHaveLength(1);
+        expect(statusUpdates[0]).toMatchObject({
+            id: created.id,
+            status: 'ENABLED',
+            success: true,
+        });
+    });
+});

--- a/packages/core/modules/use-cases/process-authorization-callback.js
+++ b/packages/core/modules/use-cases/process-authorization-callback.js
@@ -1,17 +1,31 @@
 const { Module } = require('../module');
 const { ModuleConstants } = require('../ModuleConstants');
 
+// Statuses considered "broken" for an integration whose credentials have just
+// been successfully re-authorized. Both ERROR (system-driven auth failure) and
+// DISABLED (user paused the integration) are flipped back to ENABLED when the
+// user completes a new authorization flow. See the Gap C fix in the RCA for the
+// reasoning.
+const STATUSES_RESET_ON_REAUTH = ['ERROR', 'DISABLED'];
+
 class ProcessAuthorizationCallback {
     /**
      * @param {Object} params - Configuration parameters.
      * @param {import('../repositories/module-repository-factory').ModuleRepositoryInterface} params.moduleRepository - Repository for module data operations.
      * @param {import('../../credential/repositories/credential-repository-factory').CredentialRepositoryInterface} params.credentialRepository - Repository for credential data operations.
      * @param {Array<Object>} params.moduleDefinitions - Array of module definitions.
+     * @param {import('../../integrations/repositories/integration-repository-interface').IntegrationRepositoryInterface} [params.integrationRepository] - Repository for integration data operations. When provided, integrations in a broken state linked to the re-authorized entity are restored to ENABLED.
      */
-    constructor({ moduleRepository, credentialRepository, moduleDefinitions }) {
+    constructor({
+        moduleRepository,
+        credentialRepository,
+        moduleDefinitions,
+        integrationRepository,
+    }) {
         this.moduleRepository = moduleRepository;
         this.credentialRepository = credentialRepository;
         this.moduleDefinitions = moduleDefinitions;
+        this.integrationRepository = integrationRepository;
     }
 
     async execute(userId, entityType, params) {
@@ -73,11 +87,42 @@ class ProcessAuthorizationCallback {
             module.credential.id
         );
 
+        // Best-effort: a hiccup here must not fail a successful re-auth whose
+        // credential + entity are already persisted. Operators can recover
+        // stuck integrations manually.
+        try {
+            await this.restoreIntegrationsForEntity(persistedEntity.id);
+        } catch (err) {
+            console.error(
+                `[Frigg] Failed to restore integrations for entity ${persistedEntity.id} after successful re-auth — manual intervention may be needed`,
+                err
+            );
+        }
+
         return {
             credential_id: module.credential.id,
             entity_id: persistedEntity.id,
             type: module.getName(),
         };
+    }
+
+    async restoreIntegrationsForEntity(entityId) {
+        if (!this.integrationRepository) return;
+        const integrations =
+            await this.integrationRepository.findIntegrationsByEntityId(
+                entityId
+            );
+        for (const integration of integrations) {
+            if (STATUSES_RESET_ON_REAUTH.includes(integration.status)) {
+                console.log(
+                    `[Frigg] Restoring integration ${integration.id} from ${integration.status} to ENABLED after successful re-auth (entityId=${entityId})`
+                );
+                await this.integrationRepository.updateIntegrationStatus(
+                    integration.id,
+                    'ENABLED'
+                );
+            }
+        }
     }
 
     async onTokenUpdate(module, moduleDefinition, userId) {

--- a/packages/core/modules/use-cases/process-authorization-callback.js
+++ b/packages/core/modules/use-cases/process-authorization-callback.js
@@ -4,8 +4,7 @@ const { ModuleConstants } = require('../ModuleConstants');
 // Statuses considered "broken" for an integration whose credentials have just
 // been successfully re-authorized. Both ERROR (system-driven auth failure) and
 // DISABLED (user paused the integration) are flipped back to ENABLED when the
-// user completes a new authorization flow. See the Gap C fix in the RCA for the
-// reasoning.
+// user completes a new authorization flow.
 const STATUSES_RESET_ON_REAUTH = ['ERROR', 'DISABLED'];
 
 class ProcessAuthorizationCallback {


### PR DESCRIPTION
## Summary

When a user re-authorizes an integration whose parent `Integration` record is in a broken state (`ERROR` or `DISABLED`), the framework refreshes the credential correctly but leaves `Integration.status` untouched. The queue worker short-circuits on `DISABLED` (`backend-utils.js:157,173`), so webhooks are silently discarded forever even after the customer completes a new OAuth flow.

This PR walks from the re-authorized entity up to any parent integrations and flips those in `{ERROR, DISABLED}` back to `ENABLED`, so customer-driven reconnect actually recovers the integration.

This is **Gap C of 3** from an RCA on Attio dead-token loops. Gap A (`OAuth2Requester.refreshAuth` unconditionally POSTs `grant_type=refresh_token` even when the stored `refresh_token` is `null`) and Gap B (no auto-flip to `ERROR` on `DLGT_INVALID_AUTH`) are separate upcoming PRs.

## Changes

- **New interface method** `findIntegrationsByEntityId(entityId)` on `IntegrationRepositoryInterface`.
- **Implementations**:
  - Postgres: many-to-many via `entities.some.id`
  - Mongo: scalar-array via `entityIds.has`
  - DocumentDB: raw `findMany` with `{ entityIds: objectId }`
- **Use case** `ProcessAuthorizationCallback`:
  - Accepts optional `integrationRepository` (backward compatible — omitted injection is a silent no-op).
  - At the end of `execute()`, calls new `restoreIntegrationsForEntity(entityId)` helper which looks up integrations referencing the entity and flips any in `STATUSES_RESET_ON_REAUTH = ['ERROR', 'DISABLED']` to `ENABLED`.
  - Wrapped in try/catch so a DB hiccup never fails an otherwise-successful re-auth; logs `console.error` on failure.
  - Logs `[Frigg] Restoring integration X from Y to ENABLED after successful re-auth (entityId=Z)` for operator visibility.
- **Wiring**: `integration-router.js` passes the already-created `integrationRepository` to the `ProcessAuthorizationCallback` constructor.
- **Test double** `TestIntegrationRepository` extended with matching in-memory `findIntegrationsByEntityId`.

## Semantic decision

Both `ERROR` and `DISABLED` are reset on re-auth. Reasoning: the user clicking "Reconnect" is an implicit opt-in to re-enable — whether the integration went bad via a system error or a manual user pause, the action of re-authorizing expresses intent to use it again. `PROCESSING` (active-run state) and `NEEDS_CONFIG` (config-incomplete, auth alone doesn't fix) are intentionally excluded.

## Test plan

**Unit tests (all 5 pass):**
- [x] ERROR integration flips to ENABLED
- [x] DISABLED integration flips to ENABLED
- [x] ENABLED integration is a no-op (no unnecessary updates)
- [x] Empty integrations list (first-time auth) does not throw
- [x] Mixed statuses: only broken ones flip, count is exact

**Manual end-to-end verification** on a local install:
- Integration `id=48` set to `status=DISABLED` + `Credential.authIsValid=false`
- Completed full Attio OAuth re-auth flow
- Confirmed via `GET /api/integrations` and direct DB query:
  - `Integration[48].status` → **`ENABLED`** ✓
  - `Credential[48].authIsValid` → `true`
  - `access_token` advanced
  - Log line `[Frigg] Restoring integration 48 from DISABLED to ENABLED after successful re-auth (entityId=60)` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)