### PR TITLE
fix(core): auto-disable Integration when credentials are invalidated

### DIFF
--- a/packages/core/handlers/backend-utils.js
+++ b/packages/core/handlers/backend-utils.js
@@ -154,9 +154,9 @@ const createQueueWorker = (integrationClass) => {
                         params.data.processId,
                         integrationClass
                     );
-                    if (integrationInstance?.status === 'DISABLED') {
+                    if (['DISABLED', 'ERROR'].includes(integrationInstance?.status)) {
                         console.warn(
-                            `[${integrationClass.Definition.name}] Integration for process ${params.data.processId} is DISABLED. Discarding ${params.event} message.`
+                            `[${integrationClass.Definition.name}] Integration for process ${params.data.processId} is ${integrationInstance.status}. Discarding ${params.event} message.`
                         );
                         return;
                     }
@@ -170,9 +170,9 @@ const createQueueWorker = (integrationClass) => {
                         );
                         return;
                     }
-                    if (integrationInstance.status === 'DISABLED') {
+                    if (['DISABLED', 'ERROR'].includes(integrationInstance.status)) {
                         console.warn(
-                            `[${integrationClass.Definition.name}] Integration ${params.data.integrationId} is DISABLED. Discarding ${params.event} message.`
+                            `[${integrationClass.Definition.name}] Integration ${params.data.integrationId} is ${integrationInstance.status}. Discarding ${params.event} message.`
                         );
                         return;
                     }

--- a/packages/core/handlers/workers/integration-defined-workers.test.js
+++ b/packages/core/handlers/workers/integration-defined-workers.test.js
@@ -429,6 +429,70 @@ describe('Webhook Queue Worker', () => {
             consoleSpy.mockRestore();
         });
 
+        it('should discard message when integration is ERROR', async () => {
+            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+            let mockedCreateQueueWorker;
+            jest.isolateModules(() => {
+                const mockIntegrationRecord = {
+                    id: '123',
+                    userId: 'user-1',
+                    entities: [],
+                    config: {},
+                    status: 'ERROR',
+                    version: '1.0.0',
+                    messages: { errors: [], warnings: [] },
+                };
+
+                jest.doMock('../../integrations/repositories/integration-repository-factory', () => ({
+                    createIntegrationRepository: () => ({
+                        findIntegrationById: jest.fn().mockResolvedValue(mockIntegrationRecord),
+                    }),
+                }));
+                jest.doMock('../../modules/repositories/module-repository-factory', () => ({
+                    createModuleRepository: () => ({}),
+                }));
+                jest.doMock('../app-definition-loader', () => ({
+                    loadAppDefinition: () => ({ integrations: [TestWebhookIntegration] }),
+                }));
+                jest.doMock('../../integrations/use-cases/get-integration-instance', () => ({
+                    GetIntegrationInstance: class {
+                        async execute() {
+                            const instance = new TestWebhookIntegration();
+                            instance.id = '123';
+                            instance.status = 'ERROR';
+                            return instance;
+                        }
+                    },
+                }));
+                mockedCreateQueueWorker = require('../backend-utils').createQueueWorker;
+            });
+
+            const QueueWorker = mockedCreateQueueWorker(TestWebhookIntegration);
+            const worker = new QueueWorker();
+
+            const params = {
+                event: 'ON_WEBHOOK',
+                data: {
+                    integrationId: '123',
+                    body: { webhookEvent: 'updated' },
+                },
+            };
+
+            const sqsEvent = {
+                Records: [{ messageId: 'msg-1', body: JSON.stringify(params) }],
+            };
+
+            const result = await worker.run(sqsEvent, {});
+
+            expect(result.batchItemFailures).toEqual([]);
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('ERROR')
+            );
+
+            consoleSpy.mockRestore();
+        });
+
         it('should process message normally when integration is ENABLED', async () => {
             const QueueWorker = createQueueWorker(TestWebhookIntegration);
             const worker = new QueueWorker();

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -253,7 +253,7 @@ class IntegrationBase {
             // of events it cannot handle itself (e.g. credential invalidation
             // needing an Integration.status flip). Without this, Module.notify
             // silently no-ops and Integration.status never updates on auth
-            // failure — see the Attio dead-token loop.
+            // failure.
             if (module && typeof module === 'object') {
                 module.delegate = this;
             }

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -248,6 +248,15 @@ class IntegrationBase {
                 modules[key] = module;
                 this[key] = module;
             }
+
+            // Wire the Delegate pattern so Module can notify this integration
+            // of events it cannot handle itself (e.g. credential invalidation
+            // needing an Integration.status flip). Without this, Module.notify
+            // silently no-ops and Integration.status never updates on auth
+            // failure — see the Attio dead-token loop.
+            if (module && typeof module === 'object') {
+                module.delegate = this;
+            }
         }
 
         return modules;
@@ -529,6 +538,35 @@ class IntegrationBase {
         // In the new architecture, modules are injected via constructor
         // For backward compatibility, this is a no-op
         return;
+    }
+
+    /**
+     * Receives notifications from modules (the Delegate pattern) when
+     * something integration-level needs attention. Today this catches the
+     * `CREDENTIAL_INVALIDATED` event Module fires from `markCredentialsInvalid`
+     * and flips this integration's status to DISABLED so the queue worker
+     * stops processing further webhooks until the user re-authorizes.
+     *
+     * Modules are wired to this delegate in `_appendModules()`, which runs
+     * during `setIntegrationRecord()` — this covers every construction path
+     * (HTTP read, queue worker, create/update/delete flows, etc.).
+     *
+     * The delegate string below must match `Module.DLGT_CREDENTIAL_INVALIDATED`
+     * in `packages/core/modules/module.js`.
+     *
+     * @param {Object} notifier - The module that fired the event
+     * @param {string} delegateString - Event type string
+     * @param {Object} [object] - Optional event payload
+     * @returns {Promise<void>}
+     */
+    async receiveNotification(notifier, delegateString, object = null) {
+        if (delegateString !== 'CREDENTIAL_INVALIDATED') return;
+        if (!this.id) return;
+        console.log(
+            `[Frigg] Module ${notifier?.name || '?'} reported invalid credentials for integration ${this.id} — marking DISABLED`
+        );
+        await this.updateIntegrationStatus.execute(this.id, 'DISABLED');
+        this.status = 'DISABLED';
     }
 }
 

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -563,10 +563,10 @@ class IntegrationBase {
         if (delegateString !== 'CREDENTIAL_INVALIDATED') return;
         if (!this.id) return;
         console.log(
-            `[Frigg] Module ${notifier?.name || '?'} reported invalid credentials for integration ${this.id} — marking DISABLED`
+            `[Frigg] Module ${notifier?.name || '?'} reported invalid credentials for integration ${this.id} — marking ERROR`
         );
-        await this.updateIntegrationStatus.execute(this.id, 'DISABLED');
-        this.status = 'DISABLED';
+        await this.updateIntegrationStatus.execute(this.id, 'ERROR');
+        this.status = 'ERROR';
     }
 }
 

--- a/packages/core/integrations/tests/integration-base-delegate-wiring.test.js
+++ b/packages/core/integrations/tests/integration-base-delegate-wiring.test.js
@@ -1,0 +1,35 @@
+jest.mock('../../database/config', () => ({
+    DB_TYPE: 'mongodb',
+    getDatabaseType: jest.fn(() => 'mongodb'),
+    PRISMA_LOG_LEVEL: 'error,warn',
+    PRISMA_QUERY_LOGGING: false,
+}));
+
+const { IntegrationBase } = require('../integration-base');
+
+/**
+ * The Delegate wiring between Module instances and their parent Integration
+ * lives in IntegrationBase._appendModules so that every code path that
+ * constructs an Integration (HTTP read, webhook queue worker, create/update
+ * flows, etc.) gets the bridge installed automatically.
+ */
+describe('IntegrationBase — module.delegate wiring', () => {
+    it('sets module.delegate = this for every module attached at construction', () => {
+        const moduleA = { getName: () => 'a', delegate: null };
+        const moduleB = { getName: () => 'b', delegate: null };
+
+        const integration = new IntegrationBase({
+            id: 'int-1',
+            userId: 'user-1',
+            entities: [],
+            config: { type: 'test' },
+            status: 'ENABLED',
+            version: '0.0.0',
+            messages: {},
+            modules: [moduleA, moduleB],
+        });
+
+        expect(moduleA.delegate).toBe(integration);
+        expect(moduleB.delegate).toBe(integration);
+    });
+});

--- a/packages/core/integrations/tests/integration-base-receive-notification.test.js
+++ b/packages/core/integrations/tests/integration-base-receive-notification.test.js
@@ -1,0 +1,61 @@
+jest.mock('../../database/config', () => ({
+    DB_TYPE: 'mongodb',
+    getDatabaseType: jest.fn(() => 'mongodb'),
+    PRISMA_LOG_LEVEL: 'error,warn',
+    PRISMA_QUERY_LOGGING: false,
+}));
+
+const { IntegrationBase } = require('../integration-base');
+
+describe('IntegrationBase.receiveNotification', () => {
+    let integration;
+    let mockUpdateIntegrationStatus;
+
+    beforeEach(() => {
+        integration = new IntegrationBase();
+        integration.id = 'int-1';
+        integration.status = 'ENABLED';
+
+        mockUpdateIntegrationStatus = {
+            execute: jest.fn().mockResolvedValue(true),
+        };
+        integration.updateIntegrationStatus = mockUpdateIntegrationStatus;
+    });
+
+    it('ignores unknown delegate strings', async () => {
+        await integration.receiveNotification(
+            { name: 'testmodule' },
+            'SOMETHING_ELSE',
+            {}
+        );
+        expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+        expect(integration.status).toBe('ENABLED');
+    });
+
+    it('no-ops when the integration has no id yet (not hydrated)', async () => {
+        integration.id = undefined;
+        await integration.receiveNotification(
+            { name: 'testmodule' },
+            'CREDENTIAL_INVALIDATED',
+            { credentialId: 'cred-1' }
+        );
+        expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+    });
+
+    it('flips the integration to DISABLED when a module reports CREDENTIAL_INVALIDATED', async () => {
+        const mockNotifier = { name: 'testmodule' };
+
+        await integration.receiveNotification(
+            mockNotifier,
+            'CREDENTIAL_INVALIDATED',
+            { credentialId: 'cred-1', moduleName: 'testmodule' }
+        );
+
+        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledTimes(1);
+        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
+            'int-1',
+            'DISABLED'
+        );
+        expect(integration.status).toBe('DISABLED');
+    });
+});

--- a/packages/core/integrations/tests/integration-base-receive-notification.test.js
+++ b/packages/core/integrations/tests/integration-base-receive-notification.test.js
@@ -42,7 +42,7 @@ describe('IntegrationBase.receiveNotification', () => {
         expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
     });
 
-    it('flips the integration to DISABLED when a module reports CREDENTIAL_INVALIDATED', async () => {
+    it('flips the integration to ERROR when a module reports CREDENTIAL_INVALIDATED', async () => {
         const mockNotifier = { name: 'testmodule' };
 
         await integration.receiveNotification(
@@ -54,8 +54,8 @@ describe('IntegrationBase.receiveNotification', () => {
         expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledTimes(1);
         expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
             'int-1',
-            'DISABLED'
+            'ERROR'
         );
-        expect(integration.status).toBe('DISABLED');
+        expect(integration.status).toBe('ERROR');
     });
 });

--- a/packages/core/modules/module.js
+++ b/packages/core/modules/module.js
@@ -37,6 +37,10 @@ class Module extends Delegate {
         this.credentialRepository = createCredentialRepository();
         this.moduleRepository = createModuleRepository();
 
+        // Module → parent delegate (typically IntegrationBase) events
+        this.DLGT_CREDENTIAL_INVALIDATED = 'CREDENTIAL_INVALIDATED';
+        this.delegateTypes.push(this.DLGT_CREDENTIAL_INVALIDATED);
+
         Object.assign(this, this.definition.requiredAuthMethods);
 
         const apiParams = {
@@ -142,6 +146,30 @@ class Module extends Delegate {
         // Keep the in-memory snapshot consistent so that callers can read the
         // updated state without another fetch.
         this.credential.authIsValid = false;
+
+        // Propagate upward so a parent delegate (e.g. IntegrationBase) can
+        // react — for instance by flipping Integration.status to DISABLED.
+        // Delegate.notify is a silent no-op when this.delegate is null, so
+        // Module instances constructed outside of an Integration context
+        // (e.g. during ProcessAuthorizationCallback) remain unaffected.
+        //
+        // Best-effort: this method is invoked from the OAuth2Requester 401
+        // refresh catch block, which depends on us NOT throwing. A DB hiccup
+        // in the downstream status flip must not alter refreshAuth's
+        // documented `return false` contract. The credential has already
+        // been persisted as invalid; integrations left un-flipped can be
+        // recovered by the next retry or by operator intervention.
+        try {
+            await this.notify(this.DLGT_CREDENTIAL_INVALIDATED, {
+                credentialId: this.credential.id,
+                moduleName: this.name,
+            });
+        } catch (err) {
+            console.error(
+                `[Frigg] Failed to propagate CREDENTIAL_INVALIDATED for module ${this.name}:`,
+                err?.message || err
+            );
+        }
     }
 
     async deauthorize() {

--- a/packages/core/modules/tests/module-mark-credentials-invalid.test.js
+++ b/packages/core/modules/tests/module-mark-credentials-invalid.test.js
@@ -1,0 +1,86 @@
+jest.mock('../../database/config', () => ({
+    DB_TYPE: 'mongodb',
+    getDatabaseType: jest.fn(() => 'mongodb'),
+    PRISMA_LOG_LEVEL: 'error,warn',
+    PRISMA_QUERY_LOGGING: false,
+}));
+
+const { Module } = require('../module');
+
+describe('Module.markCredentialsInvalid delegate propagation', () => {
+    let mockCredentialRepository;
+    let mockDefinition;
+    let module;
+
+    beforeEach(() => {
+        mockCredentialRepository = {
+            updateAuthenticationStatus: jest.fn().mockResolvedValue(true),
+        };
+
+        mockDefinition = {
+            moduleName: 'testmodule',
+            modelName: 'TestModule',
+            API: class MockAPI {
+                constructor() {}
+            },
+            requiredAuthMethods: {
+                getToken: jest.fn(),
+                getEntityDetails: jest.fn(),
+                getCredentialDetails: jest.fn(),
+                apiPropertiesToPersist: {
+                    credential: [],
+                    entity: [],
+                },
+                testAuthRequest: jest.fn(),
+            },
+        };
+
+        const entityObj = {
+            id: 'entity-1',
+            userId: 'user-1',
+            credential: { id: 'cred-1', authIsValid: true },
+        };
+
+        module = new Module({
+            definition: mockDefinition,
+            userId: 'user-1',
+            entity: entityObj,
+        });
+
+        module.credentialRepository = mockCredentialRepository;
+    });
+
+    it('completes silently when no delegate is wired (backward compat)', async () => {
+        expect(module.delegate).toBeNull();
+
+        await expect(module.markCredentialsInvalid()).resolves.toBeUndefined();
+
+        expect(
+            mockCredentialRepository.updateAuthenticationStatus
+        ).toHaveBeenCalledWith('cred-1', false);
+        expect(module.credential.authIsValid).toBe(false);
+    });
+
+    it('notifies its delegate with CREDENTIAL_INVALIDATED after flipping the credential', async () => {
+        const mockDelegate = {
+            receiveNotification: jest.fn().mockResolvedValue(undefined),
+        };
+        module.delegate = mockDelegate;
+
+        await module.markCredentialsInvalid();
+
+        expect(mockCredentialRepository.updateAuthenticationStatus).toHaveBeenCalledWith(
+            'cred-1',
+            false
+        );
+        expect(mockDelegate.receiveNotification).toHaveBeenCalledTimes(1);
+        expect(mockDelegate.receiveNotification).toHaveBeenCalledWith(
+            module,
+            'CREDENTIAL_INVALIDATED',
+            expect.objectContaining({
+                credentialId: 'cred-1',
+                moduleName: 'testmodule',
+            })
+        );
+    });
+});


### PR DESCRIPTION
## Summary

When `OAuth2Requester.refreshAuth` fails and `Module.markCredentialsInvalid` flips `Credential.authIsValid` to `false`, `Integration.status` was left as `ENABLED`. The queue worker only short-circuits on `DISABLED`, so every subsequent webhook kept getting processed, failed again, and re-entered the error loop -- producing 94k+ error lines/day for Attio integrations with dead tokens.

This PR uses Frigg's existing `Delegate` pattern to propagate the failure upward:

- **Module** fires a new `CREDENTIAL_INVALIDATED` event from `markCredentialsInvalid` (best-effort try/catch so it never alters `refreshAuth`'s documented `return false` contract)
- **IntegrationBase** catches the event in a new `receiveNotification` method and calls `updateIntegrationStatus.execute(this.id, 'ERROR')`
- The delegate wire (`module.delegate = this`) is installed in `IntegrationBase._appendModules`, covering all 7 code paths that construct Integration instances (HTTP reads, queue workers, create/update/delete flows)
- **Queue worker** (`backend-utils.js`) now discards on both `DISABLED` and `ERROR` statuses (previously only `DISABLED`)

### Status semantics (per Frigg team lead feedback)

| Status | Meaning | Who sets it | Queue worker | Re-auth clears it |
|---|---|---|---|---|
| **ENABLED** | Active, processing webhooks | Initial state + Gap C re-auth | Processes | n/a |
| **DISABLED** | User intentionally paused | User action only | Discards | Yes (Reconnect = opt-in) |
| **ERROR** | Credentials dead (system) | This PR (auto-flip) | Discards | Yes (new creds fix it) |

**This is Gap B of 3 from the Attio dead-token RCA:**
- Gap A (refresh short-circuit when `refresh_token` is null): PR #575
- Gap B (auto-set ERROR on invalid auth + queue worker discard): **this PR**
- Gap C (restore Integration on re-auth): PR #574

Recovery is handled by Gap C: `ProcessAuthorizationCallback.restoreIntegrationsForEntity` flips `{ERROR, DISABLED}` back to `ENABLED` on successful re-auth, so Gaps B + C are complementary.

## Files changed

| File | Change |
|---|---|
| `packages/core/modules/module.js` | New `DLGT_CREDENTIAL_INVALIDATED` constant + `this.notify(...)` at end of `markCredentialsInvalid()`, wrapped in try/catch |
| `packages/core/integrations/integration-base.js` | `module.delegate = this` wiring in `_appendModules` loop + new `receiveNotification()` handler that flips status to `ERROR` |
| `packages/core/handlers/backend-utils.js` | Queue worker status discard extended from `=== 'DISABLED'` to `['DISABLED', 'ERROR'].includes(status)` at both check points (lines 157, 173) |

## Test plan

7 unit tests across 4 files (all green, 19 suites / 171 tests full regression clean):

- [x] Module fires `CREDENTIAL_INVALIDATED` to its delegate after credential flip
- [x] Module with `delegate=null` completes silently (backward compat)
- [x] IntegrationBase flips to `ERROR` on `CREDENTIAL_INVALIDATED`
- [x] IntegrationBase ignores unknown delegate strings
- [x] IntegrationBase no-ops when `this.id` is falsy (not hydrated)
- [x] `IntegrationBase._appendModules` sets `module.delegate = this` for all modules
- [x] Queue worker discards message when integration status is `ERROR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)