### PR TITLE
ci: drop broken 'npm install -g npm@latest' from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         run: |
-          npm install -g npm@latest
           npm ci
           cd packages/ui
           npm run build


### PR DESCRIPTION
## Summary

Every Release workflow run on \`next\` (and every PR branch) has been failing for days with:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - .../npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
\`\`\`

This is a well-known regression in npm's self-upgrade path on Node 22: installing \`npm@latest\` (11.x) over the bundled npm 10.9.7 on \`ubuntu-latest\` leaves the bundled arborist tree in an inconsistent state. Subsequent operations (\`npm ci\`) crash before they can run.

Removing the unnecessary \`npm install -g npm@latest\` line unblocks releases. The bundled npm 10.9.7 on the \`ubuntu-latest\` runner image is adequate for \`npm ci\`, \`npm run build\`, and \`npx auto shipit\`.

## Evidence

Recent Release runs — all failing at this exact step:
- https://github.com/friggframework/frigg/actions/runs/24527469348 (push to \`next\`)
- https://github.com/friggframework/frigg/actions/runs/24526553964 (PR #576)
- https://github.com/friggframework/frigg/actions/runs/24519783603 (PR #576)
- https://github.com/friggframework/frigg/actions/runs/24525419964 (push to \`next\`)

## Diff

\`\`\`diff
       - name: Auto release
         run: |
-          npm install -g npm@latest
           npm ci
           cd packages/ui
           npm run build
           cd ../..
           npx auto shipit
\`\`\`

## Test plan

- [x] Workflow file YAML still parses
- [x] Minimal surgical diff (one line removed)
- [ ] Once merged, \`next\` push triggers Release workflow — should progress past \`npm ci\` and either publish (if a release-labeled PR is in the queue) or no-op cleanly

## Note on labels

Intentionally NOT adding \`release\` / \`prerelease\` labels — this is a CI-only fix that doesn't change published package contents. The next merge with those labels (e.g. PRs #574, #575, #576 — Gaps C/A/B of the Attio dead-token RCA) will cut the first successful release.

## Alternative idiom (not used here)

If a specific newer npm is ever needed, the safe modern recipe is:

\`\`\`yaml
- run: corepack enable && corepack prepare npm@11 --activate
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.577.bd5a32b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.577.bd5a32b.0
  npm install @friggframework/devtools@2.0.0--canary.577.bd5a32b.0
  npm install @friggframework/eslint-config@2.0.0--canary.577.bd5a32b.0
  npm install @friggframework/prettier-config@2.0.0--canary.577.bd5a32b.0
  npm install @friggframework/schemas@2.0.0--canary.577.bd5a32b.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.577.bd5a32b.0
  npm install @friggframework/test@2.0.0--canary.577.bd5a32b.0
  npm install @friggframework/ui@2.0.0--canary.577.bd5a32b.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.577.bd5a32b.0
  yarn add @friggframework/devtools@2.0.0--canary.577.bd5a32b.0
  yarn add @friggframework/eslint-config@2.0.0--canary.577.bd5a32b.0
  yarn add @friggframework/prettier-config@2.0.0--canary.577.bd5a32b.0
  yarn add @friggframework/schemas@2.0.0--canary.577.bd5a32b.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.577.bd5a32b.0
  yarn add @friggframework/test@2.0.0--canary.577.bd5a32b.0
  yarn add @friggframework/ui@2.0.0--canary.577.bd5a32b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.79`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/schemas`
    - feat(schemas): extract schemas changes from PR #522 [#569](https://github.com/friggframework/frigg/pull/569) ([@claude](https://github.com/claude) [@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - ci: drop broken 'npm install -g npm@latest' from release workflow [#577](https://github.com/friggframework/frigg/pull/577) ([@d-klotz](https://github.com/d-klotz))
  - Split PR #522 [1/9]: Documentation updates [#557](https://github.com/friggframework/frigg/pull/557) ([@claude](https://github.com/claude) [@seanspeaks](https://github.com/seanspeaks))
  - `@friggframework/core`
    - fix(core): auto-disable Integration when credentials are invalidated [#576](https://github.com/friggframework/frigg/pull/576) ([@d-klotz](https://github.com/d-klotz))
    - fix(core): restore Integration status to ENABLED on successful re-auth [#574](https://github.com/friggframework/frigg/pull/574) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - Sanitize fetch error [#536](https://github.com/friggframework/frigg/pull/536) ([@MichaelRyanWebber](https://github.com/MichaelRyanWebber))
    - fix(core): gracefully handle webhooks for deleted integrations [#550](https://github.com/friggframework/frigg/pull/550) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 4
  
  - [@MichaelRyanWebber](https://github.com/MichaelRyanWebber)
  - Claude ([@claude](https://github.com/claude))
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
