### PR TITLE
feat(devtools): expose Integration.Definition.queue tuning knobs

### DIFF
--- a/packages/devtools/infrastructure/domains/integration/integration-builder.js
+++ b/packages/devtools/infrastructure/domains/integration/integration-builder.js
@@ -25,6 +25,51 @@ const {
     ResourceOwnership,
 } = require('../shared/types');
 
+/**
+ * Bounds-check Definition.queue knobs against AWS SQS limits.
+ * Throws on out-of-range values so we fail at template-generation time
+ * instead of waiting for an opaque CloudFormation rejection.
+ */
+function validateQueueConfig(integrationName, queueConfig) {
+    const inRange = (val, min, max) =>
+        val === undefined || (Number.isFinite(val) && val >= min && val <= max);
+    const checks = [
+        ['visibilityTimeout', queueConfig.visibilityTimeout, 0, 43200],
+        ['messageRetentionPeriod', queueConfig.messageRetentionPeriod, 60, 1209600],
+        ['maxReceiveCount', queueConfig.maxReceiveCount, 1, 1000],
+    ];
+    for (const [key, val, min, max] of checks) {
+        if (!inRange(val, min, max)) {
+            throw new Error(
+                `Integration '${integrationName}': queue.${key}=${val} is out of range [${min}, ${max}]`
+            );
+        }
+    }
+}
+
+/**
+ * Bounds-check Definition.queue.worker knobs against the serverless
+ * framework + AWS Lambda+SQS limits. Mirrors osls's own input schema.
+ */
+function validateWorkerConfig(integrationName, workerConfig) {
+    const inRange = (val, min, max) =>
+        val === undefined || (Number.isFinite(val) && val >= min && val <= max);
+    const checks = [
+        ['batchSize', workerConfig.batchSize, 1, 10000],
+        ['maximumBatchingWindow', workerConfig.maximumBatchingWindow, 0, 300],
+        ['maximumConcurrency', workerConfig.maximumConcurrency, 2, 1000],
+        ['reservedConcurrency', workerConfig.reservedConcurrency, 0, 1000],
+        ['timeout', workerConfig.timeout, 1, 900],
+    ];
+    for (const [key, val, min, max] of checks) {
+        if (!inRange(val, min, max)) {
+            throw new Error(
+                `Integration '${integrationName}': queue.worker.${key}=${val} is out of range [${min}, ${max}]`
+            );
+        }
+    }
+}
+
 class IntegrationBuilder extends InfrastructureBuilder {
     constructor() {
         super();
@@ -218,7 +263,11 @@ class IntegrationBuilder extends InfrastructureBuilder {
                 console.log(
                     `      ✓ Creating ${integrationName}Queue in stack`
                 );
-                this.createIntegrationQueue(integrationName, result);
+                this.createIntegrationQueue(
+                    integrationName,
+                    result,
+                    integration.Definition.queue
+                );
             } else {
                 console.log(`      ✓ Using external ${integrationName}Queue`);
                 this.useExternalIntegrationQueue(
@@ -366,27 +415,36 @@ class IntegrationBuilder extends InfrastructureBuilder {
 
         // Create Queue Worker function
         const queueWorkerName = `${integrationName}QueueWorker`;
+        const workerConfig = integration.Definition.queue?.worker || {};
+        validateWorkerConfig(integrationName, workerConfig);
+        const sqsEvent = {
+            arn: {
+                'Fn::GetAtt': [
+                    `${this.capitalizeFirst(integrationName)}Queue`,
+                    'Arn',
+                ],
+            },
+            batchSize: workerConfig.batchSize ?? 1,
+            functionResponseType: 'ReportBatchItemFailures',
+        };
+        // The serverless framework SQS event accepts `maximumBatchingWindow`
+        // (not `...InSeconds` — that's the AWS-side CFN property name). osls
+        // and serverless@3+ both reject the longer key with a schema error.
+        if (workerConfig.maximumBatchingWindow !== undefined) {
+            sqsEvent.maximumBatchingWindow =
+                workerConfig.maximumBatchingWindow;
+        }
+        if (workerConfig.maximumConcurrency !== undefined) {
+            sqsEvent.maximumConcurrency = workerConfig.maximumConcurrency;
+        }
         result.functions[queueWorkerName] = {
             handler: `node_modules/@friggframework/core/handlers/workers/integration-defined-workers.handlers.${integrationName}.queueWorker`,
             skipEsbuild: true, // Nested exports in node_modules - skip esbuild bundling
             package: functionPackageConfig,
             ...(usePrismaLayer && { layers: [{ Ref: 'PrismaLambdaLayer' }] }), // Queue workers need Prisma for database operations
-            reservedConcurrency: 20,
-            events: [
-                {
-                    sqs: {
-                        arn: {
-                            'Fn::GetAtt': [
-                                `${this.capitalizeFirst(integrationName)}Queue`,
-                                'Arn',
-                            ],
-                        },
-                        batchSize: 1,
-                        functionResponseType: 'ReportBatchItemFailures',
-                    },
-                },
-            ],
-            timeout: 900, // 15 minutes max for queue workers (Lambda maximum)
+            reservedConcurrency: workerConfig.reservedConcurrency ?? 20,
+            events: [{ sqs: sqsEvent }],
+            timeout: workerConfig.timeout ?? 900, // 15 minutes max for queue workers (Lambda maximum)
         };
         console.log(`      ✓ Queue worker function defined`);
     }
@@ -495,7 +553,8 @@ class IntegrationBuilder extends InfrastructureBuilder {
     /**
      * Create integration-specific SQS queue CloudFormation resource
      */
-    createIntegrationQueue(integrationName, result) {
+    createIntegrationQueue(integrationName, result, queueConfig = {}) {
+        validateQueueConfig(integrationName, queueConfig);
         const queueReference = `${this.capitalizeFirst(integrationName)}Queue`;
         const queueName = `\${self:service}--\${self:provider.stage}-${queueReference}`;
 
@@ -503,10 +562,11 @@ class IntegrationBuilder extends InfrastructureBuilder {
             Type: 'AWS::SQS::Queue',
             Properties: {
                 QueueName: `\${self:custom.${queueReference}}`,
-                MessageRetentionPeriod: 345600, // 4 days (SQS default)
-                VisibilityTimeout: 1800,
+                MessageRetentionPeriod:
+                    queueConfig.messageRetentionPeriod ?? 345600, // 4 days (SQS default)
+                VisibilityTimeout: queueConfig.visibilityTimeout ?? 1800,
                 RedrivePolicy: {
-                    maxReceiveCount: 3,
+                    maxReceiveCount: queueConfig.maxReceiveCount ?? 3,
                     deadLetterTargetArn: {
                         'Fn::GetAtt': ['InternalErrorQueue', 'Arn'],
                     },

--- a/packages/devtools/infrastructure/domains/integration/integration-builder.test.js
+++ b/packages/devtools/infrastructure/domains/integration/integration-builder.test.js
@@ -397,6 +397,164 @@ describe('IntegrationBuilder', () => {
         });
     });
 
+    describe('Integration.Definition.queue tuning knobs', () => {
+        it('overrides VisibilityTimeout, MessageRetentionPeriod, and maxReceiveCount on the queue', async () => {
+            const appDefinition = {
+                integrations: [
+                    {
+                        Definition: {
+                            name: 'tuned',
+                            queue: {
+                                visibilityTimeout: 960,
+                                messageRetentionPeriod: 86400,
+                                maxReceiveCount: 5,
+                            },
+                        },
+                    },
+                ],
+            };
+
+            const result = await integrationBuilder.build(appDefinition, {});
+            const props = result.resources.TunedQueue.Properties;
+
+            expect(props.VisibilityTimeout).toBe(960);
+            expect(props.MessageRetentionPeriod).toBe(86400);
+            expect(props.RedrivePolicy.maxReceiveCount).toBe(5);
+        });
+
+        it('overrides worker batchSize, maximumBatchingWindow, maximumConcurrency, reservedConcurrency, and timeout', async () => {
+            const appDefinition = {
+                integrations: [
+                    {
+                        Definition: {
+                            name: 'tuned',
+                            queue: {
+                                worker: {
+                                    batchSize: 5,
+                                    maximumBatchingWindow: 2,
+                                    maximumConcurrency: 20,
+                                    reservedConcurrency: 10,
+                                    timeout: 120,
+                                },
+                            },
+                        },
+                    },
+                ],
+            };
+
+            const result = await integrationBuilder.build(appDefinition, {});
+            const fn = result.functions.tunedQueueWorker;
+            const sqsEvent = fn.events[0].sqs;
+
+            expect(sqsEvent.batchSize).toBe(5);
+            expect(sqsEvent.maximumBatchingWindow).toBe(2);
+            expect(sqsEvent.maximumConcurrency).toBe(20);
+            expect(fn.reservedConcurrency).toBe(10);
+            expect(fn.timeout).toBe(120);
+        });
+
+        it('preserves defaults when queue is omitted (backward compat)', async () => {
+            const appDefinition = {
+                integrations: [{ Definition: { name: 'untouched' } }],
+            };
+
+            const result = await integrationBuilder.build(appDefinition, {});
+            const props = result.resources.UntouchedQueue.Properties;
+            const fn = result.functions.untouchedQueueWorker;
+            const sqsEvent = fn.events[0].sqs;
+
+            expect(props.VisibilityTimeout).toBe(1800);
+            expect(props.MessageRetentionPeriod).toBe(345600);
+            expect(props.RedrivePolicy.maxReceiveCount).toBe(3);
+            expect(sqsEvent.batchSize).toBe(1);
+            expect(sqsEvent.maximumBatchingWindow).toBeUndefined();
+            expect(sqsEvent.maximumConcurrency).toBeUndefined();
+            expect(fn.reservedConcurrency).toBe(20);
+            expect(fn.timeout).toBe(900);
+        });
+
+        it('handles queue: {} and queue.worker: {} as no-op', async () => {
+            const appDefinition = {
+                integrations: [
+                    { Definition: { name: 'empty', queue: {} } },
+                    { Definition: { name: 'emptyworker', queue: { worker: {} } } },
+                ],
+            };
+
+            const result = await integrationBuilder.build(appDefinition, {});
+
+            expect(result.resources.EmptyQueue.Properties.VisibilityTimeout).toBe(1800);
+            expect(result.functions.emptyQueueWorker.events[0].sqs.batchSize).toBe(1);
+            expect(result.functions.emptyworkerQueueWorker.events[0].sqs.batchSize).toBe(1);
+        });
+
+        it('does NOT emit maximumBatchingWindow / maximumConcurrency keys when unset', async () => {
+            // Conditional spread keeps the emitted serverless template stable
+            // for consumers who don't opt in. Important — adding undefined
+            // keys would change the serialized template hash.
+            const appDefinition = {
+                integrations: [{ Definition: { name: 'notuned' } }],
+            };
+
+            const result = await integrationBuilder.build(appDefinition, {});
+            const sqsEvent = result.functions.notunedQueueWorker.events[0].sqs;
+
+            expect('maximumBatchingWindow' in sqsEvent).toBe(false);
+            expect('maximumConcurrency' in sqsEvent).toBe(false);
+        });
+
+        it('rejects out-of-range queue.visibilityTimeout (>43200)', async () => {
+            const appDefinition = {
+                integrations: [
+                    {
+                        Definition: {
+                            name: 'bad',
+                            queue: { visibilityTimeout: 99999 },
+                        },
+                    },
+                ],
+            };
+
+            await expect(
+                integrationBuilder.build(appDefinition, {})
+            ).rejects.toThrow(/visibilityTimeout=99999 is out of range/);
+        });
+
+        it('rejects out-of-range queue.worker.maximumConcurrency (<2)', async () => {
+            const appDefinition = {
+                integrations: [
+                    {
+                        Definition: {
+                            name: 'bad',
+                            queue: { worker: { maximumConcurrency: 1 } },
+                        },
+                    },
+                ],
+            };
+
+            await expect(
+                integrationBuilder.build(appDefinition, {})
+            ).rejects.toThrow(/worker\.maximumConcurrency=1 is out of range/);
+        });
+
+        it('rejects out-of-range queue.worker.timeout (>900)', async () => {
+            const appDefinition = {
+                integrations: [
+                    {
+                        Definition: {
+                            name: 'bad',
+                            queue: { worker: { timeout: 901 } },
+                        },
+                    },
+                ],
+            };
+
+            await expect(
+                integrationBuilder.build(appDefinition, {})
+            ).rejects.toThrow(/worker\.timeout=901 is out of range/);
+        });
+    });
+
     describe('DLQ Observability', () => {
         it('should create a CloudWatch alarm for DLQ message depth', async () => {
             const appDefinition = {

--- a/packages/devtools/infrastructure/domains/shared/types/app-definition.js
+++ b/packages/devtools/infrastructure/domains/shared/types/app-definition.js
@@ -100,10 +100,28 @@
  */
 
 /**
+ * Integration queue tuning knobs (optional, all defaults preserved when unset).
+ * Bounds enforced at template-generation time — see validateQueueConfig /
+ * validateWorkerConfig in integration-builder.js.
+ *
+ * @typedef {Object} IntegrationQueueDefinition
+ * @property {number} [visibilityTimeout] - SQS VisibilityTimeout seconds. Range 0..43200. Default 1800.
+ * @property {number} [messageRetentionPeriod] - SQS MessageRetentionPeriod seconds. Range 60..1209600. Default 345600 (4 days).
+ * @property {number} [maxReceiveCount] - DLQ redrive policy maxReceiveCount. Range 1..1000. Default 3.
+ * @property {Object} [worker] - Queue-worker Lambda + event-source-mapping tuning
+ * @property {number} [worker.batchSize] - SQS event batchSize. Range 1..10000. Default 1.
+ * @property {number} [worker.maximumBatchingWindow] - SQS event MaximumBatchingWindowInSeconds. Range 0..300. Default unset. NOTE: serverless-framework key, not the longer CFN property name.
+ * @property {number} [worker.maximumConcurrency] - SQS ESM ScalingConfig.MaximumConcurrency. Range 2..1000. Default unset.
+ * @property {number} [worker.reservedConcurrency] - Lambda ReservedConcurrency. Range 0..1000. Default 20.
+ * @property {number} [worker.timeout] - Queue-worker Lambda execution timeout (seconds). Range 1..900. Default 900.
+ */
+
+/**
  * Integration configuration
  * @typedef {Object} IntegrationDefinition
  * @property {Object} Definition - Integration definition object
  * @property {string} Definition.name - Integration name
+ * @property {IntegrationQueueDefinition} [Definition.queue] - Optional SQS + queue-worker tuning
  */
 
 /**


### PR DESCRIPTION
## Summary

Adds an optional `Definition.queue` block on each integration so consumers can express SQS + queue-worker tuning declaratively in their app definition, instead of applying it post-deploy via `aws lambda update-event-source-mapping` / `aws sqs set-queue-attributes`.

Today, every consumer gets the same hard-coded values (`VisibilityTimeout: 1800`, `batchSize: 1`, `reservedConcurrency: 20`, no scaling-config concurrency cap, no batching window). Tuning these requires either forking the framework or running ad-hoc AWS CLI commands after each deploy that drift from the source of truth. This PR brings them into the app definition with the same opt-in pattern as Aurora's `database.postgres.{minCapacity,maxCapacity}`.

## Knobs

All optional. Unset → identical output to before (verified by a backward-compat test).

```js
HubSpotIntegration.Definition.queue = {
  visibilityTimeout: 960,         // SQS VisibilityTimeout         [0..43200]    default 1800
  messageRetentionPeriod: 345600, // SQS MessageRetentionPeriod    [60..1209600] default 345600
  maxReceiveCount: 3,             // DLQ redrive maxReceiveCount   [1..1000]     default 3
  worker: {
    batchSize: 5,                          // SQS event batchSize                  [1..10000] default 1
    maximumBatchingWindow: 2,              // SQS MaximumBatchingWindowInSeconds   [0..300]   default unset
    maximumConcurrency: 20,                // ESM ScalingConfig.MaximumConcurrency [2..1000]  default unset
    reservedConcurrency: 20,               // Lambda ReservedConcurrency           [0..1000]  default 20
    timeout: 900,                          // Lambda execution timeout (seconds)   [1..900]   default 900
  },
};
```

## Implementation notes

- **`maximumBatchingWindow`, not `maximumBatchingWindowInSeconds`**: the serverless framework / `osls` SQS event schema accepts the shorter key and rejects the longer (CloudFormation-style) name with `additionalProperties: false`. Easy mistake — flagged in code review.
- **Conditional spread on `maximumBatchingWindow` / `maximumConcurrency`**: only emitted to the rendered template when defined, so non-opt-in consumers see byte-identical output.
- **Bounds-checked at template-generation time** in `validateQueueConfig` / `validateWorkerConfig`. Consistent with `aurora-builder.js` validating `min/maxCapacity`. Out-of-range values throw a clear error from the framework instead of an opaque CloudFormation rejection two minutes into a `serverless deploy`.
- **Backward-compat is the central invariant**: a new test covers `queue: undefined`, `queue: {}`, and `queue: { worker: {} }` — all three should produce default behavior.

## Downstream prerequisite (consumer-facing)

`worker.batchSize > 1` requires the integration's queue-worker handler to return `{ batchItemFailures: [...] }` for partial-batch failures. The framework already wires `functionResponseType: 'ReportBatchItemFailures'` (same as before), so the SQS side is correct — but with `batchSize: 1` the partial-batch path was moot, and with `batchSize > 1` it isn't. Worth calling out in release notes.

## Tests

97 pass (89 existing + 8 new):

- Override path: queue-level knobs (visibility/retention/maxReceive)
- Override path: worker-level knobs (batchSize/maximumBatchingWindow/maximumConcurrency/reservedConcurrency/timeout)
- Backward compat: `queue` omitted produces all defaults
- Edge cases: `queue: {}` and `queue: { worker: {} }` are no-ops
- Invariant: unset `maximumBatchingWindow` / `maximumConcurrency` are NOT serialized
- Validation: out-of-range `visibilityTimeout`, `worker.maximumConcurrency`, `worker.timeout` throw

## Test plan

- [x] `npx jest packages/devtools/infrastructure/domains/integration/integration-builder.test.js` — 97/97 pass
- [x] Smoke test: restart consumer's Frigg locally with default config — `IntegrationBuilder` exits cleanly through new code path, queue + worker resources emitted (verified against `clockwork-recruiting--frigg` consumer)
- [ ] End-to-end smoke against `serverless deploy` with at least one knob set (any consumer; not blocking review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)