### PR TITLE
fix(core): explicitly persist tokens on OAuth2 re-auth

### DIFF
--- a/packages/core/integrations/integration-router.js
+++ b/packages/core/integrations/integration-router.js
@@ -507,7 +507,8 @@ function setEntityRoutes(router, authenticateUser, useCases) {
             const params = checkRequiredParams(req.query, ['entityType']);
             const module = await getModuleInstanceFromType.execute(
                 userId,
-                params.entityType
+                params.entityType,
+                { state: req.query.state }
             );
             const areRequirementsValid =
                 module.validateAuthorizationRequirements();

--- a/packages/core/integrations/integration-router.js
+++ b/packages/core/integrations/integration-router.js
@@ -507,8 +507,7 @@ function setEntityRoutes(router, authenticateUser, useCases) {
             const params = checkRequiredParams(req.query, ['entityType']);
             const module = await getModuleInstanceFromType.execute(
                 userId,
-                params.entityType,
-                { state: req.query.state }
+                params.entityType
             );
             const areRequirementsValid =
                 module.validateAuthorizationRequirements();
@@ -531,13 +530,33 @@ function setEntityRoutes(router, authenticateUser, useCases) {
                 'data',
             ]);
 
-            const entityDetails = await processAuthorizationCallback.execute(
-                userId,
-                params.entityType,
-                params.data
+            const dataKeys =
+                params.data && typeof params.data === 'object'
+                    ? Object.keys(params.data)
+                    : [];
+            console.log(
+                `[Frigg] POST /api/authorize userId=${userId} entityType=${params.entityType} dataKeys=${JSON.stringify(dataKeys)}`
             );
 
-            res.json(entityDetails);
+            try {
+                const entityDetails =
+                    await processAuthorizationCallback.execute(
+                        userId,
+                        params.entityType,
+                        params.data
+                    );
+
+                console.log(
+                    `[Frigg] POST /api/authorize success userId=${userId} entityType=${params.entityType} credentialId=${entityDetails?.credential_id} entityId=${entityDetails?.entity_id}`
+                );
+
+                res.json(entityDetails);
+            } catch (err) {
+                console.error(
+                    `[Frigg] POST /api/authorize failed userId=${userId} entityType=${params.entityType} error=${err?.message || err}`
+                );
+                throw err;
+            }
         })
     );
 

--- a/packages/core/modules/use-cases/__tests__/process-authorization-callback.test.js
+++ b/packages/core/modules/use-cases/__tests__/process-authorization-callback.test.js
@@ -38,6 +38,15 @@ describe('ProcessAuthorizationCallback — re-auth status restoration', () => {
                 externalId: 'ext-1',
                 credential: 'cred-1',
             }),
+            findEntitiesByUserIdAndModuleName: jest.fn().mockResolvedValue([
+                {
+                    id: 'entity-1',
+                    userId: 'user-1',
+                    moduleName: 'testmodule',
+                    externalId: 'ext-1',
+                    credential: { id: 'cred-1', authIsValid: false },
+                },
+            ]),
             createEntity: jest.fn(),
         };
 
@@ -215,5 +224,39 @@ describe('ProcessAuthorizationCallback — re-auth status restoration', () => {
             status: 'ENABLED',
             success: true,
         });
+    });
+
+    it('persists credentials explicitly on OAuth2 re-auth (belt-and-suspenders)', async () => {
+        // Force the OAuth2 path
+        const { Module } = require('../../module');
+        Module.mockImplementation(({ userId, definition, entity }) => ({
+            userId,
+            entity,
+            credential: undefined,
+            definition,
+            apiClass: { requesterType: 'oauth2' },
+            api: { delegate: null },
+            testAuth: jest.fn().mockResolvedValue(true),
+            apiParamsFromCredential: jest.fn().mockReturnValue({}),
+            apiParamsFromEntity: jest.fn().mockReturnValue({}),
+            getName: jest.fn().mockReturnValue('testmodule'),
+        }));
+
+        moduleDefinitions[0].requiredAuthMethods.getToken = jest
+            .fn()
+            .mockResolvedValue({
+                access_token: 'fresh-access',
+                refresh_token: 'fresh-refresh',
+            });
+
+        await useCase.execute('user-1', 'testmodule', { code: 'oauth-code' });
+
+        // upsertCredential must be called once even on the OAuth2 path —
+        // we no longer rely solely on the DLGT_TOKEN_UPDATE notification.
+        expect(credentialRepository.upsertCredential).toHaveBeenCalledTimes(1);
+        expect(
+            credentialRepository.upsertCredential.mock.calls[0][0].details
+                .authIsValid
+        ).toBe(true);
     });
 });

--- a/packages/core/modules/use-cases/process-authorization-callback.js
+++ b/packages/core/modules/use-cases/process-authorization-callback.js
@@ -28,6 +28,11 @@ class ProcessAuthorizationCallback {
     }
 
     async execute(userId, entityType, params) {
+        const hasCode = Boolean(params && params.code);
+        console.log(
+            `[Frigg] processAuthorizationCallback start userId=${userId} entityType=${entityType} hasCode=${hasCode}`
+        );
+
         const moduleDefinition = this.moduleDefinitions.find((def) => {
             return entityType === def.moduleName;
         });
@@ -38,12 +43,29 @@ class ProcessAuthorizationCallback {
             );
         }
 
-        // todo: check if we need to pass entity to Module, right now it's null
-        let entity = null;
+        // Bootstrap the Module with the existing entity (if any) so the API
+        // requester is preloaded with prior tokens. This enables a refresh
+        // fallback when callers lack a fresh OAuth code, and lets us match a
+        // re-auth back to the existing credential record by id.
+        const existingEntities =
+            await this.moduleRepository.findEntitiesByUserIdAndModuleName(
+                userId,
+                entityType
+            );
+        const existingEntity =
+            existingEntities && existingEntities.length > 0
+                ? existingEntities[0]
+                : null;
+
+        if (existingEntity) {
+            console.log(
+                `[Frigg] processAuthorizationCallback found existing entity id=${existingEntity.id} credentialId=${existingEntity.credential?.id}`
+            );
+        }
 
         const module = new Module({
             userId,
-            entity,
+            entity: existingEntity,
             definition: moduleDefinition,
         });
 
@@ -53,6 +75,16 @@ class ProcessAuthorizationCallback {
                 module.api,
                 params
             );
+            console.log(
+                `[Frigg] processAuthorizationCallback OAuth getToken complete userId=${userId} entityType=${entityType}`
+            );
+            // Belt-and-suspenders: persist tokens explicitly here rather than
+            // relying solely on the DLGT_TOKEN_UPDATE notification chain
+            // inside setTokens. The notification path remains in place but
+            // has been observed to no-op silently in some prod paths,
+            // leaving newly-issued tokens unsaved while the user-visible
+            // OAuth flow appears to succeed.
+            await this.onTokenUpdate(module, moduleDefinition, userId);
         } else {
             tokenResponse =
                 await moduleDefinition.requiredAuthMethods.setAuthParams(
@@ -61,6 +93,10 @@ class ProcessAuthorizationCallback {
                 );
             await this.onTokenUpdate(module, moduleDefinition, userId);
         }
+
+        console.log(
+            `[Frigg] processAuthorizationCallback credential persisted credentialId=${module.credential?.id} authIsValid=${module.credential?.authIsValid}`
+        );
 
         const authRes = await module.testAuth();
         if (!authRes) {
@@ -90,7 +126,12 @@ class ProcessAuthorizationCallback {
         // credential + entity are already persisted. Operators can recover
         // stuck integrations manually.
         try {
-            await this.restoreIntegrationsForEntity(persistedEntity.id);
+            const restoredCount = await this.restoreIntegrationsForEntity(
+                persistedEntity.id
+            );
+            console.log(
+                `[Frigg] processAuthorizationCallback restored ${restoredCount} integration(s) for entityId=${persistedEntity.id}`
+            );
         } catch (err) {
             console.error(
                 `[Frigg] Failed to restore integrations for entity ${persistedEntity.id} after successful re-auth — manual intervention may be needed`,
@@ -106,11 +147,12 @@ class ProcessAuthorizationCallback {
     }
 
     async restoreIntegrationsForEntity(entityId) {
-        if (!this.integrationRepository) return;
+        if (!this.integrationRepository) return 0;
         const integrations =
             await this.integrationRepository.findIntegrationsByEntityId(
                 entityId
             );
+        let restored = 0;
         for (const integration of integrations) {
             if (STATUSES_RESET_ON_REAUTH.includes(integration.status)) {
                 console.log(
@@ -120,8 +162,10 @@ class ProcessAuthorizationCallback {
                     integration.id,
                     'ENABLED'
                 );
+                restored++;
             }
         }
+        return restored;
     }
 
     async onTokenUpdate(module, moduleDefinition, userId) {


### PR DESCRIPTION
## Summary

`ProcessAuthorizationCallback` relied solely on the `DLGT_TOKEN_UPDATE` notification chain (`setTokens` → `notify` → `Module.onTokenUpdate` → `upsertCredential`) to persist freshly-issued OAuth tokens. In production this chain has been observed to silently no-op: the OAuth provider issues new tokens (and invalidates the prior `refresh_token`), but the new tokens never land in the DB. The user-visible `/api/authorize` call appears to succeed, the existing credential is reused with stale token data, and downstream API calls fail with 401 once the provider rotates the old refresh_token.

This was diagnosed in a Pipedrive integration: re-installs created new Integration rows pointing at a 3-month-old credential whose tokens had been retired by Pipedrive during today's OAuth flow, but never replaced in our DB. The auth Lambda logs were silent because none of the existing code logs at the relevant boundaries.

## Changes

- **Bootstrap the Module with the existing entity** — `process-authorization-callback.js` now looks up the existing entity via `findEntitiesByUserIdAndModuleName` and passes it to `new Module(...)` so the API requester is preloaded with prior tokens. Replaces the long-standing `// todo: check if we need to pass entity to Module, right now it's null` TODO.
- **Belt-and-suspenders explicit persistence on the OAuth2 path** — explicit `await this.onTokenUpdate(module, moduleDefinition, userId)` after `getToken`. The notification chain stays in place; this ensures persistence happens even when the chain silently no-ops. Idempotent against the notification path because `upsertCredential` is keyed by `externalId`.
- **Diagnostic logging** at entry, after `getToken`, after persistence, and after restore — so future re-auth bugs aren't invisible in CloudWatch.
- **Wrap `POST /api/authorize`** with try/catch + `console.error` so handler failures surface instead of returning silently.
- **`restoreIntegrationsForEntity` returns the count** of flipped integrations for logging.

## Test plan

- [x] Existing 5 `ProcessAuthorizationCallback` re-auth status restoration tests pass
- [x] New test: `persists credentials explicitly on OAuth2 re-auth (belt-and-suspenders)` — locks in that `upsertCredential` is called exactly once on the OAuth2 path
- [ ] Smoke-test in dev: re-install a Pipedrive integration; confirm CloudWatch shows the new `[Frigg] processAuthorizationCallback ...` log lines and that the credential's `updatedAt` matches the OAuth callback time (not a later auth-flip)
- [ ] Verify a re-auth on a credential currently in `ERROR` flips it back to `ENABLED` and the integration resumes syncing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.82`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - fix(core): add per-request timeout to Requester to catch silent fetch hangs [#579](https://github.com/friggframework/frigg/pull/579) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/core`
    - fix(core): explicitly persist tokens on OAuth2 re-auth [#582](https://github.com/friggframework/frigg/pull/582) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
