### PR TITLE
fix(core): repoint entity credentialId when re-auth produces a different credential

### DIFF
--- a/packages/core/modules/use-cases/__tests__/process-authorization-callback.test.js
+++ b/packages/core/modules/use-cases/__tests__/process-authorization-callback.test.js
@@ -36,7 +36,7 @@ describe('ProcessAuthorizationCallback — re-auth status restoration', () => {
                 userId: 'user-1',
                 moduleName: 'testmodule',
                 externalId: 'ext-1',
-                credential: 'cred-1',
+                credential: { id: 'cred-1' },
             }),
             findEntitiesByUserIdAndModuleName: jest.fn().mockResolvedValue([
                 {
@@ -48,6 +48,15 @@ describe('ProcessAuthorizationCallback — re-auth status restoration', () => {
                 },
             ]),
             createEntity: jest.fn(),
+            updateEntity: jest.fn().mockImplementation((entityId, updates) =>
+                Promise.resolve({
+                    id: entityId,
+                    userId: 'user-1',
+                    moduleName: 'testmodule',
+                    externalId: 'ext-1',
+                    credential: { id: updates.credential },
+                })
+            ),
         };
 
         credentialRepository = {
@@ -258,5 +267,67 @@ describe('ProcessAuthorizationCallback — re-auth status restoration', () => {
             credentialRepository.upsertCredential.mock.calls[0][0].details
                 .authIsValid
         ).toBe(true);
+    });
+
+    it('repoints existing entity credentialId when re-auth produces a different credential', async () => {
+        // Reset Module mock back to the apiKey default (a prior test
+        // mutated it to oauth2).
+        const { Module } = require('../../module');
+        Module.mockImplementation(({ userId, definition, entity }) => ({
+            userId,
+            entity,
+            credential: undefined,
+            definition,
+            apiClass: { requesterType: 'apiKey' },
+            api: { delegate: null },
+            testAuth: jest.fn().mockResolvedValue(true),
+            apiParamsFromCredential: jest.fn().mockReturnValue({}),
+            apiParamsFromEntity: jest.fn().mockReturnValue({}),
+            getName: jest.fn().mockReturnValue('testmodule'),
+        }));
+
+        // Existing entity is linked to cred-1 (e.g. workspace A);
+        // the just-upserted credential is cred-2 (workspace B). The
+        // entity must be repointed so the integration uses the fresh
+        // tokens.
+        credentialRepository.upsertCredential = jest.fn().mockResolvedValue({
+            id: 'cred-2',
+            userId: 'user-1',
+            authIsValid: true,
+        });
+
+        await useCase.execute('user-1', 'testmodule', { apiKey: 'new-key' });
+
+        expect(moduleRepository.updateEntity).toHaveBeenCalledTimes(1);
+        expect(moduleRepository.updateEntity).toHaveBeenCalledWith('entity-1', {
+            credential: 'cred-2',
+        });
+    });
+
+    it('does not repoint when the existing entity already points at the upserted credential', async () => {
+        const { Module } = require('../../module');
+        Module.mockImplementation(({ userId, definition, entity }) => ({
+            userId,
+            entity,
+            credential: undefined,
+            definition,
+            apiClass: { requesterType: 'apiKey' },
+            api: { delegate: null },
+            testAuth: jest.fn().mockResolvedValue(true),
+            apiParamsFromCredential: jest.fn().mockReturnValue({}),
+            apiParamsFromEntity: jest.fn().mockReturnValue({}),
+            getName: jest.fn().mockReturnValue('testmodule'),
+        }));
+
+        // upsert returns cred-1, same as the entity already has
+        credentialRepository.upsertCredential = jest.fn().mockResolvedValue({
+            id: 'cred-1',
+            userId: 'user-1',
+            authIsValid: true,
+        });
+
+        await useCase.execute('user-1', 'testmodule', { apiKey: 'new-key' });
+
+        expect(moduleRepository.updateEntity).not.toHaveBeenCalled();
     });
 });

--- a/packages/core/modules/use-cases/process-authorization-callback.js
+++ b/packages/core/modules/use-cases/process-authorization-callback.js
@@ -206,6 +206,28 @@ class ProcessAuthorizationCallback {
         });
 
         if (existingEntity) {
+            // Repoint the entity's credentialId when re-auth produced a
+            // different credential than the one currently linked. This
+            // happens when the user re-authenticates against a different
+            // workspace/account of the same provider — `upsertCredential`
+            // matches/creates a credential keyed by externalId, but
+            // findEntity matches the entity by its own externalId, leaving
+            // the entity still linked to the prior workspace's credential
+            // unless we explicitly update the link.
+            const existingCredentialId = existingEntity.credential?.id;
+            if (
+                credentialId &&
+                String(existingCredentialId) !== String(credentialId)
+            ) {
+                console.log(
+                    `[Frigg] Repointing entity ${existingEntity.id} credentialId ${existingCredentialId} -> ${credentialId} after re-auth`
+                );
+                const updated = await this.moduleRepository.updateEntity(
+                    existingEntity.id,
+                    { credential: credentialId }
+                );
+                if (updated) return updated;
+            }
             return existingEntity;
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #582. When a user re-authenticates against a different workspace/account of the same provider (e.g. switching between two Pipedrive workspaces under the same Frigg user), the re-auth flow leaves the entity linked to the *prior* workspace's credential while the freshly-issued tokens land on a different credential row.

## Root cause

`upsertCredential` matches/creates a credential keyed by externalId from `getCredentialDetails` (e.g. Pipedrive `userProfile.data.id`). `findOrCreateEntity` matches the entity by its own externalId from `getEntityDetails` (e.g. Pipedrive `userProfile.data.company_id`). When the user has multiple workspaces, both methods can hit different existing rows — `upsertCredential` resolves to credential B's row, `findOrCreateEntity` returns the entity already pointing at credential A.

The OAuth callback then reports `{ credentialId: B, entityId: matched-entity }`, but the entity's `credentialId` foreign key still references A. Downstream integration creation reads the stale link, and the just-issued tokens sit on credential B with no entity pointing to it.

## Observed in dev

- Pipedrive integration 136 (user 16) created via re-auth into workspace `24952048` (cred 188).
- Entity 159 was previously linked to cred 166 (workspace `23384438` from a prior install).
- After OAuth: cred 188 had fresh tokens, cred 166 was unchanged at the OAuth time. Entity 159 still pointed at cred 166. Webhook setup later succeeded only because the runtime auto-refresh on cred 166's *separate* refresh_token happened to still be alive.

## Fix

`findOrCreateEntity` now repoints `existingEntity.credentialId` to the just-upserted `credentialId` via `moduleRepository.updateEntity` whenever they differ. No-ops when they match.

## Tests

- `repoints existing entity credentialId when re-auth produces a different credential` — locks in the new behavior
- `does not repoint when the existing entity already points at the upserted credential` — guards against unnecessary writes
- All 6 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
