### PR TITLE
fix(core): gracefully discard queue messages when process not found

### DIFF
--- a/packages/core/handlers/backend-utils.js
+++ b/packages/core/handlers/backend-utils.js
@@ -129,7 +129,7 @@ const loadIntegrationForProcess = async (processId, integrationClass) => {
     const process = await processRepository.findById(processId);
 
     if (!process) {
-        throw new Error(`Process not found: ${processId}`);
+        return null;
     }
 
     const instance = await getIntegrationInstance.execute(
@@ -167,6 +167,12 @@ const createQueueWorker = (integrationClass) => {
                         params.data.processId,
                         integrationClass
                     );
+                    if (!integrationInstance) {
+                        console.warn(
+                            `[${integrationName}] Process ${params.data.processId} not found. Discarding ${params.event} message.`
+                        );
+                        return;
+                    }
                     console.log(`[QueueWorker] hydrated`, {
                         ...logCtx,
                         integrationStatus: integrationInstance?.status,

--- a/packages/core/handlers/workers/integration-defined-workers.test.js
+++ b/packages/core/handlers/workers/integration-defined-workers.test.js
@@ -596,5 +596,88 @@ describe('Webhook Queue Worker', () => {
             await expect(worker.run(sqsEvent, {})).resolves.not.toThrow();
         });
     });
+
+    describe('Process not found handling (hydration by processId)', () => {
+        it('should discard message when process no longer exists', async () => {
+            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+            let mockedCreateQueueWorker;
+            jest.isolateModules(() => {
+                jest.doMock('../../integrations/repositories/process-repository-factory', () => ({
+                    createProcessRepository: () => ({
+                        findById: jest.fn().mockResolvedValue(null),
+                    }),
+                }));
+                jest.doMock('../../integrations/repositories/integration-repository-factory', () => ({
+                    createIntegrationRepository: () => ({}),
+                }));
+                jest.doMock('../../modules/repositories/module-repository-factory', () => ({
+                    createModuleRepository: () => ({}),
+                }));
+                mockedCreateQueueWorker = require('../backend-utils').createQueueWorker;
+            });
+
+            const QueueWorker = mockedCreateQueueWorker(TestWebhookIntegration);
+            const worker = new QueueWorker();
+
+            const params = {
+                event: 'FETCH_PERSON_PAGE',
+                data: {
+                    processId: 'deleted-process-12475',
+                    personObjectType: 'Contact',
+                    page: 3,
+                },
+            };
+
+            const sqsEvent = {
+                Records: [{ messageId: 'msg-1', body: JSON.stringify(params) }],
+            };
+
+            const result = await worker.run(sqsEvent, {});
+
+            expect(result.batchItemFailures).toEqual([]);
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Process deleted-process-12475 not found')
+            );
+
+            consoleSpy.mockRestore();
+        });
+
+        it('should still throw for other processId hydration errors', async () => {
+            let mockedCreateQueueWorker;
+            jest.isolateModules(() => {
+                jest.doMock('../../integrations/repositories/process-repository-factory', () => ({
+                    createProcessRepository: () => ({
+                        findById: jest.fn().mockRejectedValue(new Error('DB connection failed')),
+                    }),
+                }));
+                jest.doMock('../../integrations/repositories/integration-repository-factory', () => ({
+                    createIntegrationRepository: () => ({}),
+                }));
+                jest.doMock('../../modules/repositories/module-repository-factory', () => ({
+                    createModuleRepository: () => ({}),
+                }));
+                mockedCreateQueueWorker = require('../backend-utils').createQueueWorker;
+            });
+
+            const QueueWorker = mockedCreateQueueWorker(TestWebhookIntegration);
+            const worker = new QueueWorker();
+
+            const params = {
+                event: 'FETCH_PERSON_PAGE',
+                data: {
+                    processId: 'process-123',
+                    personObjectType: 'Contact',
+                },
+            };
+
+            const sqsEvent = {
+                Records: [{ messageId: 'msg-1', body: JSON.stringify(params) }],
+            };
+
+            const result = await worker.run(sqsEvent, {});
+            expect(result.batchItemFailures).toEqual([{ itemIdentifier: 'msg-1' }]);
+        });
+    });
 });
 


### PR DESCRIPTION
## Summary

- loadIntegrationForProcess now returns null instead of throwing when a process is not found
- QueueWorker processId hydration branch checks for null and discards the message gracefully
- Follows the same pattern already used by loadIntegrationForWebhook for missing integrations

## Root Cause

When a sync process completes while FETCH_PERSON_PAGE messages are still in the SQS queue, loadIntegrationForProcess throws Error(Process not found). This error has no statusCode, so it gets retried 4 times then DLQed.

## Production Evidence (Quo, 2026-05-11)

- 7 DLQ events in 24h (up from 3/day), all FETCH_PERSON_PAGE with integrationId: null
- 18 total DLQ events from this pattern

## Test plan

- [x] New test: discard message when process not found
- [x] New test: still throw for other hydration errors (DB failures)
- [x] All 23 existing tests pass