### PR TITLE
feat(core): allow apps to opt out of write-side field encryption

### DIFF
--- a/packages/core/database/encryption/encryption-schema-registry.js
+++ b/packages/core/database/encryption/encryption-schema-registry.js
@@ -43,6 +43,17 @@ const CORE_ENCRYPTION_SCHEMA = {
 let customSchema = {};
 
 /**
+ * Per-model write-side opt-out: fields registered here are NOT encrypted on
+ * write, but ARE still decrypted on read so legacy encrypted rows continue to
+ * deserialize. Lets apps migrate a model from encrypted to plain JSON without
+ * a data migration — touched rows naturally rewrite as plain on the next save,
+ * untouched rows stay encrypted-but-readable forever.
+ *
+ * Shape: `{ ModelName: ['field.path', ...] }`
+ */
+let encryptionOptOut = {};
+
+/**
  * Validates a custom encryption schema
  * @returns {{valid: boolean, errors: string[]}}
  */
@@ -218,6 +229,14 @@ function loadCustomEncryptionSchema() {
             registerCustomSchema(customSchema);
         }
 
+        // Load app-level encryption opt-out — apps can declare fields they
+        // don't want encrypted on write (decryption on read still works,
+        // so legacy data remains readable).
+        const disable = appDefinition.encryption?.disable;
+        if (disable && Object.keys(disable).length > 0) {
+            registerEncryptionOptOut(disable);
+        }
+
         // Load module-level encryption schemas from integrations
         const integrations = appDefinition.integrations;
         if (integrations && Array.isArray(integrations)) {
@@ -240,6 +259,115 @@ function getEncryptedFields(modelName) {
     return [...new Set(allFields)];
 }
 
+/**
+ * Validates an encryption opt-out config.
+ *
+ * Unlike custom schema validation, opt-out IS allowed to target paths that
+ * already live in CORE_ENCRYPTION_SCHEMA — that's the entire point.
+ *
+ * @param {Object} optOut - Map of `{ ModelName: ['field.path', ...] }`
+ * @returns {{valid: boolean, errors: string[]}}
+ */
+function validateOptOut(optOut) {
+    const errors = [];
+
+    if (!optOut || typeof optOut !== 'object') {
+        errors.push('Encryption opt-out must be an object');
+        return { valid: false, errors };
+    }
+
+    for (const [modelName, fields] of Object.entries(optOut)) {
+        if (typeof modelName !== 'string' || !modelName) {
+            errors.push(`Invalid model name in opt-out: ${modelName}`);
+            continue;
+        }
+
+        if (!Array.isArray(fields)) {
+            errors.push(
+                `Model "${modelName}" opt-out must be an array of field paths`
+            );
+            continue;
+        }
+
+        for (const fieldPath of fields) {
+            if (typeof fieldPath !== 'string' || !fieldPath) {
+                errors.push(
+                    `Model "${modelName}" has invalid opt-out field path: ${fieldPath}`
+                );
+            }
+        }
+    }
+
+    return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Registers an encryption opt-out config. Listed fields will be skipped during
+ * encryption on write while still being eligible for decryption on read (so
+ * legacy encrypted rows still deserialize correctly).
+ *
+ * Intended call site: `appDefinition.encryption.disable` via
+ * `loadCustomEncryptionSchema`.
+ *
+ * @param {Object} optOut - Map of `{ ModelName: ['field.path', ...] }`
+ * @throws {Error} If opt-out validation fails
+ */
+function registerEncryptionOptOut(optOut) {
+    if (!optOut || Object.keys(optOut).length === 0) {
+        return;
+    }
+
+    const validation = validateOptOut(optOut);
+    if (!validation.valid) {
+        throw new Error(
+            `Invalid encryption opt-out:\n- ${validation.errors.join('\n- ')}`
+        );
+    }
+
+    encryptionOptOut = { ...optOut };
+    logger.info(
+        `Registered encryption opt-out for models: ${Object.keys(
+            encryptionOptOut
+        ).join(', ')}`
+    );
+}
+
+/**
+ * Returns the field paths that should be encrypted when writing the given
+ * model. This is `getEncryptedFields` minus any paths the app has opted out
+ * of via `registerEncryptionOptOut`.
+ *
+ * Use this in the encrypt-on-write path of the FieldEncryptionService.
+ */
+function getFieldsToEncryptOnWrite(modelName) {
+    const allFields = getEncryptedFields(modelName);
+    const optedOut = new Set(encryptionOptOut[modelName] || []);
+    if (optedOut.size === 0) return allFields;
+    return allFields.filter((path) => !optedOut.has(path));
+}
+
+/**
+ * Returns the field paths that should be checked for decryption when reading
+ * the given model. Always includes opted-out paths so legacy encrypted rows
+ * remain readable after an app opts a field out.
+ *
+ * `FieldEncryptionService._isEncrypted` already short-circuits for plain JSON
+ * values, so listing more fields than necessary here is harmless.
+ *
+ * Use this in the decrypt-on-read path of the FieldEncryptionService.
+ */
+function getFieldsToDecryptOnRead(modelName) {
+    return getEncryptedFields(modelName);
+}
+
+/**
+ * Clears any registered encryption opt-outs. Test-helper; not intended for
+ * runtime use.
+ */
+function resetEncryptionOptOut() {
+    encryptionOptOut = {};
+}
+
 function hasEncryptedFields(modelName) {
     return getEncryptedFields(modelName).length > 0;
 }
@@ -257,12 +385,17 @@ function resetCustomSchema() {
 module.exports = {
     CORE_ENCRYPTION_SCHEMA,
     getEncryptedFields,
+    getFieldsToEncryptOnWrite,
+    getFieldsToDecryptOnRead,
     hasEncryptedFields,
     getEncryptedModels,
     registerCustomSchema,
+    registerEncryptionOptOut,
     loadCustomEncryptionSchema,
     loadModuleEncryptionSchemas,
     extractCredentialFieldsFromModules,
     validateCustomSchema,
+    validateOptOut,
     resetCustomSchema,
+    resetEncryptionOptOut,
 };

--- a/packages/core/database/encryption/encryption-schema-registry.test.js
+++ b/packages/core/database/encryption/encryption-schema-registry.test.js
@@ -1,17 +1,23 @@
 const {
     CORE_ENCRYPTION_SCHEMA,
     getEncryptedFields,
+    getFieldsToEncryptOnWrite,
+    getFieldsToDecryptOnRead,
     hasEncryptedFields,
     getEncryptedModels,
     registerCustomSchema,
+    registerEncryptionOptOut,
     validateCustomSchema,
+    validateOptOut,
     resetCustomSchema,
+    resetEncryptionOptOut,
 } = require('./encryption-schema-registry');
 
 describe('Encryption Schema Registry', () => {
     afterEach(() => {
         // Reset custom schema after each test
         resetCustomSchema();
+        resetEncryptionOptOut();
     });
 
     describe('CORE_ENCRYPTION_SCHEMA', () => {
@@ -386,6 +392,167 @@ describe('Encryption Schema Registry', () => {
                 // Core models still encrypted
                 expect(hasEncryptedFields('Credential')).toBe(true);
                 expect(hasEncryptedFields('User')).toBe(true);
+            });
+        });
+    });
+
+    describe('Encryption Opt-Out (write-side)', () => {
+        describe('validateOptOut', () => {
+            it('should validate a valid opt-out config', () => {
+                const result = validateOptOut({
+                    IntegrationMapping: ['mapping'],
+                });
+
+                expect(result.valid).toBe(true);
+                expect(result.errors).toEqual([]);
+            });
+
+            it('should reject non-object opt-out', () => {
+                const result = validateOptOut('invalid');
+
+                expect(result.valid).toBe(false);
+                expect(result.errors[0]).toContain('must be an object');
+            });
+
+            it('should reject opt-out where fields is not an array', () => {
+                const result = validateOptOut({
+                    IntegrationMapping: 'mapping',
+                });
+
+                expect(result.valid).toBe(false);
+                expect(result.errors[0]).toContain('must be an array');
+            });
+
+            it('should reject opt-out with non-string field paths', () => {
+                const result = validateOptOut({
+                    IntegrationMapping: ['mapping', null, ''],
+                });
+
+                expect(result.valid).toBe(false);
+                expect(result.errors.length).toBeGreaterThan(0);
+            });
+
+            it('should allow opt-out paths that overlap with core encrypted fields', () => {
+                // Unlike registerCustomSchema, opt-out IS allowed to target core paths —
+                // that's the whole point.
+                const result = validateOptOut({
+                    IntegrationMapping: ['mapping'],
+                    Credential: ['data.access_token'],
+                });
+
+                expect(result.valid).toBe(true);
+                expect(result.errors).toEqual([]);
+            });
+        });
+
+        describe('registerEncryptionOptOut', () => {
+            it('should register a valid opt-out config without throwing', () => {
+                expect(() =>
+                    registerEncryptionOptOut({
+                        IntegrationMapping: ['mapping'],
+                    })
+                ).not.toThrow();
+            });
+
+            it('should throw on invalid opt-out config', () => {
+                expect(() =>
+                    registerEncryptionOptOut({
+                        IntegrationMapping: 'not-an-array',
+                    })
+                ).toThrow('Invalid encryption opt-out');
+            });
+
+            it('should handle empty config gracefully', () => {
+                expect(() => registerEncryptionOptOut({})).not.toThrow();
+                expect(() => registerEncryptionOptOut(null)).not.toThrow();
+            });
+        });
+
+        describe('getFieldsToEncryptOnWrite', () => {
+            it('should equal getEncryptedFields when no opt-out registered', () => {
+                expect(getFieldsToEncryptOnWrite('IntegrationMapping')).toEqual(
+                    getEncryptedFields('IntegrationMapping')
+                );
+                expect(getFieldsToEncryptOnWrite('Credential')).toEqual(
+                    getEncryptedFields('Credential')
+                );
+            });
+
+            it('should exclude opted-out fields', () => {
+                registerEncryptionOptOut({
+                    IntegrationMapping: ['mapping'],
+                });
+
+                const writeFields =
+                    getFieldsToEncryptOnWrite('IntegrationMapping');
+
+                expect(writeFields).not.toContain('mapping');
+            });
+
+            it('should only exclude opted-out fields, not the whole model', () => {
+                registerCustomSchema({
+                    IntegrationMapping: {
+                        fields: ['someExtraField'],
+                    },
+                });
+                registerEncryptionOptOut({
+                    IntegrationMapping: ['mapping'],
+                });
+
+                const writeFields =
+                    getFieldsToEncryptOnWrite('IntegrationMapping');
+
+                expect(writeFields).not.toContain('mapping');
+                expect(writeFields).toContain('someExtraField');
+            });
+
+            it('should not affect unrelated models', () => {
+                registerEncryptionOptOut({
+                    IntegrationMapping: ['mapping'],
+                });
+
+                const credentialWriteFields =
+                    getFieldsToEncryptOnWrite('Credential');
+
+                expect(credentialWriteFields).toContain('data.access_token');
+                expect(credentialWriteFields).toContain('data.refresh_token');
+            });
+        });
+
+        describe('getFieldsToDecryptOnRead', () => {
+            it('should equal getEncryptedFields when no opt-out registered', () => {
+                expect(getFieldsToDecryptOnRead('IntegrationMapping')).toEqual(
+                    getEncryptedFields('IntegrationMapping')
+                );
+            });
+
+            it('should INCLUDE opted-out fields (legacy data still decrypts)', () => {
+                registerEncryptionOptOut({
+                    IntegrationMapping: ['mapping'],
+                });
+
+                const readFields =
+                    getFieldsToDecryptOnRead('IntegrationMapping');
+
+                expect(readFields).toContain('mapping');
+            });
+        });
+
+        describe('resetEncryptionOptOut', () => {
+            it('should clear all opt-outs', () => {
+                registerEncryptionOptOut({
+                    IntegrationMapping: ['mapping'],
+                });
+
+                expect(
+                    getFieldsToEncryptOnWrite('IntegrationMapping')
+                ).not.toContain('mapping');
+
+                resetEncryptionOptOut();
+
+                expect(
+                    getFieldsToEncryptOnWrite('IntegrationMapping')
+                ).toContain('mapping');
             });
         });
     });

--- a/packages/core/database/encryption/field-encryption-service.js
+++ b/packages/core/database/encryption/field-encryption-service.js
@@ -17,12 +17,40 @@ class FieldEncryptionService {
         this.schema = schema;
     }
 
+    /**
+     * Resolve the field paths to encrypt on write. Prefers
+     * `schema.getFieldsToEncryptOnWrite` (which respects app opt-outs); falls
+     * back to `schema.getEncryptedFields` for backwards compatibility with
+     * older schema adapters.
+     * @private
+     */
+    _getWriteFields(modelName) {
+        if (typeof this.schema.getFieldsToEncryptOnWrite === 'function') {
+            return this.schema.getFieldsToEncryptOnWrite(modelName);
+        }
+        return this.schema.getEncryptedFields(modelName);
+    }
+
+    /**
+     * Resolve the field paths to attempt decryption on read. Prefers
+     * `schema.getFieldsToDecryptOnRead` (which IGNORES opt-outs so legacy
+     * encrypted rows still deserialize); falls back to
+     * `schema.getEncryptedFields` for backwards compatibility.
+     * @private
+     */
+    _getReadFields(modelName) {
+        if (typeof this.schema.getFieldsToDecryptOnRead === 'function') {
+            return this.schema.getFieldsToDecryptOnRead(modelName);
+        }
+        return this.schema.getEncryptedFields(modelName);
+    }
+
     async encryptFields(modelName, document) {
         if (!document || typeof document !== 'object') {
             return document;
         }
 
-        const fields = this.schema.getEncryptedFields(modelName);
+        const fields = this._getWriteFields(modelName);
         if (fields.length === 0) {
             return document;
         }
@@ -58,7 +86,7 @@ class FieldEncryptionService {
             return document;
         }
 
-        const fields = this.schema.getEncryptedFields(modelName);
+        const fields = this._getReadFields(modelName);
         if (fields.length === 0) {
             return document;
         }

--- a/packages/core/database/encryption/field-encryption-service.test.js
+++ b/packages/core/database/encryption/field-encryption-service.test.js
@@ -522,4 +522,107 @@ describe('FieldEncryptionService', () => {
             expect(service._deepClone(true)).toBe(true);
         });
     });
+
+    describe('write vs read field split (opt-out support)', () => {
+        // Simulates a schema where IntegrationMapping has been opted out
+        // of write-side encryption but is still on the decrypt-on-read list.
+        const splitSchema = {
+            getEncryptedFields: jest.fn().mockImplementation((modelName) => {
+                if (modelName === 'IntegrationMapping') return ['mapping'];
+                return [];
+            }),
+            getFieldsToEncryptOnWrite: jest
+                .fn()
+                .mockImplementation((modelName) => {
+                    // Opted out — nothing to encrypt on write
+                    if (modelName === 'IntegrationMapping') return [];
+                    return [];
+                }),
+            getFieldsToDecryptOnRead: jest
+                .fn()
+                .mockImplementation((modelName) => {
+                    // Still tries to decrypt — for legacy data
+                    if (modelName === 'IntegrationMapping') return ['mapping'];
+                    return [];
+                }),
+        };
+
+        let splitService;
+
+        beforeEach(() => {
+            splitService = new FieldEncryptionService({
+                cryptor: mockCryptor,
+                schema: splitSchema,
+            });
+        });
+
+        it('should NOT encrypt opted-out fields on write', async () => {
+            const document = {
+                id: '123',
+                mapping: { crmId: 'abc', lastStatus: 'failed' },
+            };
+
+            const result = await splitService.encryptFields(
+                'IntegrationMapping',
+                document
+            );
+
+            expect(mockCryptor.encrypt).not.toHaveBeenCalled();
+            expect(result.mapping).toEqual({
+                crmId: 'abc',
+                lastStatus: 'failed',
+            });
+        });
+
+        it('should still decrypt opted-out fields on read (legacy data)', async () => {
+            const encryptedBlob = 'encrypted:{"crmId":"abc"}:keydata:enckey';
+            const document = {
+                id: '123',
+                mapping: encryptedBlob,
+            };
+
+            const result = await splitService.decryptFields(
+                'IntegrationMapping',
+                document
+            );
+
+            expect(mockCryptor.decrypt).toHaveBeenCalledWith(encryptedBlob);
+            expect(result.mapping).toEqual({ crmId: 'abc' });
+        });
+
+        it('should pass through plain JSON on read without invoking cryptor', async () => {
+            const document = {
+                id: '123',
+                mapping: { crmId: 'abc', lastStatus: 'created' },
+            };
+
+            const result = await splitService.decryptFields(
+                'IntegrationMapping',
+                document
+            );
+
+            // Plain object → _isEncrypted returns false → cryptor not called
+            expect(mockCryptor.decrypt).not.toHaveBeenCalled();
+            expect(result.mapping).toEqual({
+                crmId: 'abc',
+                lastStatus: 'created',
+            });
+        });
+
+        it('should fall back to getEncryptedFields when split methods missing', async () => {
+            const legacySchema = {
+                getEncryptedFields: jest.fn().mockReturnValue(['mapping']),
+            };
+            const legacyService = new FieldEncryptionService({
+                cryptor: mockCryptor,
+                schema: legacySchema,
+            });
+
+            const document = { mapping: { foo: 'bar' } };
+            await legacyService.encryptFields('IntegrationMapping', document);
+
+            // Backwards-compat: encrypted via getEncryptedFields
+            expect(mockCryptor.encrypt).toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/core/database/encryption/prisma-encryption-extension.js
+++ b/packages/core/database/encryption/prisma-encryption-extension.js
@@ -3,7 +3,11 @@
  * Intercepts Prisma queries to encrypt on write and decrypt on read.
  */
 
-const { getEncryptedFields } = require('./encryption-schema-registry');
+const {
+    getEncryptedFields,
+    getFieldsToEncryptOnWrite,
+    getFieldsToDecryptOnRead,
+} = require('./encryption-schema-registry');
 const { FieldEncryptionService } = require('./field-encryption-service');
 
 function createEncryptionExtension({ cryptor, enabled = true }) {
@@ -19,7 +23,11 @@ function createEncryptionExtension({ cryptor, enabled = true }) {
 
     const encryptionService = new FieldEncryptionService({
         cryptor,
-        schema: { getEncryptedFields },
+        schema: {
+            getEncryptedFields,
+            getFieldsToEncryptOnWrite,
+            getFieldsToDecryptOnRead,
+        },
     });
 
     return {


### PR DESCRIPTION
## Summary

Adds a per-app encryption opt-out so apps can declare fields they don't want encrypted on write, while keeping decrypt-on-read for legacy encrypted data. Touched rows naturally migrate to plain on next save — no data migration required.

```js
// In an app's index.js
const Definition = {
    encryption: {
        disable: { IntegrationMapping: ['mapping'] }
    }
};
```

After opting out:
- New writes → plain JSON (queryable with Postgres jsonb operators / Mongo nested filters)
- Legacy encrypted rows → still decrypt transparently on read
- Touched rows are rewritten as plain on next save
- Untouched rows remain encrypted-but-readable indefinitely

## Why

Apps storing non-sensitive data in encrypted fields (e.g. `IntegrationMapping.mapping`) need to query it directly in the DB for features like per-record failure tracking and dashboards. The current core schema encrypts the whole `mapping` JSONB, blocking `WHERE mapping->>'foo' = 'bar'` queries.

This is **per-app and opt-in**. Encrypt-by-default behavior is unchanged for every other app — they never declare the `disable` block.

## Implementation

- `encryption-schema-registry`:
  - New: `registerEncryptionOptOut`, `validateOptOut`, `resetEncryptionOptOut`
  - New: `getFieldsToEncryptOnWrite(model)` — respects opt-out (used for encrypt path)
  - New: `getFieldsToDecryptOnRead(model)` — ignores opt-out (used for decrypt path, so legacy data still deserializes)
  - `loadCustomEncryptionSchema` now also reads `appDefinition.encryption.disable`
- `FieldEncryptionService`:
  - Split write-side and read-side field resolution via `_getWriteFields` / `_getReadFields`
  - Backwards compatible: falls back to `getEncryptedFields` when the new schema methods are missing
- `prisma-encryption-extension`: wires the new lookups through to the service

## Test plan

- [x] 15 new tests for the registry opt-out API (validate, register, write/read split, reset)
- [x] 4 new tests for the `FieldEncryptionService` write/read split + legacy schema fallback
- [x] All existing encryption-related tests continue to pass (114 → 133 passing in touched suites; 0 regressions)
- [ ] Reviewer: manual smoke — declare `encryption.disable` in a test backend, verify a previously-encrypted row still reads correctly and a new write lands as plain JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.585.8f515e1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.585.8f515e1.0
  npm install @friggframework/devtools@2.0.0--canary.585.8f515e1.0
  npm install @friggframework/eslint-config@2.0.0--canary.585.8f515e1.0
  npm install @friggframework/prettier-config@2.0.0--canary.585.8f515e1.0
  npm install @friggframework/schemas@2.0.0--canary.585.8f515e1.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.585.8f515e1.0
  npm install @friggframework/test@2.0.0--canary.585.8f515e1.0
  npm install @friggframework/ui@2.0.0--canary.585.8f515e1.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.585.8f515e1.0
  yarn add @friggframework/devtools@2.0.0--canary.585.8f515e1.0
  yarn add @friggframework/eslint-config@2.0.0--canary.585.8f515e1.0
  yarn add @friggframework/prettier-config@2.0.0--canary.585.8f515e1.0
  yarn add @friggframework/schemas@2.0.0--canary.585.8f515e1.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.585.8f515e1.0
  yarn add @friggframework/test@2.0.0--canary.585.8f515e1.0
  yarn add @friggframework/ui@2.0.0--canary.585.8f515e1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.84`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/core`
    - feat(core): allow apps to opt out of write-side field encryption [#585](https://github.com/friggframework/frigg/pull/585) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - fix(core): repoint entity credentialId when re-auth produces a different credential [#583](https://github.com/friggframework/frigg/pull/583) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
