### PR TITLE
fix(auth): self-heal Integration.status on token refresh success

### DIFF
--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -542,17 +542,25 @@ class IntegrationBase {
 
     /**
      * Receives notifications from modules (the Delegate pattern) when
-     * something integration-level needs attention. Today this catches the
-     * `CREDENTIAL_INVALIDATED` event Module fires from `markCredentialsInvalid`
-     * and flips this integration's status to DISABLED so the queue worker
-     * stops processing further webhooks until the user re-authorizes.
+     * something integration-level needs attention. Today this catches:
+     *
+     *   - `CREDENTIAL_INVALIDATED` (Module → `markCredentialsInvalid`):
+     *     flips Integration.status to ERROR so the queue worker stops
+     *     processing further webhooks until auth is healed.
+     *   - `CREDENTIAL_VALIDATED` (Module → `onTokenUpdate`, fired after a
+     *     successful refresh): self-heals — if status is ERROR, transitions
+     *     back to ENABLED so the user doesn't have to manually reconnect
+     *     when a transient credential issue resolves on its own. Non-ERROR
+     *     statuses (NEEDS_CONFIG, DISABLED, etc.) are intentionally left
+     *     untouched — credential validity isn't authority to override
+     *     those states.
      *
      * Modules are wired to this delegate in `_appendModules()`, which runs
      * during `setIntegrationRecord()` — this covers every construction path
      * (HTTP read, queue worker, create/update/delete flows, etc.).
      *
-     * The delegate string below must match `Module.DLGT_CREDENTIAL_INVALIDATED`
-     * in `packages/core/modules/module.js`.
+     * The delegate strings below must match `Module.DLGT_CREDENTIAL_INVALIDATED`
+     * and `Module.DLGT_CREDENTIAL_VALIDATED` in `packages/core/modules/module.js`.
      *
      * @param {Object} notifier - The module that fired the event
      * @param {string} delegateString - Event type string
@@ -560,13 +568,27 @@ class IntegrationBase {
      * @returns {Promise<void>}
      */
     async receiveNotification(notifier, delegateString, object = null) {
-        if (delegateString !== 'CREDENTIAL_INVALIDATED') return;
-        if (!this.id) return;
-        console.log(
-            `[Frigg] Module ${notifier?.name || '?'} reported invalid credentials for integration ${this.id} — marking ERROR`
-        );
-        await this.updateIntegrationStatus.execute(this.id, 'ERROR');
-        this.status = 'ERROR';
+        if (delegateString === 'CREDENTIAL_INVALIDATED') {
+            if (!this.id) return;
+            console.log(
+                `[Frigg] Module ${notifier?.name || '?'} reported invalid credentials for integration ${this.id} — marking ERROR`
+            );
+            await this.updateIntegrationStatus.execute(this.id, 'ERROR');
+            this.status = 'ERROR';
+            return;
+        }
+        if (delegateString === 'CREDENTIAL_VALIDATED') {
+            if (!this.id) return;
+            // Narrow self-heal: only resurrect from ERROR. Other states
+            // (NEEDS_CONFIG, DISABLED, PROCESSING, ENABLED itself) are
+            // load-bearing for reasons unrelated to credential validity.
+            if (this.status !== 'ERROR') return;
+            console.log(
+                `[Frigg] Module ${notifier?.name || '?'} reported valid credentials for integration ${this.id} — clearing ERROR → ENABLED`
+            );
+            await this.updateIntegrationStatus.execute(this.id, 'ENABLED');
+            this.status = 'ENABLED';
+        }
     }
 }
 

--- a/packages/core/integrations/tests/integration-base-receive-notification.test.js
+++ b/packages/core/integrations/tests/integration-base-receive-notification.test.js
@@ -58,4 +58,64 @@ describe('IntegrationBase.receiveNotification', () => {
         );
         expect(integration.status).toBe('ERROR');
     });
+
+    describe('CREDENTIAL_VALIDATED (self-heal after a refresh succeeds)', () => {
+        it('clears ERROR back to ENABLED when a module reports valid credentials', async () => {
+            integration.status = 'ERROR';
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_VALIDATED',
+                { credentialId: 'cred-1', moduleName: 'testmodule' }
+            );
+
+            expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledTimes(1);
+            expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
+                'int-1',
+                'ENABLED'
+            );
+            expect(integration.status).toBe('ENABLED');
+        });
+
+        it('is a no-op when the integration is already ENABLED', async () => {
+            integration.status = 'ENABLED';
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_VALIDATED',
+                { credentialId: 'cred-1', moduleName: 'testmodule' }
+            );
+
+            expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+            expect(integration.status).toBe('ENABLED');
+        });
+
+        it('does NOT clobber other non-ERROR states (e.g. NEEDS_CONFIG, DISABLED)', async () => {
+            for (const status of ['NEEDS_CONFIG', 'DISABLED', 'PROCESSING']) {
+                mockUpdateIntegrationStatus.execute.mockClear();
+                integration.status = status;
+                await integration.receiveNotification(
+                    { name: 'testmodule' },
+                    'CREDENTIAL_VALIDATED',
+                    { credentialId: 'cred-1', moduleName: 'testmodule' }
+                );
+                expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+                expect(integration.status).toBe(status);
+            }
+        });
+
+        it('no-ops when the integration has no id yet (not hydrated)', async () => {
+            integration.id = undefined;
+            integration.status = 'ERROR';
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_VALIDATED',
+                { credentialId: 'cred-1', moduleName: 'testmodule' }
+            );
+
+            expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+            expect(integration.status).toBe('ERROR');
+        });
+    });
 });

--- a/packages/core/modules/module.js
+++ b/packages/core/modules/module.js
@@ -41,6 +41,13 @@ class Module extends Delegate {
         // Module → parent delegate (typically IntegrationBase) events
         this.DLGT_CREDENTIAL_INVALIDATED = 'CREDENTIAL_INVALIDATED';
         this.delegateTypes.push(this.DLGT_CREDENTIAL_INVALIDATED);
+        // Symmetric "auth healed" signal — fired after a successful token
+        // refresh persists the credential as valid again. Lets the parent
+        // (IntegrationBase) reset Integration.status from ERROR back to
+        // ENABLED so the user doesn't have to manually reconnect after a
+        // transient credential failure.
+        this.DLGT_CREDENTIAL_VALIDATED = 'CREDENTIAL_VALIDATED';
+        this.delegateTypes.push(this.DLGT_CREDENTIAL_VALIDATED);
 
         Object.assign(this, this.definition.requiredAuthMethods);
 
@@ -123,6 +130,30 @@ class Module extends Delegate {
             credentialDetails
         );
         this.credential = persisted;
+
+        // Propagate upward so a parent delegate (e.g. IntegrationBase) can
+        // self-heal Integration.status from ERROR back to ENABLED. Symmetric
+        // with the markCredentialsInvalid → CREDENTIAL_INVALIDATED path.
+        //
+        // Best-effort: this method is invoked from OAuth2Requester.setTokens
+        // immediately after a successful refresh; the new access_token has
+        // already been persisted on the credential, and the original 401'd
+        // API call is about to be retried with the new token. A delegate
+        // hiccup must NOT throw — that would re-surface as a 401 catch in
+        // the requester and confuse the auth state machine.
+        if (this.credential?.id) {
+            try {
+                await this.notify(this.DLGT_CREDENTIAL_VALIDATED, {
+                    credentialId: this.credential.id,
+                    moduleName: this.name,
+                });
+            } catch (err) {
+                console.error(
+                    `[Frigg] Failed to propagate CREDENTIAL_VALIDATED for module ${this.name}:`,
+                    err?.message || err
+                );
+            }
+        }
     }
 
     async receiveNotification(notifier, delegateString, object = null) {

--- a/packages/core/modules/requester/oauth-2.test.js
+++ b/packages/core/modules/requester/oauth-2.test.js
@@ -354,7 +354,18 @@ describe('OAuth2Requester', () => {
             expect(mockFetch.mock.calls[0][1].headers.Authorization).toBeUndefined();
         });
 
-        it('should not retry more than once for consecutive 401s', async () => {
+        it('should not retry more than once for consecutive 401s, and should NOT speculatively notify INVALID_AUTH on the second 401', async () => {
+            // Contract change (fix/auth-state-reset-on-refresh):
+            // The previous behavior fired INVALID_AUTH on the second 401
+            // within the same Requester instance — which speculatively
+            // marked the integration ERROR even when the refresh itself
+            // had just succeeded (the API simply rejected the new token
+            // on this specific call, or a transient 401 followed the
+            // refresh). The new contract: refresh is attempted exactly
+            // once per requester instance; on a subsequent 401 we let
+            // the HTTP error propagate without firing INVALID_AUTH (the
+            // next worker invocation gets a fresh shot at refresh with
+            // the freshly persisted credential).
             const mockFetch = jest.fn().mockResolvedValue({
                 status: 401,
                 headers: { get: () => 'application/json' },
@@ -379,8 +390,11 @@ describe('OAuth2Requester', () => {
 
             // Should call fetch twice: initial + 1 retry after refresh
             expect(mockFetch).toHaveBeenCalledTimes(2);
-            // Should notify DLGT_INVALID_AUTH after second 401
-            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+            // Should NOT notify DLGT_INVALID_AUTH on the second 401 —
+            // the refresh itself succeeded (it's the API call that's
+            // still 401ing for an unrelated reason), so the auth state
+            // shouldn't transition to ERROR.
+            expect(requester.notify).not.toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
         });
 
         it('should use getTokenFromClientCredentials for client_credentials grant type on 401', async () => {

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -151,16 +151,40 @@ class Requester extends Delegate {
                 await new Promise((resolve) => setTimeout(resolve, delay));
                 return this._request(url, options, i + 1);
             } else if (status === 401) {
-                if (!this.isRefreshable || this.refreshCount > 0) {
+                // Three outcomes per the auth-state contract:
+                //   1. Token is not refreshable      → fire INVALID_AUTH (→ ERROR)
+                //   2. Refreshable, refresh FAILS    → refreshAuth's own catch
+                //                                      fires INVALID_AUTH; we
+                //                                      do NOT double-fire here
+                //   3. Refreshable, refresh SUCCEEDS → retry silently, no
+                //                                      status change
+                //
+                // The previous version also fired INVALID_AUTH on
+                // `refreshCount > 0` (any second 401 on the same Requester
+                // instance). That caused integrations to be marked ERROR
+                // when a transient 401 hit AFTER a successful refresh, or
+                // when sibling concurrent requesters had already refreshed
+                // (the new access token hadn't propagated to this
+                // instance's in-memory state). A 401 after we've already
+                // attempted refresh should just propagate up as a normal
+                // HTTP error and let the next worker invocation try
+                // refresh with the freshly persisted credential.
+                if (!this.isRefreshable) {
                     await this.notify(this.DLGT_INVALID_AUTH);
-                } else {
+                } else if (this.refreshCount === 0) {
                     this.refreshCount++;
                     const refreshSucceeded = await this.refreshAuth();
                     if (refreshSucceeded) {
                         clearRequestTimer();
                         return this._request(url, options, i + 1);
                     }
+                    // refresh failed — refreshAuth() already fired
+                    // INVALID_AUTH from its catch block; fall through
+                    // to throw the 401 below.
                 }
+                // refreshable AND already attempted in this instance: do
+                // nothing; the 401 will be thrown below and the integration
+                // status is left untouched.
             }
 
             // If the error wasn't retried, throw. FetchError.create reads

--- a/packages/core/modules/requester/requester.test.js
+++ b/packages/core/modules/requester/requester.test.js
@@ -284,6 +284,109 @@ describe('Requester', () => {
         });
     });
 
+    describe('401 handling — do not speculatively mark ERROR', () => {
+        function jsonOk(body = { ok: true }) {
+            return {
+                status: 200,
+                headers: { get: () => 'application/json' },
+                json: async () => body,
+            };
+        }
+        function unauthorized() {
+            return {
+                status: 401,
+                headers: { get: () => 'application/json' },
+                json: async () => ({ error: 'unauthorized' }),
+                text: async () => '{"error":"unauthorized"}',
+            };
+        }
+
+        it('fires DLGT_INVALID_AUTH when the token is NOT refreshable (case 1)', async () => {
+            const fetchMock = jest.fn().mockResolvedValueOnce(unauthorized());
+            const requester = new TestRequester({
+                fetch: fetchMock,
+                backOff: [],
+            });
+            requester.isRefreshable = false;
+            const notify = jest.fn();
+            requester.notify = notify;
+
+            await expect(requester._get({ url: 'https://x.example/r' })).rejects.toBeDefined();
+            expect(notify).toHaveBeenCalledWith('INVALID_AUTH');
+        });
+
+        it('attempts refresh when the token IS refreshable and retries the request on success (case 3)', async () => {
+            const fetchMock = jest
+                .fn()
+                .mockResolvedValueOnce(unauthorized())
+                .mockResolvedValueOnce(jsonOk({ ok: true }));
+            const requester = new TestRequester({
+                fetch: fetchMock,
+                backOff: [],
+            });
+            requester.isRefreshable = true;
+            requester.refreshAuth = jest.fn().mockResolvedValue(true);
+            const notify = jest.fn();
+            requester.notify = notify;
+
+            const result = await requester._get({ url: 'https://x.example/r' });
+            expect(result).toEqual({ ok: true });
+            expect(requester.refreshAuth).toHaveBeenCalledTimes(1);
+            // Refresh succeeded → do not fire INVALID_AUTH (no ERROR transition).
+            expect(notify).not.toHaveBeenCalled();
+        });
+
+        it('does NOT fire INVALID_AUTH itself when refresh fails — refreshAuth handles that (case 2)', async () => {
+            // refreshAuth() returns false on failure and fires INVALID_AUTH from
+            // its own catch in oauth-2.js. The requester must not double-fire.
+            const fetchMock = jest.fn().mockResolvedValueOnce(unauthorized());
+            const requester = new TestRequester({
+                fetch: fetchMock,
+                backOff: [],
+            });
+            requester.isRefreshable = true;
+            requester.refreshAuth = jest.fn().mockResolvedValue(false);
+            const notify = jest.fn();
+            requester.notify = notify;
+
+            await expect(requester._get({ url: 'https://x.example/r' })).rejects.toBeDefined();
+            expect(requester.refreshAuth).toHaveBeenCalledTimes(1);
+            // Requester does not fire INVALID_AUTH on refresh failure — oauth-2's
+            // refreshAuth catch is the sole source for that signal.
+            expect(notify).not.toHaveBeenCalled();
+        });
+
+        it('does NOT speculatively fire INVALID_AUTH on a second 401 within the same requester instance', async () => {
+            // First request: 401 → refresh succeeds → retry succeeds. Second
+            // request on the SAME requester: 401 again (transient). Old
+            // behavior fired INVALID_AUTH because refreshCount > 0. New
+            // behavior throws the 401 up without marking ERROR — a
+            // subsequently-constructed requester (next worker invocation)
+            // will get a chance to refresh fresh.
+            const fetchMock = jest
+                .fn()
+                .mockResolvedValueOnce(unauthorized()) // first call: 401
+                .mockResolvedValueOnce(jsonOk({ ok: true })) // refresh retry: ok
+                .mockResolvedValueOnce(unauthorized()); // second call: 401 again
+            const requester = new TestRequester({
+                fetch: fetchMock,
+                backOff: [],
+            });
+            requester.isRefreshable = true;
+            requester.refreshAuth = jest.fn().mockResolvedValue(true);
+            const notify = jest.fn();
+            requester.notify = notify;
+
+            await requester._get({ url: 'https://x.example/a' });
+            await expect(requester._get({ url: 'https://x.example/b' })).rejects.toBeDefined();
+
+            // Refresh was attempted once (refreshCount guard prevents loops).
+            expect(requester.refreshAuth).toHaveBeenCalledTimes(1);
+            // No INVALID_AUTH on the second 401 — let the 401 propagate.
+            expect(notify).not.toHaveBeenCalled();
+        });
+    });
+
     describe('ECONNRESET retry (regression guard)', () => {
         it('still retries on ECONNRESET following the backOff schedule', async () => {
             jest.useFakeTimers();

--- a/packages/core/modules/tests/module-on-token-update.test.js
+++ b/packages/core/modules/tests/module-on-token-update.test.js
@@ -106,4 +106,25 @@ describe('Module.onTokenUpdate with organization userId', () => {
             '13' // Organization userId
         );
     });
+
+    it('notifies delegate of DLGT_CREDENTIAL_VALIDATED after credential is persisted as valid', async () => {
+        const notify = jest.fn().mockResolvedValue(undefined);
+        module.notify = notify;
+        module.credential = { id: 'cred-existing' };
+
+        await module.onTokenUpdate();
+
+        expect(notify).toHaveBeenCalledWith('CREDENTIAL_VALIDATED', {
+            credentialId: 'cred-123',
+            moduleName: 'testmodule',
+        });
+    });
+
+    it('does NOT throw when the delegate notify fails — token update is best-effort propagation', async () => {
+        module.notify = jest
+            .fn()
+            .mockRejectedValue(new Error('delegate boom'));
+
+        await expect(module.onTokenUpdate()).resolves.not.toThrow();
+    });
 });


### PR DESCRIPTION
## Summary

When an OAuth2 access token expires, Frigg currently sets `Integration.status = ERROR` and never resets it — even after the refresh succeeds. Users must manually disconnect + reconnect to clear the stuck ERROR state. Under concurrent workloads the same bug fires dozens of `CREDENTIAL_INVALIDATED` notifications per integration, guaranteeing the state sticks even when refresh eventually works.

This PR implements the auth-state contract symmetrically:

| 401 outcome | Status transition |
|---|---|
| Not refreshable | → `ERROR` |
| Refresh fails | → `ERROR` (via `refreshAuth`'s own catch) |
| Refresh succeeds | no change; if previously `ERROR`, self-heal to `ENABLED` |

## Changes

**`packages/core/modules/requester/requester.js`**
- On 401, only fire `INVALID_AUTH` when the token is not refreshable.
- Refreshable + first attempt → call `refreshAuth()`.
- Refreshable + already attempted → throw the 401 up without speculatively marking ERROR. The next worker invocation gets a fresh shot at refresh with the freshly persisted credential.

**`packages/core/modules/module.js`**
- New `DLGT_CREDENTIAL_VALIDATED` delegate event, emitted from `onTokenUpdate()` after the credential is persisted with `authIsValid = true`.
- Best-effort: delegate failures don't throw out of the token-update path (the 401'd request is about to be retried).

**`packages/core/integrations/integration-base.js`**
- Handle `CREDENTIAL_VALIDATED` in `receiveNotification` — if status is `ERROR`, transition to `ENABLED`.
- Narrow self-heal: other states (`NEEDS_CONFIG`, `DISABLED`, etc.) are intentionally left untouched. Credential validity isn't authority to override them.

## Tests

61 passing across the affected suites:

- `requester.test.js` — 4 new cases (not refreshable, refresh success, refresh failure, second-401 no-speculative-INVALID_AUTH)
- `oauth-2.test.js` — updated the consecutive-401 test to assert the new contract
- `module-on-token-update.test.js` — asserts `notify(CREDENTIAL_VALIDATED)` fires + delegate failure doesn't throw
- `integration-base-receive-notification.test.js` — 4 new cases for the self-heal logic

Pre-existing `*-encryption.test.js` failures observed on `next` are unrelated and unchanged.

## Real-world repro

Local Clockwork ↔ HubSpot integration left idle overnight. On wake, Clockwork access token had expired. First request → 401 → 29 concurrent requesters each tried refresh; sibling requesters' subsequent 401s on the same instance fired \`INVALID_AUTH\` (refreshCount > 0 branch). Integration was marked ERROR even though one refresh did succeed and the credential was persisted as valid. User had to re-connect via OAuth dance even though no actual auth issue existed.

After this PR: the second 401 inside a single requester propagates as a normal HTTP error; the successful refresh in any sibling requester notifies `CREDENTIAL_VALIDATED`; IntegrationBase clears the ERROR state. No manual reconnect required.

## Test plan

- [ ] Run `npx jest modules/requester/ modules/tests/module-on-token-update.test.js integrations/tests/integration-base-receive-notification.test.js modules/tests/module-mark-credentials-invalid.test.js integrations/tests/integration-base-delegate-wiring.test.js` from `packages/core`.
- [ ] Verify existing `CREDENTIAL_INVALIDATED` path still flips to ERROR.
- [ ] Verify `CREDENTIAL_VALIDATED` from a non-ERROR state is a no-op.
- [ ] Verify that a 401 followed by a successful refresh retry produces no \`INVALID_AUTH\` notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)