### PR TITLE
fix(core): respect refresh outcome before marking integration ERROR on 401

### DIFF
--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -560,13 +560,25 @@ class IntegrationBase {
      * @returns {Promise<void>}
      */
     async receiveNotification(notifier, delegateString, object = null) {
-        if (delegateString !== 'CREDENTIAL_INVALIDATED') return;
         if (!this.id) return;
-        console.log(
-            `[Frigg] Module ${notifier?.name || '?'} reported invalid credentials for integration ${this.id} — marking ERROR`
-        );
-        await this.updateIntegrationStatus.execute(this.id, 'ERROR');
-        this.status = 'ERROR';
+
+        if (delegateString === 'CREDENTIAL_INVALIDATED') {
+            console.log(
+                `[Frigg] Module ${notifier?.name || '?'} reported invalid credentials for integration ${this.id} — marking ERROR`
+            );
+            await this.updateIntegrationStatus.execute(this.id, 'ERROR');
+            this.status = 'ERROR';
+            return;
+        }
+
+        if (delegateString === 'CREDENTIAL_VALIDATED') {
+            if (this.status !== 'ERROR') return;
+            console.log(
+                `[Frigg] Module ${notifier?.name || '?'} reported valid credentials for integration ${this.id} — clearing ERROR → ENABLED`
+            );
+            await this.updateIntegrationStatus.execute(this.id, 'ENABLED');
+            this.status = 'ENABLED';
+        }
     }
 }
 

--- a/packages/core/integrations/tests/integration-base-receive-notification.test.js
+++ b/packages/core/integrations/tests/integration-base-receive-notification.test.js
@@ -58,4 +58,80 @@ describe('IntegrationBase.receiveNotification', () => {
         );
         expect(integration.status).toBe('ERROR');
     });
+
+    describe('CREDENTIAL_VALIDATED self-heal', () => {
+        const validatedPayload = {
+            credentialId: 'cred-1',
+            moduleName: 'testmodule',
+        };
+
+        it('heals ERROR → ENABLED when a module reports CREDENTIAL_VALIDATED', async () => {
+            integration.status = 'ERROR';
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_VALIDATED',
+                validatedPayload
+            );
+
+            expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledTimes(1);
+            expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
+                'int-1',
+                'ENABLED'
+            );
+            expect(integration.status).toBe('ENABLED');
+        });
+
+        it('does nothing when the integration is already ENABLED', async () => {
+            integration.status = 'ENABLED';
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_VALIDATED',
+                validatedPayload
+            );
+
+            expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+            expect(integration.status).toBe('ENABLED');
+        });
+
+        it('does not override NEEDS_CONFIG', async () => {
+            integration.status = 'NEEDS_CONFIG';
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_VALIDATED',
+                validatedPayload
+            );
+
+            expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+            expect(integration.status).toBe('NEEDS_CONFIG');
+        });
+
+        it('does not override DISABLED', async () => {
+            integration.status = 'DISABLED';
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_VALIDATED',
+                validatedPayload
+            );
+
+            expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+            expect(integration.status).toBe('DISABLED');
+        });
+
+        it('no-ops when the integration has no id yet', async () => {
+            integration.id = undefined;
+            integration.status = 'ERROR';
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_VALIDATED',
+                validatedPayload
+            );
+
+            expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/core/modules/module.js
+++ b/packages/core/modules/module.js
@@ -41,6 +41,8 @@ class Module extends Delegate {
         // Module → parent delegate (typically IntegrationBase) events
         this.DLGT_CREDENTIAL_INVALIDATED = 'CREDENTIAL_INVALIDATED';
         this.delegateTypes.push(this.DLGT_CREDENTIAL_INVALIDATED);
+        this.DLGT_CREDENTIAL_VALIDATED = 'CREDENTIAL_VALIDATED';
+        this.delegateTypes.push(this.DLGT_CREDENTIAL_VALIDATED);
 
         Object.assign(this, this.definition.requiredAuthMethods);
 
@@ -123,6 +125,20 @@ class Module extends Delegate {
             credentialDetails
         );
         this.credential = persisted;
+
+        if (this.credential?.id) {
+            try {
+                await this.notify(this.DLGT_CREDENTIAL_VALIDATED, {
+                    credentialId: this.credential.id,
+                    moduleName: this.name,
+                });
+            } catch (err) {
+                console.error(
+                    `[Frigg] Failed to propagate CREDENTIAL_VALIDATED for module ${this.name}:`,
+                    err?.message || err
+                );
+            }
+        }
     }
 
     async receiveNotification(notifier, delegateString, object = null) {

--- a/packages/core/modules/requester/oauth-2.test.js
+++ b/packages/core/modules/requester/oauth-2.test.js
@@ -354,7 +354,7 @@ describe('OAuth2Requester', () => {
             expect(mockFetch.mock.calls[0][1].headers.Authorization).toBeUndefined();
         });
 
-        it('should not retry more than once for consecutive 401s', async () => {
+        it('should not retry more than once for consecutive 401s and should NOT notify on the second 401', async () => {
             const mockFetch = jest.fn().mockResolvedValue({
                 status: 401,
                 headers: { get: () => 'application/json' },
@@ -377,10 +377,8 @@ describe('OAuth2Requester', () => {
             await expect(requester._get({ url: 'https://api.example.com/data' }))
                 .rejects.toThrow();
 
-            // Should call fetch twice: initial + 1 retry after refresh
             expect(mockFetch).toHaveBeenCalledTimes(2);
-            // Should notify DLGT_INVALID_AUTH after second 401
-            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+            expect(requester.notify).not.toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
         });
 
         it('should use getTokenFromClientCredentials for client_credentials grant type on 401', async () => {

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -178,6 +178,11 @@ class Requester extends Delegate {
                 );
             }
 
+            // Successful response: reset the per-instance refresh budget so
+            // a later 401 in the same Requester lifetime can attempt refresh
+            // again instead of silently falling through.
+            this.refreshCount = 0;
+
             // parsedBody consumes the response body stream. If the server
             // stalls mid-stream the timer (still armed) aborts it.
             return options.returnFullRes

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -151,9 +151,9 @@ class Requester extends Delegate {
                 await new Promise((resolve) => setTimeout(resolve, delay));
                 return this._request(url, options, i + 1);
             } else if (status === 401) {
-                if (!this.isRefreshable || this.refreshCount > 0) {
+                if (!this.isRefreshable) {
                     await this.notify(this.DLGT_INVALID_AUTH);
-                } else {
+                } else if (this.refreshCount === 0) {
                     this.refreshCount++;
                     const refreshSucceeded = await this.refreshAuth();
                     if (refreshSucceeded) {

--- a/packages/core/modules/requester/requester.test.js
+++ b/packages/core/modules/requester/requester.test.js
@@ -373,6 +373,27 @@ describe('Requester', () => {
             expect(requester.notify).not.toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
             expect(fetchMock).toHaveBeenCalledTimes(2);
         });
+
+        it('resets refreshCount after a successful 2xx so a later 401 can attempt refresh again', async () => {
+            const fetchMock = oauthFetch([
+                { status: 401 },
+                { status: 200, body: { ok: 'first' } },
+                { status: 401 },
+                { status: 200, body: { ok: 'second' } },
+            ]);
+            const requester = new RefreshableRequester({ fetch: fetchMock });
+            requester.refreshAuth = jest.fn().mockResolvedValue(true);
+            requester.notify = jest.fn();
+
+            const r1 = await requester._get({ url: 'https://example.com/first' });
+            const r2 = await requester._get({ url: 'https://example.com/second' });
+
+            expect(r1).toEqual({ ok: 'first' });
+            expect(r2).toEqual({ ok: 'second' });
+            expect(requester.refreshAuth).toHaveBeenCalledTimes(2);
+            expect(requester.notify).not.toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+            expect(fetchMock).toHaveBeenCalledTimes(4);
+        });
     });
 
     describe('ECONNRESET retry (regression guard)', () => {

--- a/packages/core/modules/requester/requester.test.js
+++ b/packages/core/modules/requester/requester.test.js
@@ -284,6 +284,97 @@ describe('Requester', () => {
         });
     });
 
+    describe('401 auth-state contract', () => {
+        function oauthFetch(responses) {
+            const queue = [...responses];
+            return jest.fn(async () => {
+                const next = queue.shift();
+                if (!next) throw new Error('unexpected fetch call');
+                return {
+                    status: next.status,
+                    headers: { get: () => 'application/json' },
+                    json: async () => next.body ?? {},
+                };
+            });
+        }
+
+        class RefreshableRequester extends Requester {
+            constructor(params) {
+                super(params);
+                this.isRefreshable = true;
+            }
+            async addAuthHeaders(headers) {
+                return headers;
+            }
+            async refreshAuth() {
+                return true;
+            }
+        }
+
+        it('fires INVALID_AUTH when the requester is not refreshable', async () => {
+            const fetchMock = oauthFetch([{ status: 401, body: { error: 'unauthorized' } }]);
+            const requester = new TestRequester({ fetch: fetchMock });
+            requester.notify = jest.fn();
+
+            await expect(
+                requester._get({ url: 'https://example.com/protected' })
+            ).rejects.toThrow();
+
+            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
+
+        it('does NOT fire INVALID_AUTH when refresh succeeds and retry returns 200', async () => {
+            const fetchMock = oauthFetch([
+                { status: 401 },
+                { status: 200, body: { ok: true } },
+            ]);
+            const requester = new RefreshableRequester({ fetch: fetchMock });
+            requester.refreshAuth = jest.fn().mockResolvedValue(true);
+            requester.notify = jest.fn();
+
+            const result = await requester._get({ url: 'https://example.com/protected' });
+
+            expect(result).toEqual({ ok: true });
+            expect(requester.refreshAuth).toHaveBeenCalledTimes(1);
+            expect(requester.notify).not.toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+
+        it('does NOT fire INVALID_AUTH from the requester when refresh fails (refreshAuth owns the notify)', async () => {
+            const fetchMock = oauthFetch([{ status: 401 }]);
+            const requester = new RefreshableRequester({ fetch: fetchMock });
+            requester.refreshAuth = jest.fn().mockResolvedValue(false);
+            requester.notify = jest.fn();
+
+            await expect(
+                requester._get({ url: 'https://example.com/protected' })
+            ).rejects.toThrow();
+
+            expect(requester.refreshAuth).toHaveBeenCalledTimes(1);
+            expect(requester.notify).not.toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
+
+        it('does NOT fire INVALID_AUTH on a second 401 after a successful refresh', async () => {
+            const fetchMock = oauthFetch([
+                { status: 401 },
+                { status: 401 },
+            ]);
+            const requester = new RefreshableRequester({ fetch: fetchMock });
+            requester.refreshAuth = jest.fn().mockResolvedValue(true);
+            requester.notify = jest.fn();
+
+            await expect(
+                requester._get({ url: 'https://example.com/protected' })
+            ).rejects.toThrow();
+
+            expect(requester.refreshAuth).toHaveBeenCalledTimes(1);
+            expect(requester.notify).not.toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+    });
+
     describe('ECONNRESET retry (regression guard)', () => {
         it('still retries on ECONNRESET following the backOff schedule', async () => {
             jest.useFakeTimers();

--- a/packages/core/modules/tests/module-on-token-update.test.js
+++ b/packages/core/modules/tests/module-on-token-update.test.js
@@ -107,3 +107,117 @@ describe('Module.onTokenUpdate with organization userId', () => {
         );
     });
 });
+
+describe('Module.onTokenUpdate CREDENTIAL_VALIDATED propagation', () => {
+    let mockCredentialRepository;
+    let mockApi;
+    let mockDefinition;
+    let module;
+
+    beforeEach(() => {
+        mockCredentialRepository = {
+            upsertCredential: jest.fn().mockResolvedValue({
+                id: 'cred-1',
+                userId: 'user-1',
+                authIsValid: true,
+            }),
+        };
+
+        mockApi = {
+            access_token: 'fresh-access-token',
+            refresh_token: 'fresh-refresh-token',
+            DLGT_TOKEN_UPDATE: 'TOKEN_UPDATE',
+        };
+
+        mockDefinition = {
+            moduleName: 'testmodule',
+            modelName: 'TestModule',
+            API: class MockAPI {
+                constructor() {}
+            },
+            requiredAuthMethods: {
+                getToken: jest.fn(),
+                getEntityDetails: jest.fn(),
+                getCredentialDetails: jest.fn((api, userId) => ({
+                    identifiers: { userId },
+                    details: {
+                        access_token: api.access_token,
+                        refresh_token: api.refresh_token,
+                    },
+                })),
+                apiPropertiesToPersist: {
+                    credential: ['access_token', 'refresh_token'],
+                    entity: [],
+                },
+                testAuthRequest: jest.fn(),
+            },
+        };
+
+        module = new Module({
+            definition: mockDefinition,
+            userId: 'user-1',
+            entity: { id: 'entity-1', userId: 'user-1' },
+        });
+        module.credentialRepository = mockCredentialRepository;
+        module.api = mockApi;
+    });
+
+    it('notifies its delegate with CREDENTIAL_VALIDATED after persisting the refreshed credential', async () => {
+        const mockDelegate = {
+            receiveNotification: jest.fn().mockResolvedValue(undefined),
+        };
+        module.delegate = mockDelegate;
+
+        await module.onTokenUpdate();
+
+        expect(mockCredentialRepository.upsertCredential).toHaveBeenCalledTimes(1);
+        expect(mockDelegate.receiveNotification).toHaveBeenCalledWith(
+            module,
+            'CREDENTIAL_VALIDATED',
+            expect.objectContaining({
+                credentialId: 'cred-1',
+                moduleName: 'testmodule',
+            })
+        );
+    });
+
+    it('completes silently when no delegate is wired (initial-auth path)', async () => {
+        expect(module.delegate).toBeNull();
+
+        await expect(module.onTokenUpdate()).resolves.toBeUndefined();
+        expect(mockCredentialRepository.upsertCredential).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not throw when the delegate fails to receive the notification', async () => {
+        const mockDelegate = {
+            receiveNotification: jest.fn().mockRejectedValue(new Error('delegate boom')),
+        };
+        module.delegate = mockDelegate;
+
+        await expect(module.onTokenUpdate()).resolves.toBeUndefined();
+        expect(mockDelegate.receiveNotification).toHaveBeenCalledWith(
+            module,
+            'CREDENTIAL_VALIDATED',
+            expect.any(Object)
+        );
+    });
+
+    it('does not emit CREDENTIAL_VALIDATED when the persisted credential has no id', async () => {
+        mockCredentialRepository.upsertCredential.mockResolvedValueOnce({
+            userId: 'user-1',
+            authIsValid: true,
+        });
+        const mockDelegate = {
+            receiveNotification: jest.fn().mockResolvedValue(undefined),
+        };
+        module.delegate = mockDelegate;
+
+        await module.onTokenUpdate();
+
+        expect(mockDelegate.receiveNotification).not.toHaveBeenCalledWith(
+            module,
+            'CREDENTIAL_VALIDATED',
+            expect.any(Object)
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Stops marking `Integration.status = ERROR` on every 401 and starts respecting the refresh outcome.

Auth-state contract per 401:
- token NOT refreshable → ERROR
- refresh FAILS → ERROR (`refreshAuth`'s own catch fires `DLGT_INVALID_AUTH`)
- refresh SUCCEEDS → no status change; if status was ERROR, heal back to ENABLED

The previous Requester also speculatively fired `DLGT_INVALID_AUTH` on any second 401 within the same Requester instance (`refreshCount > 0`). Under concurrent sync workloads that flipped integrations to ERROR before refresh had a chance to succeed in a sibling requester — so the ERROR state stuck even when refresh eventually worked.

## Changes

- **Requester** (`packages/core/modules/requester/requester.js`) — split the 401 handler into 3 explicit branches; drop the `|| refreshCount > 0` clause.
- **Module** (`packages/core/modules/module.js`) — register `DLGT_CREDENTIAL_VALIDATED` and emit it from `onTokenUpdate()` after the refreshed credential persists with `authIsValid = true`. Best-effort try/catch.
- **IntegrationBase** (`packages/core/integrations/integration-base.js`) — `receiveNotification` self-heals on `CREDENTIAL_VALIDATED`: ERROR → ENABLED only; leaves NEEDS_CONFIG / DISABLED / other intentional states alone.

## Test plan

TDD red-green-refactor:

- [x] `requester.test.js` — 4 new contract cases (not-refreshable notifies; refresh-succeeds no notify + retries; refresh-fails no notify from requester; second-401 after successful refresh no notify)
- [x] `oauth-2.test.js` — updated consecutive-401 test to assert the new contract (no notify on second 401)
- [x] `module-on-token-update.test.js` — 4 new cases for `CREDENTIAL_VALIDATED` emission, delegate-throw tolerance, no-id no-op
- [x] `integration-base-receive-notification.test.js` — 5 new self-heal cases
- [x] 187 tests pass across affected suites (`modules/requester`, `modules/tests`, `integrations/tests`)
- [ ] Manual end-to-end with Attio/Zoho: force-expire the access token, trigger a worker, observe `[Frigg] Token refresh succeeded` + integration stays ENABLED (or heals from ERROR)
- [ ] Regression: invalidate both access and refresh tokens, confirm integration ends up in ERROR

Pre-existing failures in `*-encryption.test.js`, `Cryptor.test.js`, `webhook-flow.integration.test.js`, `queuer-util.test.js`, `integration-commands.test.js`, and `adopter-jwt.test.js` are unrelated — verified by re-running them on the stashed branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)