### PR TITLE
feat(core): increment totalSkipped counter on UpdateProcessMetrics

### DIFF
--- a/packages/core/integrations/use-cases/update-process-metrics.js
+++ b/packages/core/integrations/use-cases/update-process-metrics.js
@@ -28,8 +28,9 @@
  * const updateMetrics = new UpdateProcessMetrics({ processRepository, websocketService });
  * await updateMetrics.execute(processId, {
  *   processed: 100,
- *   success: 95,
+ *   success: 92,
  *   errors: 5,
+ *   skipped: 3,
  *   errorDetails: [{ contactId: 'abc', error: 'Missing email', timestamp: '...' }]
  * });
  */
@@ -54,6 +55,11 @@ class UpdateProcessMetrics {
      * @param {number} [metricsUpdate.processed=0] - Records processed in this batch
      * @param {number} [metricsUpdate.success=0] - Successful records
      * @param {number} [metricsUpdate.errors=0] - Failed records
+     * @param {number} [metricsUpdate.skipped=0] - Intentionally-skipped
+     *     records (hash-match, dedupe, loop protection, etc.). Increments
+     *     `results.aggregateData.totalSkipped`. Distinct from errors so the
+     *     UI can show `processed = synced + failed + skipped` without
+     *     conflating intentional skips with failures.
      * @param {Array} [metricsUpdate.errorDetails=[]] - Error details array
      * @returns {Promise<Object>} Updated process record
      * @throws {Error} If process not found or update fails
@@ -71,9 +77,11 @@ class UpdateProcessMetrics {
         const processed = metricsUpdate.processed || 0;
         const success = metricsUpdate.success || 0;
         const errors = metricsUpdate.errors || 0;
+        const skipped = metricsUpdate.skipped || 0;
         if (processed) increment['context.processedRecords'] = processed;
         if (success) increment['results.aggregateData.totalSynced'] = success;
         if (errors) increment['results.aggregateData.totalFailed'] = errors;
+        if (skipped) increment['results.aggregateData.totalSkipped'] = skipped;
 
         const pushSlice = {};
         if (
@@ -191,6 +199,7 @@ class UpdateProcessMetrics {
                     total: context.totalRecords || 0,
                     successCount: aggregateData.totalSynced || 0,
                     errorCount: aggregateData.totalFailed || 0,
+                    skippedCount: aggregateData.totalSkipped || 0,
                     recordsPerSecond: aggregateData.recordsPerSecond || 0,
                     estimatedCompletion: context.estimatedCompletion || null,
                     timestamp: new Date().toISOString(),

--- a/packages/core/integrations/use-cases/update-process-metrics.test.js
+++ b/packages/core/integrations/use-cases/update-process-metrics.test.js
@@ -108,6 +108,77 @@ describe('UpdateProcessMetrics', () => {
             );
         });
 
+        it('routes skipped to applyProcessUpdate.increment as totalSkipped', async () => {
+            // Records that were intentionally not synced (hash-skip, loop
+            // protection, etc.) must increment a real counter so the UI
+            // can show processed = synced + failed + skipped. Previously
+            // the skipped count was silently dropped from the atomic phase.
+            mockProcessRepository.applyProcessUpdate.mockResolvedValue(
+                atomicSnapshot
+            );
+            mockProcessRepository.update.mockResolvedValue(atomicSnapshot);
+
+            await useCase.execute(processId, {
+                processed: 10,
+                success: 7,
+                errors: 0,
+                skipped: 3,
+            });
+
+            expect(mockProcessRepository.applyProcessUpdate).toHaveBeenCalledWith(
+                processId,
+                {
+                    increment: {
+                        'context.processedRecords': 10,
+                        'results.aggregateData.totalSynced': 7,
+                        'results.aggregateData.totalSkipped': 3,
+                    },
+                    pushSlice: {},
+                }
+            );
+        });
+
+        it('omits totalSkipped from the increment map when skipped is zero', async () => {
+            mockProcessRepository.applyProcessUpdate.mockResolvedValue(
+                atomicSnapshot
+            );
+            mockProcessRepository.update.mockResolvedValue(atomicSnapshot);
+
+            await useCase.execute(processId, {
+                processed: 5,
+                success: 5,
+                errors: 0,
+                skipped: 0,
+            });
+
+            const [, ops] =
+                mockProcessRepository.applyProcessUpdate.mock.calls[0];
+            expect('results.aggregateData.totalSkipped' in ops.increment).toBe(
+                false
+            );
+        });
+
+        it('treats a skipped-only batch as atomic work (does not short-circuit)', async () => {
+            // Regression guard: hasAtomicWork must include skipped so that
+            // a batch of skipped-only events still issues the UPDATE.
+            mockProcessRepository.applyProcessUpdate.mockResolvedValue(
+                atomicSnapshot
+            );
+            mockProcessRepository.update.mockResolvedValue(atomicSnapshot);
+
+            await useCase.execute(processId, {
+                processed: 0,
+                success: 0,
+                errors: 0,
+                skipped: 1,
+            });
+
+            expect(mockProcessRepository.applyProcessUpdate).toHaveBeenCalledTimes(
+                1
+            );
+            expect(mockProcessRepository.findById).not.toHaveBeenCalled();
+        });
+
         it('routes errorDetails to pushSlice with keepLast 100', async () => {
             mockProcessRepository.applyProcessUpdate.mockResolvedValue(
                 atomicSnapshot


### PR DESCRIPTION
## Summary

- `UpdateProcessMetrics.execute` accepts a new `skipped` field on the metrics-update object and routes it into the atomic phase as `results.aggregateData.totalSkipped`.
- Mirrors how `success` and `errors` are handled: omitted from the increment map when zero, and counts as atomic work so a skipped-only batch doesn't fall through to `findById`.
- WebSocket broadcasts additionally expose `skippedCount` in the progress payload.

## Why

The UI identity `processed = totalSynced + totalFailed + totalSkipped` was breaking for integrations that legitimately skip records (hash-match, loop protection, dedupe). The old code only had three increment paths — `processed`, `success`, `errors` — so any `skipped: N` passed through `recordBatchMetrics` was silently dropped on the atomic path. The best it could do was leave a `kind: 'skipped_count'` breadcrumb in the bounded `errorDetails` array (capped at 100), which then showed up as `errors` in any UI that surfaced the array.

Concrete case that surfaced this: a HubSpot ↔ Clockwork integration was hash-skipping ~574 records per initial sync (records that originated in the destination system, so the c2h hash matched and the upsert was correctly skipped). The status panel showed:

```
Processed:  3086
Synced:     2512
Failed:        0
Skipped:       0   ← actually 574, dropped by the atomic path
```

After this change the same scenario would write `totalSkipped = 574` and the identity holds.

## Compatibility

- **Pure addition.** Existing callers that don't pass `skipped` see no behaviour change — the existing 17 tests still pass unchanged.
- **WebSocket broadcast** now includes `skippedCount` alongside `successCount`/`errorCount`. Additive; no removed fields.
- No DB schema change. `totalSkipped` is created on first increment by `jsonb_set` / `\$inc` `create_missing=true`.

## Tests

3 new tests in `update-process-metrics.test.js`:

- `routes skipped to applyProcessUpdate.increment as totalSkipped`
- `omits totalSkipped from the increment map when skipped is zero`
- `treats a skipped-only batch as atomic work (does not short-circuit)`

Full suite for `update-process-metrics.test.js`: **20/20 green** (17 prior + 3 new).

Wider `packages/core` baseline: 64 failures pre-existing on `next` at `75dc5e65`. Same 64 failures with my change applied — confirmed via `git stash` round-trip. None of them touch this code path.

## Test plan

- [x] New unit tests cover the additive code paths.
- [x] Confirmed baseline failure count unchanged.
- [ ] Reviewer: confirm WebSocket subscribers don't reject unknown additional fields in the progress payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.86`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/core`
    - feat(core): increment totalSkipped counter on UpdateProcessMetrics [#588](https://github.com/friggframework/frigg/pull/588) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - fix(core): respect refresh outcome before marking integration ERROR on 401 [#587](https://github.com/friggframework/frigg/pull/587) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
