### PR TITLE
feat(core,devtools): namespace extension routes + useDatabase flag

### DIFF
--- a/packages/core/core/create-handler.js
+++ b/packages/core/core/create-handler.js
@@ -80,10 +80,7 @@ const createHandler = (optionByName = {}) => {
             // If enabled (i.e. if SECRET_ARN is set in process.env) Fetch secrets from AWS Secrets Manager, and set them as environment variables.
             await secretsToEnv();
 
-            // Open the database connection up front when the handler needs it.
-            // Lazy-required so DB-free handlers (e.g. extension webhook
-            // receivers with useDatabase:false) never load the Prisma client.
-            // $connect is idempotent, so this safely reuses a warm connection.
+            // Lazy-required so DB-free handlers never load the Prisma client.
             if (shouldUseDatabase) {
                 const { connectPrisma } = require('../database/prisma');
                 await connectPrisma();

--- a/packages/core/core/create-handler.js
+++ b/packages/core/core/create-handler.js
@@ -49,6 +49,7 @@ const createHandler = (optionByName = {}) => {
         eventName = 'Event',
         isUserFacingResponse = true,
         method,
+        shouldUseDatabase = true,
     } = optionByName;
 
     if (!method) {
@@ -78,6 +79,15 @@ const createHandler = (optionByName = {}) => {
 
             // If enabled (i.e. if SECRET_ARN is set in process.env) Fetch secrets from AWS Secrets Manager, and set them as environment variables.
             await secretsToEnv();
+
+            // Open the database connection up front when the handler needs it.
+            // Lazy-required so DB-free handlers (e.g. extension webhook
+            // receivers with useDatabase:false) never load the Prisma client.
+            // $connect is idempotent, so this safely reuses a warm connection.
+            if (shouldUseDatabase) {
+                const { connectPrisma } = require('../database/prisma');
+                await connectPrisma();
+            }
 
             // Helps reuse the database connection.  Lowers response times.
             context.callbackWaitsForEmptyEventLoop = false;

--- a/packages/core/core/create-handler.test.js
+++ b/packages/core/core/create-handler.test.js
@@ -1,0 +1,68 @@
+jest.mock('../database/prisma', () => ({
+    connectPrisma: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('./secrets-to-env', () => ({
+    secretsToEnv: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../logs', () => ({
+    initDebugLog: jest.fn(),
+    flushDebugLog: jest.fn(),
+}));
+
+const { connectPrisma } = require('../database/prisma');
+const { createHandler } = require('./create-handler');
+
+describe('createHandler — shouldUseDatabase', () => {
+    const ctx = { awsRequestId: 'r1' };
+
+    beforeEach(() => {
+        connectPrisma.mockClear();
+        connectPrisma.mockResolvedValue(undefined);
+    });
+
+    it('connects to the database when shouldUseDatabase is true', async () => {
+        const handler = createHandler({
+            eventName: 'X',
+            shouldUseDatabase: true,
+            method: async () => ({ statusCode: 200 }),
+        });
+        await handler({}, { ...ctx });
+        expect(connectPrisma).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT connect when shouldUseDatabase is false', async () => {
+        const handler = createHandler({
+            eventName: 'X',
+            shouldUseDatabase: false,
+            method: async () => ({ statusCode: 200 }),
+        });
+        await handler({}, { ...ctx });
+        expect(connectPrisma).not.toHaveBeenCalled();
+    });
+
+    it('connects before invoking the method', async () => {
+        const order = [];
+        connectPrisma.mockImplementation(async () => {
+            order.push('connect');
+        });
+        const handler = createHandler({
+            eventName: 'X',
+            shouldUseDatabase: true,
+            method: async () => {
+                order.push('method');
+                return { statusCode: 200 };
+            },
+        });
+        await handler({}, { ...ctx });
+        expect(order).toEqual(['connect', 'method']);
+    });
+
+    it('defaults to connecting when shouldUseDatabase is omitted (backwards-compatible)', async () => {
+        const handler = createHandler({
+            eventName: 'X',
+            method: async () => ({ statusCode: 200 }),
+        });
+        await handler({}, { ...ctx });
+        expect(connectPrisma).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/core/handlers/routers/health.js
+++ b/packages/core/handlers/routers/health.js
@@ -511,6 +511,10 @@ router.get('/health/ready', async (_req, res) => {
     });
 });
 
-const handler = createAppHandler('HTTP Event: Health', router);
+// shouldUseDatabase: false — health must NOT eagerly open a DB connection.
+// /health/live is a pure liveness probe (no DB), and /health/ready probes the
+// DB itself and degrades to 503 gracefully. Eager-connect at handler entry
+// would turn a DB outage into a 500 for both (killing healthy containers).
+const handler = createAppHandler('HTTP Event: Health', router, false);
 
 module.exports = { handler, router };

--- a/packages/core/handlers/routers/health.js
+++ b/packages/core/handlers/routers/health.js
@@ -511,10 +511,8 @@ router.get('/health/ready', async (_req, res) => {
     });
 });
 
-// shouldUseDatabase: false — health must NOT eagerly open a DB connection.
-// /health/live is a pure liveness probe (no DB), and /health/ready probes the
-// DB itself and degrades to 503 gracefully. Eager-connect at handler entry
-// would turn a DB outage into a 500 for both (killing healthy containers).
+// DB-free: /health/ready probes the DB itself and degrades to 503. Eager-connect
+// here would turn a DB outage into a 500, killing otherwise-healthy containers.
 const handler = createAppHandler('HTTP Event: Health', router, false);
 
 module.exports = { handler, router };

--- a/packages/core/handlers/routers/health.test.js
+++ b/packages/core/handlers/routers/health.test.js
@@ -22,6 +22,14 @@ jest.mock('../../database/prisma', () => ({
     disconnectPrisma: jest.fn(),
 }));
 
+// Capture how health.js wraps its router. `router` is exported independently
+// of the handler, so mocking createAppHandler does not affect the router-based
+// tests below.
+jest.mock('./../app-handler-helpers', () => ({
+    createApp: jest.fn(),
+    createAppHandler: jest.fn(() => ({})),
+}));
+
 const mockHealthCheckRepository = {
     getDatabaseConnectionState: jest.fn().mockResolvedValue({
         readyState: 1, stateName: 'connected', isConnected: true,
@@ -68,6 +76,17 @@ jest.mock('./../app-handler-helpers', () => ({
 }));
 
 const { router } = require('./health');
+
+describe('Health handler DB posture', () => {
+    it('creates the handler DB-free (shouldUseDatabase=false) so liveness/readiness never eager-connect', () => {
+        const { createAppHandler } = require('./../app-handler-helpers');
+        const healthCall = createAppHandler.mock.calls.find(
+            (c) => c[0] === 'HTTP Event: Health'
+        );
+        expect(healthCall).toBeDefined();
+        expect(healthCall[2]).toBe(false);
+    });
+});
 
 const mockRequest = (path, headers = {}) => ({
     path,

--- a/packages/core/handlers/routers/integration-defined-routers.js
+++ b/packages/core/handlers/routers/integration-defined-routers.js
@@ -94,9 +94,23 @@ for (const IntegrationClass of integrationClasses) {
     };
 
     for (const [bindingName, group] of bindingGroups) {
+        // The function key is the wire contract with the devtools serverless
+        // generator (integration-builder.js builds the identical key). Keep
+        // the derivation here and there IN SYNC.
         const fnKey = `${IntegrationClass.Definition.name}__${sanitizeBindingKey(
             bindingName
         )}`;
+        // Two binding keys that sanitize to the same value (e.g. "hub-spot"
+        // and "hubspot") would silently overwrite each other's handler. The
+        // namespaced-path claim() above can't catch it (the paths differ), so
+        // fail loud here.
+        if (Object.prototype.hasOwnProperty.call(handlers, fnKey)) {
+            throw new Error(
+                `Integration "${IntegrationClass.Definition.name}" extension handler conflict: ` +
+                    `binding "${bindingName}" sanitizes to "${fnKey}", which is already taken. ` +
+                    `Use binding keys that are distinct after stripping non-alphanumeric characters.`
+            );
+        }
         handlers[fnKey] = {
             handler: createAppHandler(
                 `HTTP Event: ${IntegrationClass.Definition.name} extension ${bindingName}`,

--- a/packages/core/handlers/routers/integration-defined-routers.js
+++ b/packages/core/handlers/routers/integration-defined-routers.js
@@ -12,6 +12,9 @@ const { integrations: integrationClasses } = loadAppDefinition();
 
 const routeKey = (method, path) => `${(method || 'ANY').toUpperCase()} ${path}`;
 
+// Serverless function keys must be alphanumeric; binding keys are developer-chosen.
+const sanitizeBindingKey = (name) => String(name).replace(/[^A-Za-z0-9]/g, '');
+
 //todo: this should be in a use case class
 for (const IntegrationClass of integrationClasses) {
     const router = Router();
@@ -53,20 +56,32 @@ for (const IntegrationClass of integrationClasses) {
         }
     }
 
-    // Tier 3 Integration Extension routes — see EXTENSIONS.md
+    // Tier 3 Integration Extension routes — each binding gets a dedicated
+    // handler, namespaced under /{bindingName}, so multiple modules' extensions
+    // can declare the same relative path (e.g. two /webhooks) without colliding.
+    // Each per-binding handler carries its own shouldUseDatabase (resolved from
+    // the extension/binding `useDatabase`, default false → DB-free receiver).
+    const bindingGroups = new Map();
     for (const extRoute of getExtensionRoutes(IntegrationClass)) {
+        const namespacedPath = `/${extRoute.bindingName}${extRoute.path}`;
         claim(
             extRoute.method,
-            extRoute.path,
+            namespacedPath,
             `extension "${extRoute.extensionName}" (binding "${extRoute.bindingName}")`
         );
-        router.use(
-            basePath,
+        if (!bindingGroups.has(extRoute.bindingName)) {
+            bindingGroups.set(extRoute.bindingName, {
+                router: Router(),
+                useDatabase: extRoute.useDatabase,
+            });
+        }
+        const group = bindingGroups.get(extRoute.bindingName);
+        group.router.use(
+            `${basePath}/${extRoute.bindingName}`,
             loadRouterFromObject(IntegrationClass, extRoute)
         );
-        const method = extRoute.method.toUpperCase();
         console.log(
-            `│ ${method} ${basePath}${extRoute.path}  (extension: ${extRoute.extensionName})`
+            `│ ${extRoute.method.toUpperCase()} ${basePath}/${extRoute.bindingName}${extRoute.path}  (extension: ${extRoute.extensionName}, useDatabase: ${extRoute.useDatabase})`
         );
     }
     console.log('│');
@@ -77,6 +92,19 @@ for (const IntegrationClass of integrationClasses) {
             router
         ),
     };
+
+    for (const [bindingName, group] of bindingGroups) {
+        const fnKey = `${IntegrationClass.Definition.name}__${sanitizeBindingKey(
+            bindingName
+        )}`;
+        handlers[fnKey] = {
+            handler: createAppHandler(
+                `HTTP Event: ${IntegrationClass.Definition.name} extension ${bindingName}`,
+                group.router,
+                group.useDatabase
+            ),
+        };
+    }
 }
 
 module.exports = { handlers };

--- a/packages/core/handlers/routers/integration-defined-routers.js
+++ b/packages/core/handlers/routers/integration-defined-routers.js
@@ -56,11 +56,8 @@ for (const IntegrationClass of integrationClasses) {
         }
     }
 
-    // Tier 3 Integration Extension routes — each binding gets a dedicated
-    // handler, namespaced under /{bindingName}, so multiple modules' extensions
-    // can declare the same relative path (e.g. two /webhooks) without colliding.
-    // Each per-binding handler carries its own shouldUseDatabase (resolved from
-    // the extension/binding `useDatabase`, default false → DB-free receiver).
+    // Each extension binding gets its own namespaced handler (/{bindingName}),
+    // so two modules' extensions can share a path like /webhooks without colliding.
     const bindingGroups = new Map();
     for (const extRoute of getExtensionRoutes(IntegrationClass)) {
         const namespacedPath = `/${extRoute.bindingName}${extRoute.path}`;
@@ -94,16 +91,12 @@ for (const IntegrationClass of integrationClasses) {
     };
 
     for (const [bindingName, group] of bindingGroups) {
-        // The function key is the wire contract with the devtools serverless
-        // generator (integration-builder.js builds the identical key). Keep
-        // the derivation here and there IN SYNC.
+        // Wire contract: integration-builder.js (devtools) derives the identical
+        // function key for the serverless config. Keep both in sync.
         const fnKey = `${IntegrationClass.Definition.name}__${sanitizeBindingKey(
             bindingName
         )}`;
-        // Two binding keys that sanitize to the same value (e.g. "hub-spot"
-        // and "hubspot") would silently overwrite each other's handler. The
-        // namespaced-path claim() above can't catch it (the paths differ), so
-        // fail loud here.
+        // Distinct binding keys can sanitize to the same fnKey — fail loud rather than overwrite.
         if (Object.prototype.hasOwnProperty.call(handlers, fnKey)) {
             throw new Error(
                 `Integration "${IntegrationClass.Definition.name}" extension handler conflict: ` +

--- a/packages/core/handlers/routers/integration-defined-routers.test.js
+++ b/packages/core/handlers/routers/integration-defined-routers.test.js
@@ -107,6 +107,7 @@ describe('integration-defined-routers — extension routes', () => {
             path: '/stub-hook',
             method: 'POST',
             event: 'STUB_EVENT',
+            useDatabase: false,
         });
     });
 
@@ -168,62 +169,109 @@ describe('integration-defined-routers — extension routes', () => {
     });
 });
 
-describe('integration-defined-routers — boot-time route conflict detection', () => {
+describe('integration-defined-routers — per-binding namespacing', () => {
     afterEach(() => {
         jest.resetModules();
     });
 
-    it('throws when an extension route collides with a Definition.routes entry', () => {
-        const extension = {
-            name: 'collide-ext',
-            routes: [{ path: '/hook', method: 'POST', event: 'X_EVENT' }],
-            events: { X_EVENT: { handler: async () => null } },
-        };
-        class CollidingIntegration extends IntegrationBase {
+    const makeExt = (name, event) => ({
+        name,
+        routes: [{ path: '/webhooks', method: 'POST', event }],
+        events: { [event]: { handler: async () => null } },
+    });
+
+    it('exposes a dedicated handler per extension binding, keyed by binding name, alongside the main integration handler', () => {
+        const ext = makeExt('hs-webhooks', 'HS_EVENT');
+        class Multi extends IntegrationBase {
             static Definition = {
-                name: 'collider',
+                name: 'multi',
                 version: '1.0.0',
                 modules: {},
-                routes: [{ path: '/hook', method: 'POST', event: 'OWN_EVENT' }],
-                extensions: { ext: { extension } },
+                extensions: { hubspotWebhooks: { extension: ext } },
             };
         }
         jest.doMock('../app-definition-loader', () => ({
-            loadAppDefinition: () => ({
-                integrations: [CollidingIntegration],
-            }),
+            loadAppDefinition: () => ({ integrations: [Multi] }),
+        }));
+        const { handlers } = require('./integration-defined-routers');
+        expect(handlers).toHaveProperty('multi'); // main catch-all
+        expect(handlers).toHaveProperty('multi__hubspotWebhooks'); // per-binding
+    });
+
+    it('does NOT collide when two bindings declare the same relative route path (namespacing disambiguates)', () => {
+        const a = makeExt('ext-a', 'A_EVENT');
+        const b = makeExt('ext-b', 'B_EVENT');
+        class TwoMod extends IntegrationBase {
+            static Definition = {
+                name: 'twomod',
+                version: '1.0.0',
+                modules: {},
+                extensions: {
+                    hubspot: { extension: a },
+                    clockwork: { extension: b },
+                },
+            };
+        }
+        jest.doMock('../app-definition-loader', () => ({
+            loadAppDefinition: () => ({ integrations: [TwoMod] }),
+        }));
+        let mod;
+        expect(() => {
+            mod = require('./integration-defined-routers');
+        }).not.toThrow();
+        expect(mod.handlers).toHaveProperty('twomod__hubspot');
+        expect(mod.handlers).toHaveProperty('twomod__clockwork');
+    });
+
+    it('still throws when a single binding declares two routes with the same method+path', () => {
+        const dup = {
+            name: 'dup-ext',
+            routes: [
+                { path: '/dup', method: 'POST', event: 'E1' },
+                { path: '/dup', method: 'POST', event: 'E2' },
+            ],
+            events: {
+                E1: { handler: async () => null },
+                E2: { handler: async () => null },
+            },
+        };
+        class DupIntegration extends IntegrationBase {
+            static Definition = {
+                name: 'dupint',
+                version: '1.0.0',
+                modules: {},
+                extensions: { only: { extension: dup } },
+            };
+        }
+        jest.doMock('../app-definition-loader', () => ({
+            loadAppDefinition: () => ({ integrations: [DupIntegration] }),
         }));
         expect(() => require('./integration-defined-routers')).toThrow(
-            /route conflict.*POST \/hook.*Definition\.routes.*extension "collide-ext"/
+            /route conflict.*POST \/only\/dup/
         );
     });
 
-    it('throws when two extensions in the same integration share a path', () => {
-        const extA = {
-            name: 'ext-a',
-            routes: [{ path: '/shared', method: 'POST', event: 'A_EVENT' }],
-            events: { A_EVENT: { handler: async () => null } },
+    it('does not collide an extension route with a Definition.route that shares the un-namespaced path (extension is namespaced)', () => {
+        const ext = {
+            name: 'ns-ext',
+            routes: [{ path: '/hook', method: 'POST', event: 'X_EVENT' }],
+            events: { X_EVENT: { handler: async () => null } },
         };
-        const extB = {
-            name: 'ext-b',
-            routes: [{ path: '/shared', method: 'POST', event: 'B_EVENT' }],
-            events: { B_EVENT: { handler: async () => null } },
-        };
-        class DoubleColliderIntegration extends IntegrationBase {
+        class NoCollide extends IntegrationBase {
             static Definition = {
-                name: 'double-collide',
+                name: 'nocollide',
                 version: '1.0.0',
                 modules: {},
-                extensions: { a: { extension: extA }, b: { extension: extB } },
+                routes: [{ path: '/hook', method: 'POST', event: 'OWN_EVENT' }],
+                extensions: { ext: { extension: ext } },
             };
         }
         jest.doMock('../app-definition-loader', () => ({
-            loadAppDefinition: () => ({
-                integrations: [DoubleColliderIntegration],
-            }),
+            loadAppDefinition: () => ({ integrations: [NoCollide] }),
         }));
-        expect(() => require('./integration-defined-routers')).toThrow(
-            /route conflict.*POST \/shared.*ext-a.*ext-b/
-        );
+        // Definition route claims POST /hook; extension claims POST /ext/hook — distinct.
+        expect(() =>
+            require('./integration-defined-routers')
+        ).not.toThrow();
     });
 });

--- a/packages/core/handlers/routers/integration-defined-routers.test.js
+++ b/packages/core/handlers/routers/integration-defined-routers.test.js
@@ -274,4 +274,59 @@ describe('integration-defined-routers — per-binding namespacing', () => {
             require('./integration-defined-routers')
         ).not.toThrow();
     });
+
+    it('throws at boot when two binding keys sanitize to the same handler key', () => {
+        const a = makeExt('ext-a', 'A_EVENT');
+        const b = makeExt('ext-b', 'B_EVENT');
+        class Collide extends IntegrationBase {
+            static Definition = {
+                name: 'collide',
+                version: '1.0.0',
+                modules: {},
+                extensions: {
+                    'hub-spot': { extension: a }, // sanitizes to "hubspot"
+                    hubspot: { extension: b }, // also "hubspot" → collision
+                },
+            };
+        }
+        jest.doMock('../app-definition-loader', () => ({
+            loadAppDefinition: () => ({ integrations: [Collide] }),
+        }));
+        expect(() => require('./integration-defined-routers')).toThrow(
+            /extension handler conflict.*sanitizes to "collide__hubspot"/
+        );
+    });
+
+    it('passes the resolved binding useDatabase through to createAppHandler', () => {
+        const calls = [];
+        jest.doMock('./../app-handler-helpers', () => ({
+            createAppHandler: (eventName, router, shouldUseDatabase) => {
+                calls.push({ eventName, shouldUseDatabase });
+                return { __mock: eventName };
+            },
+        }));
+        const ext = {
+            name: 'e',
+            useDatabase: false,
+            routes: [{ path: '/w', method: 'POST', event: 'E' }],
+            events: { E: { handler: async () => null } },
+        };
+        class C extends IntegrationBase {
+            static Definition = {
+                name: 'c',
+                version: '1.0.0',
+                modules: {},
+                extensions: { wh: { extension: ext } },
+            };
+        }
+        jest.doMock('../app-definition-loader', () => ({
+            loadAppDefinition: () => ({ integrations: [C] }),
+        }));
+        require('./integration-defined-routers');
+        const bindingCall = calls.find((c) =>
+            /extension wh$/.test(c.eventName)
+        );
+        expect(bindingCall).toBeDefined();
+        expect(bindingCall.shouldUseDatabase).toBe(false);
+    });
 });

--- a/packages/core/integrations/EXTENSIONS.md
+++ b/packages/core/integrations/EXTENSIONS.md
@@ -24,6 +24,8 @@ class HubSpotIntegration extends IntegrationBase {
             hubspotWebhooks: {
                 extension: hubspot.extensions.webhooks,
                 handlers: { HUBSPOT_WEBHOOK: 'onHubSpotEvent' },
+                // optional: override the extension's declared useDatabase
+                // useDatabase: true,
             },
         },
     };
@@ -39,19 +41,39 @@ class HubSpotIntegration extends IntegrationBase {
 }
 ```
 
-The binding key (`hubspotWebhooks`) is your local name. The extension reference (`hubspot.extensions.webhooks`) is whatever the API module exports.
+The binding key (`hubspotWebhooks`) is your local name. It is also the **URL namespace** for the extension's routes (see below), so pick something readable — `hubspot` yields a cleaner URL than `hubspotWebhooks`. The extension reference (`hubspot.extensions.webhooks`) is whatever the API module exports.
 
 ## Step 2: Deploy
 
-The framework auto-mounts each extension's routes at the integration's base path. Boot logs show:
+Each extension binding is mounted under its **binding key**, on its own dedicated handler/Lambda function. This means two modules' extensions (e.g. a HubSpot and a Clockwork webhooks extension on the same integration) never collide — each lives at a distinct namespaced path. Boot logs show:
 
 ```
 │ Configuring routes for hubspot Integration:
-│ POST /api/hubspot-integration/webhooks  (extension: hubspot-webhooks)
+│ POST /api/hubspot-integration/hubspotWebhooks/webhooks  (extension: hubspot-webhooks, useDatabase: false)
 │
 ```
 
-Hit that URL and the bound method (`onHubSpotEvent`) fires on the resolved per-account integration instance.
+So the full URL is `/api/{integration-name}-integration/{bindingKey}{route.path}`. Register that URL with the upstream provider (e.g. paste it into your HubSpot app's webhook settings). Hit it and the bound method (`onHubSpotEvent`) fires on the resolved per-account integration instance.
+
+## `useDatabase` — does the receiver open a DB connection?
+
+Each extension declares whether its route handler should open a database connection:
+
+```javascript
+// in the extension bundle (api-module side)
+module.exports = {
+    name: 'hubspot-webhooks',
+    useDatabase: false,   // default — the receiver is DB-free
+    routes: [ /* ... */ ],
+    events: { /* ... */ },
+};
+```
+
+- **Default is `false`** — a webhook receiver that only verifies a signature and enqueues should not pay for a DB connection (faster cold start; at build time its Lambda doesn't get the Prisma layer).
+- Set `useDatabase: true` at the **extension level** if the receiver itself needs the DB. A binding may override it locally (`extensions: { x: { extension, useDatabase: true } }`), though that's rarely needed.
+- Resolution order: `binding.useDatabase ?? extension.useDatabase ?? false`.
+
+If `useDatabase` is `false`, the receiver must not touch the database. Work that needs the DB (e.g. resolving `portalId → integrationId`) belongs in the queue worker that processes the dispatched event, not in the receiver.
 
 ## How handler binding works
 
@@ -84,7 +106,7 @@ This means **binding the same extension twice only works if the extension itself
 
 Subclass overrides via `this.events[eventName]` (set in the constructor) take precedence over extension-declared events. If a binding tried to wire a handler that's now shadowed, the framework logs a warning naming the integration, binding, and ignored method.
 
-Route path conflicts (two extensions declaring the same `method + path`, or an extension colliding with a `Definition.routes` entry) also throw at boot.
+**Routes do not collide across bindings** — each binding's routes are namespaced under its binding key (`/{bindingKey}{route.path}`), so two extensions can both declare `POST /webhooks` and live at distinct URLs. A route conflict only throws at boot if a *single* binding declares two routes with the same `method + path` (or a `Definition.routes` entry exactly matches an extension's namespaced path). Note this is independent of event-name conflicts above: namespacing disambiguates URLs, but two bindings still must use distinct **event** names since events are merged into one `this.events` map.
 
 ## Authoring an extension (for API module authors)
 

--- a/packages/core/integrations/EXTENSIONS.md
+++ b/packages/core/integrations/EXTENSIONS.md
@@ -55,6 +55,8 @@ Each extension binding is mounted under its **binding key**, on its own dedicate
 
 So the full URL is `/api/{integration-name}-integration/{bindingKey}{route.path}`. Register that URL with the upstream provider (e.g. paste it into your HubSpot app's webhook settings). Hit it and the bound method (`onHubSpotEvent`) fires on the resolved per-account integration instance.
 
+> **⚠️ Breaking:** extension routes used to mount un-namespaced (`/api/{x}-integration/webhooks`). They are now namespaced under the binding key. Any provider webhook already registered against the old path must be re-pointed at the new `/{bindingKey}` URL — and for signature schemes that sign the full URL (e.g. HubSpot v3), the old registration will also fail verification until updated.
+
 ## `useDatabase` — does the receiver open a DB connection?
 
 Each extension declares whether its route handler should open a database connection:
@@ -72,6 +74,7 @@ module.exports = {
 - **Default is `false`** — a webhook receiver that only verifies a signature and enqueues should not pay for a DB connection (faster cold start; at build time its Lambda doesn't get the Prisma layer).
 - Set `useDatabase: true` at the **extension level** if the receiver itself needs the DB. A binding may override it locally (`extensions: { x: { extension, useDatabase: true } }`), though that's rarely needed.
 - Resolution order: `binding.useDatabase ?? extension.useDatabase ?? false`.
+- Scope note: `false` is the default **for extension routes**. `createHandler` itself still defaults `shouldUseDatabase: true` for the integration's own catch-all handler and the legacy `Definition.webhooks: true` path — those connect as before. The `false` default applies only to the per-binding extension handler.
 
 If `useDatabase` is `false`, the receiver must not touch the database. Work that needs the DB (e.g. resolving `portalId → integrationId`) belongs in the queue worker that processes the dispatched event, not in the receiver.
 

--- a/packages/core/integrations/extension.js
+++ b/packages/core/integrations/extension.js
@@ -70,6 +70,24 @@ function validateExtensionBinding(extension, bindingName, integrationName, bindi
         throw new Error(`${ctx}: extension is missing required "name" field`);
     }
 
+    if (
+        extension.useDatabase !== undefined &&
+        typeof extension.useDatabase !== 'boolean'
+    ) {
+        throw new Error(
+            `${ctx}: extension "${extension.name}" "useDatabase" must be a boolean`
+        );
+    }
+    if (
+        binding &&
+        binding.useDatabase !== undefined &&
+        typeof binding.useDatabase !== 'boolean'
+    ) {
+        throw new Error(
+            `${ctx}: binding "useDatabase" must be a boolean`
+        );
+    }
+
     const events = extension.events || {};
     if (typeof events !== 'object' || Array.isArray(events)) {
         throw new Error(
@@ -181,6 +199,10 @@ function getExtensionRoutes(IntegrationClass) {
             integrationName,
             binding
         );
+        // useDatabase is resolved at the binding level, falling back to the
+        // extension's declared value, then to false (DB-free by default).
+        const useDatabase =
+            binding.useDatabase ?? binding.extension.useDatabase ?? false;
         const routes = binding.extension.routes || [];
         for (const route of routes) {
             flat.push({
@@ -189,6 +211,7 @@ function getExtensionRoutes(IntegrationClass) {
                 path: route.path,
                 method: route.method,
                 event: route.event,
+                useDatabase,
             });
         }
     }

--- a/packages/core/integrations/extension.js
+++ b/packages/core/integrations/extension.js
@@ -199,8 +199,6 @@ function getExtensionRoutes(IntegrationClass) {
             integrationName,
             binding
         );
-        // useDatabase is resolved at the binding level, falling back to the
-        // extension's declared value, then to false (DB-free by default).
         const useDatabase =
             binding.useDatabase ?? binding.extension.useDatabase ?? false;
         const routes = binding.extension.routes || [];

--- a/packages/core/integrations/tests/extension.test.js
+++ b/packages/core/integrations/tests/extension.test.js
@@ -145,6 +145,81 @@ describe('getExtensionRoutes', () => {
     });
 });
 
+describe('useDatabase resolution', () => {
+    it('accepts a boolean extension.useDatabase', () => {
+        expect(() =>
+            validateExtensionBinding(
+                buildExtension({ useDatabase: true }),
+                'b',
+                'int'
+            )
+        ).not.toThrow();
+        expect(() =>
+            validateExtensionBinding(
+                buildExtension({ useDatabase: false }),
+                'b',
+                'int'
+            )
+        ).not.toThrow();
+    });
+
+    it('rejects a non-boolean extension.useDatabase', () => {
+        expect(() =>
+            validateExtensionBinding(
+                buildExtension({ useDatabase: 'yes' }),
+                'b',
+                'int'
+            )
+        ).toThrow(/useDatabase.*boolean/i);
+    });
+
+    it('rejects a non-boolean binding.useDatabase', () => {
+        const ext = buildExtension();
+        expect(() =>
+            validateExtensionBinding(ext, 'b', 'int', {
+                extension: ext,
+                useDatabase: 'nope',
+            })
+        ).toThrow(/useDatabase.*boolean/i);
+    });
+
+    it('getExtensionRoutes defaults useDatabase to false when unset', () => {
+        const ext = buildExtension();
+        class C extends IntegrationBase {
+            static Definition = {
+                name: 'c',
+                modules: {},
+                extensions: { b: { extension: ext } },
+            };
+        }
+        expect(getExtensionRoutes(C)[0].useDatabase).toBe(false);
+    });
+
+    it('getExtensionRoutes surfaces extension-level useDatabase', () => {
+        const ext = buildExtension({ useDatabase: true });
+        class C extends IntegrationBase {
+            static Definition = {
+                name: 'c',
+                modules: {},
+                extensions: { b: { extension: ext } },
+            };
+        }
+        expect(getExtensionRoutes(C)[0].useDatabase).toBe(true);
+    });
+
+    it('getExtensionRoutes lets binding.useDatabase override the extension default (false wins over true)', () => {
+        const ext = buildExtension({ useDatabase: true });
+        class C extends IntegrationBase {
+            static Definition = {
+                name: 'c',
+                modules: {},
+                extensions: { b: { extension: ext, useDatabase: false } },
+            };
+        }
+        expect(getExtensionRoutes(C)[0].useDatabase).toBe(false);
+    });
+});
+
 describe('validateExtensionBinding — handler/binding shape validation', () => {
     it('rejects an event whose handler is set but not a function', () => {
         expect(() =>

--- a/packages/devtools/infrastructure/domains/integration/integration-builder.js
+++ b/packages/devtools/infrastructure/domains/integration/integration-builder.js
@@ -386,9 +386,24 @@ class IntegrationBuilder extends InfrastructureBuilder {
                 binding.useDatabase ??
                 (extension && extension.useDatabase) ??
                 false;
+            // fnName is the wire contract with core's integration-defined-routers
+            // (it exports handlers[`${name}__${sanitizeBindingKey(binding)}`]).
+            // Keep this derivation IN SYNC with that file.
             const fnName = `${integrationName}__${sanitizeBindingKey(
                 bindingKey
             )}`;
+            // Guard the same silent-overwrite the runtime router guards: two
+            // binding keys that sanitize to the same value would clobber one
+            // function definition while leaving both httpApi paths live.
+            if (
+                Object.prototype.hasOwnProperty.call(result.functions, fnName)
+            ) {
+                throw new Error(
+                    `Integration "${integrationName}" extension function conflict: ` +
+                        `binding "${bindingKey}" sanitizes to "${fnName}", which is already taken. ` +
+                        `Use binding keys that are distinct after stripping non-alphanumeric characters.`
+                );
+            }
             result.functions[fnName] = {
                 handler: `node_modules/@friggframework/core/handlers/routers/integration-defined-routers.handlers.${fnName}.handler`,
                 skipEsbuild: true,

--- a/packages/devtools/infrastructure/domains/integration/integration-builder.js
+++ b/packages/devtools/infrastructure/domains/integration/integration-builder.js
@@ -348,8 +348,7 @@ class IntegrationBuilder extends InfrastructureBuilder {
         }
 
         // Create HTTP API handler for integration (catch-all route AFTER
-        // webhooks). Tier 3 extension routes are NOT folded in here — each
-        // binding gets its own function below so it can have its own DB infra.
+        // webhooks). Extension routes get their own functions below.
         result.functions[integrationName] = {
             handler: `node_modules/@friggframework/core/handlers/routers/integration-defined-routers.handlers.${integrationName}.handler`,
             skipEsbuild: true, // Nested exports in node_modules - skip esbuild bundling
@@ -366,13 +365,8 @@ class IntegrationBuilder extends InfrastructureBuilder {
         };
         console.log(`      ✓ HTTP handler function defined`);
 
-        // Tier 3 Integration Extensions — one dedicated function per binding,
-        // namespaced under /{bindingKey} so multiple modules' extensions (e.g.
-        // hubspot + clockwork webhooks) never collide on the same path. The
-        // Prisma layer is attached only when the extension/binding declares
-        // useDatabase: true (default false → DB-free receiver, faster cold
-        // start). Route shape mirrors core's getExtensionRoutes; read directly
-        // to avoid coupling the build-time generator to a core runtime import.
+        // One serverless function per extension binding, namespaced under
+        // /{bindingKey}. Prisma layer attached only when useDatabase is true.
         const sanitizeBindingKey = (name) =>
             String(name).replace(/[^A-Za-z0-9]/g, '');
         const extensionEntries = Object.entries(
@@ -386,15 +380,12 @@ class IntegrationBuilder extends InfrastructureBuilder {
                 binding.useDatabase ??
                 (extension && extension.useDatabase) ??
                 false;
-            // fnName is the wire contract with core's integration-defined-routers
-            // (it exports handlers[`${name}__${sanitizeBindingKey(binding)}`]).
-            // Keep this derivation IN SYNC with that file.
+            // Wire contract: core's integration-defined-routers derives the
+            // identical handler key. Keep both in sync.
             const fnName = `${integrationName}__${sanitizeBindingKey(
                 bindingKey
             )}`;
-            // Guard the same silent-overwrite the runtime router guards: two
-            // binding keys that sanitize to the same value would clobber one
-            // function definition while leaving both httpApi paths live.
+            // Distinct binding keys can sanitize to the same fnName — fail loud rather than overwrite.
             if (
                 Object.prototype.hasOwnProperty.call(result.functions, fnName)
             ) {

--- a/packages/devtools/infrastructure/domains/integration/integration-builder.js
+++ b/packages/devtools/infrastructure/domains/integration/integration-builder.js
@@ -347,46 +347,15 @@ class IntegrationBuilder extends InfrastructureBuilder {
             console.log(`      ✓ Webhook handler function defined`);
         }
 
-        // Tier 3 Integration Extension routes (e.g. hubspot.extensions.webhooks).
-        // The integration-defined-routers handler already mounts these at
-        // runtime; emitting explicit httpApi events here registers them as
-        // dedicated routes (visible at startup, and matched ahead of the
-        // catch-all) instead of silently relying on {proxy+}. They point at
-        // the same handler as the catch-all. Route shape mirrors core's
-        // getExtensionRoutes; we read it directly to avoid coupling the
-        // build-time generator to a core runtime import.
-        const extensionBindings = Object.values(
-            integration.Definition.extensions || {}
-        );
-        const extensionRouteEvents = [];
-        for (const binding of extensionBindings) {
-            const routes =
-                (binding && binding.extension && binding.extension.routes) ||
-                [];
-            for (const route of routes) {
-                extensionRouteEvents.push({
-                    httpApi: {
-                        path: `/api/${integrationName}-integration${route.path}`,
-                        method: route.method,
-                    },
-                });
-            }
-        }
-        if (extensionRouteEvents.length > 0) {
-            console.log(
-                `      ✓ ${extensionRouteEvents.length} extension route(s) defined`
-            );
-        }
-
         // Create HTTP API handler for integration (catch-all route AFTER
-        // webhooks and extension routes)
+        // webhooks). Tier 3 extension routes are NOT folded in here — each
+        // binding gets its own function below so it can have its own DB infra.
         result.functions[integrationName] = {
             handler: `node_modules/@friggframework/core/handlers/routers/integration-defined-routers.handlers.${integrationName}.handler`,
             skipEsbuild: true, // Nested exports in node_modules - skip esbuild bundling
             package: functionPackageConfig,
             ...(usePrismaLayer && { layers: [{ Ref: 'PrismaLambdaLayer' }] }), // HTTP handlers need Prisma for integration queries
             events: [
-                ...extensionRouteEvents,
                 {
                     httpApi: {
                         path: `/api/${integrationName}-integration/{proxy+}`,
@@ -396,6 +365,47 @@ class IntegrationBuilder extends InfrastructureBuilder {
             ],
         };
         console.log(`      ✓ HTTP handler function defined`);
+
+        // Tier 3 Integration Extensions — one dedicated function per binding,
+        // namespaced under /{bindingKey} so multiple modules' extensions (e.g.
+        // hubspot + clockwork webhooks) never collide on the same path. The
+        // Prisma layer is attached only when the extension/binding declares
+        // useDatabase: true (default false → DB-free receiver, faster cold
+        // start). Route shape mirrors core's getExtensionRoutes; read directly
+        // to avoid coupling the build-time generator to a core runtime import.
+        const sanitizeBindingKey = (name) =>
+            String(name).replace(/[^A-Za-z0-9]/g, '');
+        const extensionEntries = Object.entries(
+            integration.Definition.extensions || {}
+        );
+        for (const [bindingKey, binding] of extensionEntries) {
+            const extension = binding && binding.extension;
+            const routes = (extension && extension.routes) || [];
+            if (routes.length === 0) continue;
+            const useDatabase =
+                binding.useDatabase ??
+                (extension && extension.useDatabase) ??
+                false;
+            const fnName = `${integrationName}__${sanitizeBindingKey(
+                bindingKey
+            )}`;
+            result.functions[fnName] = {
+                handler: `node_modules/@friggframework/core/handlers/routers/integration-defined-routers.handlers.${fnName}.handler`,
+                skipEsbuild: true,
+                package: functionPackageConfig,
+                ...(usePrismaLayer &&
+                    useDatabase && { layers: [{ Ref: 'PrismaLambdaLayer' }] }),
+                events: routes.map((route) => ({
+                    httpApi: {
+                        path: `/api/${integrationName}-integration/${bindingKey}${route.path}`,
+                        method: route.method,
+                    },
+                })),
+            };
+            console.log(
+                `      ✓ Extension handler function defined: ${fnName} (useDatabase: ${useDatabase})`
+            );
+        }
 
         // Create Queue Worker function
         const queueWorkerName = `${integrationName}QueueWorker`;

--- a/packages/devtools/infrastructure/domains/integration/integration-builder.test.js
+++ b/packages/devtools/infrastructure/domains/integration/integration-builder.test.js
@@ -568,7 +568,7 @@ describe('IntegrationBuilder', () => {
             ]);
         });
 
-        it('should emit dedicated httpApi events for Tier 3 extension routes, before the catch-all', async () => {
+        it('emits a dedicated per-binding function (namespaced) for Tier 3 extension routes; the main handler keeps only {proxy+}', async () => {
             const appDefinition = {
                 integrations: [
                     {
@@ -602,15 +602,24 @@ describe('IntegrationBuilder', () => {
 
             const result = await integrationBuilder.build(appDefinition, {});
 
-            // The extension route is registered on the same handler as the
-            // catch-all, and ordered before {proxy+}.
-            expect(result.functions.hubspot.events).toEqual([
+            // Dedicated per-binding function, namespaced under the binding key,
+            // pointing at its own handler export.
+            const fn = result.functions.hubspot__hubspotWebhooks;
+            expect(fn).toBeDefined();
+            expect(fn.handler).toBe(
+                'node_modules/@friggframework/core/handlers/routers/integration-defined-routers.handlers.hubspot__hubspotWebhooks.handler'
+            );
+            expect(fn.events).toEqual([
                 {
                     httpApi: {
-                        path: '/api/hubspot-integration/webhooks',
+                        path: '/api/hubspot-integration/hubspotWebhooks/webhooks',
                         method: 'POST',
                     },
                 },
+            ]);
+
+            // The main integration handler keeps only the catch-all.
+            expect(result.functions.hubspot.events).toEqual([
                 {
                     httpApi: {
                         path: '/api/hubspot-integration/{proxy+}',
@@ -618,6 +627,45 @@ describe('IntegrationBuilder', () => {
                     },
                 },
             ]);
+
+            // useDatabase defaults to false → no Prisma layer on the receiver.
+            expect(fn.layers).toBeUndefined();
+        });
+
+        it('attaches the Prisma layer to a per-binding function only when useDatabase is true', async () => {
+            const mkDef = (useDatabase) => ({
+                integrations: [
+                    {
+                        Definition: {
+                            name: 'hs',
+                            extensions: {
+                                wh: {
+                                    extension: {
+                                        name: 'wh-ext',
+                                        useDatabase,
+                                        routes: [
+                                            {
+                                                path: '/webhooks',
+                                                method: 'POST',
+                                                event: 'E',
+                                            },
+                                        ],
+                                        events: { E: { handler: () => {} } },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                ],
+            });
+
+            const withDb = await integrationBuilder.build(mkDef(true), {});
+            expect(withDb.functions.hs__wh.layers).toEqual([
+                { Ref: 'PrismaLambdaLayer' },
+            ]);
+
+            const withoutDb = await integrationBuilder.build(mkDef(false), {});
+            expect(withoutDb.functions.hs__wh.layers).toBeUndefined();
         });
 
         it('should only have the catch-all proxy route when no extensions are declared', async () => {

--- a/packages/devtools/infrastructure/domains/integration/integration-builder.test.js
+++ b/packages/devtools/infrastructure/domains/integration/integration-builder.test.js
@@ -668,6 +668,30 @@ describe('IntegrationBuilder', () => {
             expect(withoutDb.functions.hs__wh.layers).toBeUndefined();
         });
 
+        it('throws when two binding keys sanitize to the same function name', async () => {
+            const mkExt = (name, event) => ({
+                name,
+                routes: [{ path: '/w', method: 'POST', event }],
+                events: { [event]: { handler: () => {} } },
+            });
+            const appDefinition = {
+                integrations: [
+                    {
+                        Definition: {
+                            name: 'hs',
+                            extensions: {
+                                'hub-spot': { extension: mkExt('a', 'A') }, // → hs__hubspot
+                                hubspot: { extension: mkExt('b', 'B') }, // → hs__hubspot
+                            },
+                        },
+                    },
+                ],
+            };
+            await expect(
+                integrationBuilder.build(appDefinition, {})
+            ).rejects.toThrow(/extension function conflict.*hs__hubspot/);
+        });
+
         it('should only have the catch-all proxy route when no extensions are declared', async () => {
             const appDefinition = {
                 integrations: [{ Definition: { name: 'plain' } }],


### PR DESCRIPTION
## Summary

Two follow-up adjustments to Tier 3 Integration Extensions (#590), resolving the multi-module routing ambiguity and DB-connection control Sean and Daniel agreed on after testing HubSpot webhooks end-to-end.

### 1. Namespace extension routes under the binding key
Extension routes previously mounted at `/api/{integration}-integration{route.path}`. Because the base path comes from the **integration** name (not the module), two modules' webhook extensions on one integration (e.g. HubSpot + Clockwork) both resolved to `POST /webhooks` and threw a boot-time route conflict — Frigg couldn't tell which module a request was for.

Now each binding mounts under its **binding key**: `/api/{integration}-integration/{bindingKey}{route.path}`, on its own dedicated handler/Lambda function (`handlers[\`${name}__${bindingKey}\`]`). Cross-extension collisions are now structurally impossible. Within-binding duplicate `method+path` still throws.

### 2. `useDatabase` flag (extension-level, binding-overridable, default `false`)
Extensions declare whether their route handler opens a DB connection.
- `extension.js` — boolean validation; `getExtensionRoutes` surfaces resolved `binding.useDatabase ?? extension.useDatabase ?? false`.
- `create-handler.js` — `shouldUseDatabase` now has **real teeth**: eagerly `connectPrisma()` when true (lazy-required, so DB-free handlers never load the client). Default `true` preserves existing handler behavior; the per-binding extension handler passes its resolved `useDatabase`.
- `integration-builder.js` — each binding becomes its own serverless function with namespaced `httpApi` events; the Prisma layer is attached **only** when `useDatabase` is true. The main integration function keeps just the `{proxy+}` catch-all.

`EXTENSIONS.md` documents the namespaced URL shape and `useDatabase`.

## Behavior / breaking notes
- The webhook receiver URL changes from `/api/{x}-integration/webhooks` to `/api/{x}-integration/{bindingKey}/webhooks`. Consumers must reconfigure the upstream provider's webhook URL. This is the intended fix (it's what lets HubSpot + Clockwork coexist).
- `createHandler`'s `shouldUseDatabase` now actually connects when true (it was plumbed-but-ignored since the mongoose→Prisma refactor). Default true keeps existing handlers connecting; the legacy webhook (false) and DB-free extensions skip.

## Test plan
- [x] TDD red→green for each unit: extension `useDatabase` resolution/validation; `createHandler` `connectPrisma` teeth; router namespacing + per-binding handlers + conflict semantics; builder per-binding function + conditional Prisma layer.
- [x] Full `packages/core` suite: +12 passing, **0 new failures** vs `next` (64 pre-existing failures unchanged).
- [x] `packages/devtools` integration-builder suite: 51/51.
- [ ] Downstream: api-module-hubspot webhooks extension restructure (receiver DB-free, lookup→worker) — separate PR, version-couples to this core canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.596.fc8739c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.596.fc8739c.0
  npm install @friggframework/devtools@2.0.0--canary.596.fc8739c.0
  npm install @friggframework/eslint-config@2.0.0--canary.596.fc8739c.0
  npm install @friggframework/prettier-config@2.0.0--canary.596.fc8739c.0
  npm install @friggframework/schemas@2.0.0--canary.596.fc8739c.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.596.fc8739c.0
  npm install @friggframework/test@2.0.0--canary.596.fc8739c.0
  npm install @friggframework/ui@2.0.0--canary.596.fc8739c.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.596.fc8739c.0
  yarn add @friggframework/devtools@2.0.0--canary.596.fc8739c.0
  yarn add @friggframework/eslint-config@2.0.0--canary.596.fc8739c.0
  yarn add @friggframework/prettier-config@2.0.0--canary.596.fc8739c.0
  yarn add @friggframework/schemas@2.0.0--canary.596.fc8739c.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.596.fc8739c.0
  yarn add @friggframework/test@2.0.0--canary.596.fc8739c.0
  yarn add @friggframework/ui@2.0.0--canary.596.fc8739c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.89`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - feat(core): Tier 3 Integration Extensions — Definition.extensions [#590](https://github.com/friggframework/frigg/pull/590) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/core`, `@friggframework/devtools`
    - feat(core,devtools): namespace extension routes + useDatabase flag [#596](https://github.com/friggframework/frigg/pull/596) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
