### PR TITLE
fix(deps): resync package-lock.json (encoding, iconv-lite missing entries)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23414,6 +23414,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",


### PR DESCRIPTION
## Summary
- `npm ci` was failing on the **build (22.x)** job of *Frigg CI* for **every PR targeting `next`** (pre-existing on `next` itself, repro'd on `5305d8cd`). The root `package-lock.json` was missing two transitive entries: `encoding@0.1.13` — an **optional** dependency of `minipass-fetch` — and its transitive `iconv-lite@0.6.3`.
- This adds **only those two missing package entries** (23 insertions, 0 deletions). No other dependency resolutions were touched.

## Root cause
The lockfile already declares `encoding` under `minipass-fetch`'s `optionalDependencies`, but had no package entry for it (nor for `iconv-lite@0.6.3`). CI's `npm run use:npm` installs **npm@latest (11.x)**, which strictly enforces lockfile completeness and rejects this as out-of-sync:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: encoding@0.1.13 from lock file
npm error Missing: iconv-lite@0.6.3 from lock file
```

npm 10.x and macOS skip the optional `encoding` dependency entirely, so the break was invisible locally — it only manifests on Linux + npm 11.

## Test plan
- [x] Reproduced in Docker `node:22` + `npm@latest` (11.16.0) with the **pre-fix** lockfile → `npm ci` fails with the exact `Missing: encoding / iconv-lite` error above.
- [x] With the fix, `npm ci` **passes** in the same Linux + npm 11.16.0 environment (`added 2790 packages`, exit 0).
- [x] Diff verified minimal: only `node_modules/encoding` and `node_modules/encoding/node_modules/iconv-lite` added; valid JSON.

## Notes
- A full `npm install` regen under npm 11 additionally wanted to **prune** unrelated orphaned transitive entries (`@aws-sdk/client-scheduler`, `@aws-sdk/credential-provider-login`, `fast-xml-builder` — not declared in any manifest). That churn was intentionally left out of scope to keep this fix surgical; it can be addressed separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.597.ea460ba.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.597.ea460ba.0
  npm install @friggframework/devtools@2.0.0--canary.597.ea460ba.0
  npm install @friggframework/eslint-config@2.0.0--canary.597.ea460ba.0
  npm install @friggframework/prettier-config@2.0.0--canary.597.ea460ba.0
  npm install @friggframework/schemas@2.0.0--canary.597.ea460ba.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.597.ea460ba.0
  npm install @friggframework/test@2.0.0--canary.597.ea460ba.0
  npm install @friggframework/ui@2.0.0--canary.597.ea460ba.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.597.ea460ba.0
  yarn add @friggframework/devtools@2.0.0--canary.597.ea460ba.0
  yarn add @friggframework/eslint-config@2.0.0--canary.597.ea460ba.0
  yarn add @friggframework/prettier-config@2.0.0--canary.597.ea460ba.0
  yarn add @friggframework/schemas@2.0.0--canary.597.ea460ba.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.597.ea460ba.0
  yarn add @friggframework/test@2.0.0--canary.597.ea460ba.0
  yarn add @friggframework/ui@2.0.0--canary.597.ea460ba.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
