### PR TITLE
fix(core): discard webhook message when integration deleted mid-flight

### DIFF
--- a/packages/core/handlers/backend-utils.js
+++ b/packages/core/handlers/backend-utils.js
@@ -110,6 +110,22 @@ const loadIntegrationForWebhook = async (integrationId) => {
     return instance;
 };
 
+// Returns false only when the integration is confirmed gone; a transient
+// lookup failure returns true so genuine errors keep their normal retry path.
+const integrationExists = async (integrationId) => {
+    const integrationRepository = createIntegrationRepository();
+    try {
+        const record =
+            await integrationRepository.findIntegrationById(integrationId);
+        return Boolean(record);
+    } catch (error) {
+        if (error.message?.includes('not found')) {
+            return false;
+        }
+        return true;
+    }
+};
+
 const loadIntegrationForProcess = async (processId, integrationClass) => {
 
     const { processRepository, integrationRepository, moduleRepository } =
@@ -233,6 +249,18 @@ const createQueueWorker = (integrationClass) => {
                 console.log(`[QueueWorker] ${params.event} dispatched ok`, logCtx);
                 return result;
             } catch (error) {
+                // Integration deleted mid-flight: no retry can succeed once
+                // it's gone, so discard instead of sending it to the DLQ.
+                if (
+                    params.data?.integrationId &&
+                    !(await integrationExists(params.data.integrationId))
+                ) {
+                    console.warn(
+                        `[${integrationName}] Integration ${params.data.integrationId} was deleted mid-flight — discarding ${params.event} message (no retry)`
+                    );
+                    return;
+                }
+
                 console.error(
                     `Error in ${params.event} for ${integrationName}:`,
                     error
@@ -265,4 +293,5 @@ const createQueueWorker = (integrationClass) => {
 module.exports = {
     loadRouterFromObject,
     createQueueWorker,
+    integrationExists,
 };

--- a/packages/core/handlers/backend-utils.test.js
+++ b/packages/core/handlers/backend-utils.test.js
@@ -1,0 +1,151 @@
+/**
+ * @group unit
+ */
+
+jest.mock('@friggframework/core', () => ({
+    Worker: class {},
+}));
+jest.mock('./integration-event-dispatcher', () => ({
+    IntegrationEventDispatcher: jest.fn(),
+}));
+jest.mock('../integrations/use-cases/get-integration-instance', () => ({
+    GetIntegrationInstance: jest.fn(),
+}));
+jest.mock('../modules/module-factory', () => ({ ModuleFactory: jest.fn() }));
+jest.mock('../integrations/repositories/process-repository-factory', () => ({
+    createProcessRepository: jest.fn(),
+}));
+jest.mock(
+    '../integrations/repositories/integration-repository-factory',
+    () => ({
+        createIntegrationRepository: jest.fn(),
+    })
+);
+jest.mock('../modules/repositories/module-repository-factory', () => ({
+    createModuleRepository: jest.fn(),
+}));
+jest.mock('../integrations/utils/map-integration-dto', () => ({
+    getModulesDefinitionFromIntegrationClasses: jest.fn(() => []),
+}));
+jest.mock('./app-definition-loader', () => ({
+    loadAppDefinition: jest.fn(() => ({ integrations: [] })),
+}));
+
+const { integrationExists, createQueueWorker } = require('./backend-utils');
+const {
+    createIntegrationRepository,
+} = require('../integrations/repositories/integration-repository-factory');
+const {
+    GetIntegrationInstance,
+} = require('../integrations/use-cases/get-integration-instance');
+const {
+    IntegrationEventDispatcher,
+} = require('./integration-event-dispatcher');
+
+describe('integrationExists', () => {
+    const setRepo = (findIntegrationById) =>
+        createIntegrationRepository.mockReturnValue({ findIntegrationById });
+
+    afterEach(() => jest.clearAllMocks());
+
+    it('is true when the integration record is found', async () => {
+        setRepo(jest.fn().mockResolvedValue({ id: '19306' }));
+        await expect(integrationExists('19306')).resolves.toBe(true);
+    });
+
+    it('is false when the lookup returns null', async () => {
+        setRepo(jest.fn().mockResolvedValue(null));
+        await expect(integrationExists('19306')).resolves.toBe(false);
+    });
+
+    it('is false when the lookup throws "not found"', async () => {
+        setRepo(
+            jest
+                .fn()
+                .mockRejectedValue(new Error('Integration 19306 not found'))
+        );
+        await expect(integrationExists('19306')).resolves.toBe(false);
+    });
+
+    it('is true on an unrelated lookup failure (do not discard on a transient DB error)', async () => {
+        setRepo(jest.fn().mockRejectedValue(new Error('connection reset')));
+        await expect(integrationExists('19306')).resolves.toBe(true);
+    });
+});
+
+describe('createQueueWorker — integration deleted mid-flight', () => {
+    class FakeIntegration {
+        static Definition = { name: 'fake' };
+    }
+
+    afterEach(() => jest.clearAllMocks());
+
+    it('discards the webhook message (no throw) when the integration is gone after a processing error', async () => {
+        const findIntegrationById = jest
+            .fn()
+            .mockResolvedValueOnce({ id: '19306', userId: 'u1' }) // hydration
+            .mockResolvedValueOnce(null); // re-check → gone
+        createIntegrationRepository.mockReturnValue({ findIntegrationById });
+
+        GetIntegrationInstance.mockImplementation(() => ({
+            execute: jest
+                .fn()
+                .mockResolvedValue({ id: '19306', status: 'ENABLED' }),
+        }));
+        IntegrationEventDispatcher.mockImplementation(() => ({
+            dispatchJob: jest
+                .fn()
+                .mockRejectedValue(new Error('mapping write failed')),
+        }));
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+        jest.spyOn(console, 'error').mockImplementation();
+        jest.spyOn(console, 'log').mockImplementation();
+
+        const QueueWorker = createQueueWorker(FakeIntegration);
+        const worker = new QueueWorker();
+
+        await expect(
+            worker._run(
+                { event: 'ON_WEBHOOK', data: { integrationId: '19306' } },
+                {}
+            )
+        ).resolves.toBeUndefined();
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('deleted mid-flight')
+        );
+    });
+
+    it('re-throws the original error when the integration still exists (transient failure retries)', async () => {
+        const findIntegrationById = jest
+            .fn()
+            .mockResolvedValueOnce({ id: '19306', userId: 'u1' }) // hydration
+            .mockResolvedValueOnce({ id: '19306' }); // re-check → still there
+        createIntegrationRepository.mockReturnValue({ findIntegrationById });
+
+        GetIntegrationInstance.mockImplementation(() => ({
+            execute: jest
+                .fn()
+                .mockResolvedValue({ id: '19306', status: 'ENABLED' }),
+        }));
+        const boom = new Error('transient 500');
+        IntegrationEventDispatcher.mockImplementation(() => ({
+            dispatchJob: jest.fn().mockRejectedValue(boom),
+        }));
+
+        jest.spyOn(console, 'warn').mockImplementation();
+        jest.spyOn(console, 'error').mockImplementation();
+        jest.spyOn(console, 'log').mockImplementation();
+
+        const QueueWorker = createQueueWorker(FakeIntegration);
+        const worker = new QueueWorker();
+
+        await expect(
+            worker._run(
+                { event: 'ON_WEBHOOK', data: { integrationId: '19306' } },
+                {}
+            )
+        ).rejects.toBe(boom);
+    });
+});


### PR DESCRIPTION
## What

When an integration is **hard-deleted while one of its queue messages is still being processed** (e.g. a user uninstalls mid-flight), the `QueueWorker` now **discards the message instead of retrying it into the DLQ**.

## Why

The worker already hydrates the integration up front and discards if it's gone (`loadIntegrationForWebhook` → null, or the `DISABLED`/`ERROR` status checks). But an integration can be deleted **after** that hydration check, **while the handler is making external API calls** — a time-of-check/time-of-use race.

Once the parent `Integration` row is gone, every subsequent DB write fails. Observed in production: a Pipedrive uninstall during a ~6,050-event webhook burst produced Prisma `P2003` foreign-key violations on `IntegrationMapping_integrationId_fkey` from the mapping upsert. Because a `P2003` carries no `statusCode`, the existing halt-on-4xx logic can't stop it, so the message is retried to `maxReceiveCount` and lands in the DLQ — for what is really an expected lifecycle event. The same race also surfaces as a masked `"Integration not found"` (when the error-recording write itself fails) or a revoked-credential `401`.

A pre-check before the work can't close this race, and translating the specific Prisma error into a typed error is fragile (it can be masked by a downstream error-recording write before any handler sees it).

## How

On the **error path only**, re-check whether the integration still exists; if it's **confirmed gone**, discard the message (no retry) instead of letting it reach the DLQ.

- New `integrationExists(integrationId)` helper — returns `false` only when the lookup confirms the integration is gone (record `null` or a `"not found"` error). A **transient** lookup failure returns `true`, so genuine errors keep their normal retry path.
- Checking **live state** (rather than inspecting the error) is robust to *whatever* error surfaced first — the FK violation, a masked `"not found"`, or a revoked-credential `401` — and covers **every integration** with no per-integration handler code.
- Cost is a single indexed lookup, only on the (rare) error path; the happy path is untouched.

## Tests

`packages/core/handlers/backend-utils.test.js` (new):
- `integrationExists`: found → true, null → false, `"not found"` → false, transient error → true (don't discard on a DB blip).
- `createQueueWorker`: discards (no throw) when the integration is gone after a processing error; re-throws the original error when the integration still exists (so transient failures still retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
