### PR TITLE
feat(core): add Process command factory and enrich use-case error codes

### DIFF
--- a/packages/core/application/commands/process-commands.integration.test.js
+++ b/packages/core/application/commands/process-commands.integration.test.js
@@ -1,0 +1,92 @@
+/**
+ * Process commands — end-to-end error-code mapping.
+ *
+ * Unlike process-commands.test.js (which mocks the use cases), this suite
+ * exercises the REAL use cases against a stubbed repository to prove that
+ * the codes they attach (INVALID_PROCESS_DATA / PROCESS_NOT_FOUND) survive
+ * all the way to the HTTP-ish response shape produced by mapErrorToResponse.
+ */
+
+jest.mock('../../database/config', () => ({
+    DB_TYPE: 'mongodb',
+    getDatabaseType: jest.fn(() => 'mongodb'),
+    PRISMA_LOG_LEVEL: 'error,warn',
+    PRISMA_QUERY_LOGGING: false,
+}));
+
+const mockFindById = jest.fn();
+const mockCreate = jest.fn();
+const mockUpdate = jest.fn();
+const mockApplyProcessUpdate = jest.fn();
+
+jest.mock(
+    '../../integrations/repositories/process-repository-factory',
+    () => ({
+        createProcessRepository: () => ({
+            findById: mockFindById,
+            create: mockCreate,
+            update: mockUpdate,
+            applyProcessUpdate: mockApplyProcessUpdate,
+        }),
+    }),
+);
+
+const { createProcessCommands } = require('./process-commands');
+
+describe('process commands — error-code mapping (real use cases)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('maps invalid createProcess data to 400 INVALID_PROCESS_DATA', async () => {
+        const commands = createProcessCommands();
+
+        const result = await commands.createProcess({
+            integrationId: 'int-1',
+            name: 'sync',
+            type: 'CRM_SYNC',
+        }); // missing userId
+
+        expect(result).toMatchObject({
+            error: 400,
+            code: 'INVALID_PROCESS_DATA',
+        });
+    });
+
+    it('maps a missing process on updateProcessState to 404 PROCESS_NOT_FOUND', async () => {
+        mockFindById.mockResolvedValue(null);
+        const commands = createProcessCommands();
+
+        const result = await commands.updateProcessState('missing', 'COMPLETED');
+
+        expect(result).toEqual({
+            error: 404,
+            reason: 'Process not found: missing',
+            code: 'PROCESS_NOT_FOUND',
+        });
+    });
+
+    it('maps a missing process on updateProcessMetrics to 404 PROCESS_NOT_FOUND', async () => {
+        mockApplyProcessUpdate.mockResolvedValue(null);
+        const commands = createProcessCommands();
+
+        const result = await commands.updateProcessMetrics('missing', {
+            processed: 1,
+        });
+
+        expect(result).toEqual({
+            error: 404,
+            reason: 'Process not found: missing',
+            code: 'PROCESS_NOT_FOUND',
+        });
+    });
+
+    it('passes through null from getProcess (finder convention, not a 404)', async () => {
+        mockFindById.mockResolvedValue(null);
+        const commands = createProcessCommands();
+
+        const result = await commands.getProcess('missing');
+
+        expect(result).toBeNull();
+    });
+});

--- a/packages/core/application/commands/process-commands.js
+++ b/packages/core/application/commands/process-commands.js
@@ -1,0 +1,135 @@
+/**
+ * Process Commands
+ *
+ * Application Layer - Command factory for long-running process tracking.
+ *
+ * Wraps the Process use cases (create, get, update state, update metrics)
+ * behind the same `createXCommands()` surface used by the other domains so
+ * integration developers can track processes without touching repositories
+ * or the underlying ORM directly.
+ *
+ * @example
+ * const processCommands = createProcessCommands();
+ * const process = await processCommands.createProcess({
+ *     userId: 'user-1',
+ *     integrationId: 'integration-1',
+ *     name: 'zoho-crm-contact-sync',
+ *     type: 'CRM_SYNC',
+ * });
+ * await processCommands.updateProcessState(process.id, 'FETCHING_TOTAL');
+ * await processCommands.updateProcessMetrics(process.id, { processed: 100, success: 100 });
+ */
+
+const {
+    createProcessRepository,
+} = require('../../integrations/repositories/process-repository-factory');
+const { CreateProcess } = require('../../integrations/use-cases/create-process');
+const { GetProcess } = require('../../integrations/use-cases/get-process');
+const {
+    UpdateProcessState,
+} = require('../../integrations/use-cases/update-process-state');
+const {
+    UpdateProcessMetrics,
+} = require('../../integrations/use-cases/update-process-metrics');
+
+const ERROR_CODE_MAP = {
+    PROCESS_NOT_FOUND: 404,
+    INVALID_PROCESS_DATA: 400,
+};
+
+function mapErrorToResponse(error) {
+    const status = ERROR_CODE_MAP[error?.code] || 500;
+    return {
+        error: status,
+        reason: error?.message,
+        code: error?.code,
+    };
+}
+
+/**
+ * Create process tracking commands.
+ *
+ * @param {Object} [params]
+ * @param {Object} [params.websocketService] - Optional WebSocket service
+ *     forwarded to UpdateProcessMetrics for progress broadcasting.
+ * @returns {Object} Process commands object
+ */
+function createProcessCommands({ websocketService } = {}) {
+    const processRepository = createProcessRepository();
+
+    const createProcessUseCase = new CreateProcess({ processRepository });
+    const getProcessUseCase = new GetProcess({ processRepository });
+    const updateProcessStateUseCase = new UpdateProcessState({
+        processRepository,
+    });
+    const updateProcessMetricsUseCase = new UpdateProcessMetrics({
+        processRepository,
+        websocketService,
+    });
+
+    return {
+        /**
+         * Create a new process record.
+         * @param {Object} processData - Process data (userId, integrationId, name, type, ...)
+         * @returns {Promise<Object>} Created process record
+         */
+        async createProcess(processData) {
+            try {
+                return await createProcessUseCase.execute(processData);
+            } catch (error) {
+                return mapErrorToResponse(error);
+            }
+        },
+
+        /**
+         * Retrieve a process by ID.
+         * @param {string} processId - Process ID
+         * @returns {Promise<Object|null>} Process record, or null if not found
+         */
+        async getProcess(processId) {
+            try {
+                return await getProcessUseCase.execute(processId);
+            } catch (error) {
+                return mapErrorToResponse(error);
+            }
+        },
+
+        /**
+         * Transition a process to a new state, merging optional context updates.
+         * @param {string} processId - Process ID
+         * @param {string} newState - New state value
+         * @param {Object} [contextUpdates={}] - Context fields to merge
+         * @returns {Promise<Object>} Updated process record
+         */
+        async updateProcessState(processId, newState, contextUpdates = {}) {
+            try {
+                return await updateProcessStateUseCase.execute(
+                    processId,
+                    newState,
+                    contextUpdates
+                );
+            } catch (error) {
+                return mapErrorToResponse(error);
+            }
+        },
+
+        /**
+         * Apply a metrics update (counters + bounded error history) to a process.
+         * @param {string} processId - Process ID
+         * @param {Object} metricsUpdate - Metrics to add (processed, success, errors, skipped, errorDetails)
+         * @returns {Promise<Object>} Updated process record
+         */
+        async updateProcessMetrics(processId, metricsUpdate) {
+            try {
+                return await updateProcessMetricsUseCase.execute(
+                    processId,
+                    metricsUpdate
+                );
+            } catch (error) {
+                return mapErrorToResponse(error);
+            }
+        },
+    };
+}
+
+module.exports = { createProcessCommands };

--- a/packages/core/application/commands/process-commands.test.js
+++ b/packages/core/application/commands/process-commands.test.js
@@ -1,0 +1,243 @@
+jest.mock('../../database/config', () => ({
+    DB_TYPE: 'mongodb',
+    getDatabaseType: jest.fn(() => 'mongodb'),
+    PRISMA_LOG_LEVEL: 'error,warn',
+    PRISMA_QUERY_LOGGING: false,
+}));
+
+jest.mock(
+    '../../integrations/repositories/process-repository-factory',
+    () => ({
+        createProcessRepository: jest.fn(() => ({})),
+    }),
+);
+
+const mockCreateExecute = jest.fn();
+const mockGetExecute = jest.fn();
+const mockUpdateStateExecute = jest.fn();
+const mockUpdateMetricsExecute = jest.fn();
+
+jest.mock('../../integrations/use-cases/create-process', () => ({
+    CreateProcess: jest
+        .fn()
+        .mockImplementation(() => ({ execute: mockCreateExecute })),
+}));
+jest.mock('../../integrations/use-cases/get-process', () => ({
+    GetProcess: jest
+        .fn()
+        .mockImplementation(() => ({ execute: mockGetExecute })),
+}));
+jest.mock('../../integrations/use-cases/update-process-state', () => ({
+    UpdateProcessState: jest
+        .fn()
+        .mockImplementation(() => ({ execute: mockUpdateStateExecute })),
+}));
+jest.mock('../../integrations/use-cases/update-process-metrics', () => ({
+    UpdateProcessMetrics: jest
+        .fn()
+        .mockImplementation(() => ({ execute: mockUpdateMetricsExecute })),
+}));
+
+const { CreateProcess } = require('../../integrations/use-cases/create-process');
+const { GetProcess } = require('../../integrations/use-cases/get-process');
+const {
+    UpdateProcessState,
+} = require('../../integrations/use-cases/update-process-state');
+const {
+    UpdateProcessMetrics,
+} = require('../../integrations/use-cases/update-process-metrics');
+const { createProcessCommands } = require('./process-commands');
+
+describe('process commands', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockCreateExecute.mockReset();
+        mockGetExecute.mockReset();
+        mockUpdateStateExecute.mockReset();
+        mockUpdateMetricsExecute.mockReset();
+    });
+
+    describe('factory wiring', () => {
+        it('instantiates the four use cases with the default repository', () => {
+            createProcessCommands();
+
+            expect(CreateProcess).toHaveBeenCalledWith({
+                processRepository: expect.any(Object),
+            });
+            expect(GetProcess).toHaveBeenCalledWith({
+                processRepository: expect.any(Object),
+            });
+            expect(UpdateProcessState).toHaveBeenCalledWith({
+                processRepository: expect.any(Object),
+            });
+            expect(UpdateProcessMetrics).toHaveBeenCalledWith({
+                processRepository: expect.any(Object),
+                websocketService: undefined,
+            });
+        });
+
+        it('forwards an optional websocketService to UpdateProcessMetrics', () => {
+            const websocketService = { broadcast: jest.fn() };
+
+            createProcessCommands({ websocketService });
+
+            expect(UpdateProcessMetrics).toHaveBeenCalledWith({
+                processRepository: expect.any(Object),
+                websocketService,
+            });
+        });
+
+        it('exposes exactly the four command methods', () => {
+            const commands = createProcessCommands();
+
+            expect(Object.keys(commands).sort()).toEqual([
+                'createProcess',
+                'getProcess',
+                'updateProcessMetrics',
+                'updateProcessState',
+            ]);
+        });
+    });
+
+    describe('createProcess', () => {
+        it('delegates to CreateProcess and returns the created process', async () => {
+            const processData = {
+                userId: 'user-1',
+                integrationId: 'integration-1',
+                name: 'zoho-crm-contact-sync',
+                type: 'CRM_SYNC',
+            };
+            const created = { id: 'process-1', ...processData };
+            mockCreateExecute.mockResolvedValue(created);
+
+            const commands = createProcessCommands();
+            const result = await commands.createProcess(processData);
+
+            expect(mockCreateExecute).toHaveBeenCalledWith(processData);
+            expect(result).toEqual(created);
+        });
+
+        it('maps thrown errors to a response object', async () => {
+            mockCreateExecute.mockRejectedValue(
+                new Error('Missing required fields for process creation: userId'),
+            );
+
+            const commands = createProcessCommands();
+            const result = await commands.createProcess({});
+
+            expect(result).toEqual({
+                error: 500,
+                reason: 'Missing required fields for process creation: userId',
+                code: undefined,
+            });
+        });
+    });
+
+    describe('getProcess', () => {
+        it('delegates to GetProcess and returns the process', async () => {
+            const process = { id: 'process-1' };
+            mockGetExecute.mockResolvedValue(process);
+
+            const commands = createProcessCommands();
+            const result = await commands.getProcess('process-1');
+
+            expect(mockGetExecute).toHaveBeenCalledWith('process-1');
+            expect(result).toEqual(process);
+        });
+
+        it('passes through null when the process is not found', async () => {
+            mockGetExecute.mockResolvedValue(null);
+
+            const commands = createProcessCommands();
+            const result = await commands.getProcess('missing');
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('updateProcessState', () => {
+        it('delegates with processId, newState and contextUpdates', async () => {
+            const updated = { id: 'process-1', state: 'FETCHING_TOTAL' };
+            mockUpdateStateExecute.mockResolvedValue(updated);
+
+            const commands = createProcessCommands();
+            const result = await commands.updateProcessState(
+                'process-1',
+                'FETCHING_TOTAL',
+                { currentPage: 1 },
+            );
+
+            expect(mockUpdateStateExecute).toHaveBeenCalledWith(
+                'process-1',
+                'FETCHING_TOTAL',
+                { currentPage: 1 },
+            );
+            expect(result).toEqual(updated);
+        });
+
+        it('defaults contextUpdates to an empty object', async () => {
+            mockUpdateStateExecute.mockResolvedValue({});
+
+            const commands = createProcessCommands();
+            await commands.updateProcessState('process-1', 'COMPLETED');
+
+            expect(mockUpdateStateExecute).toHaveBeenCalledWith(
+                'process-1',
+                'COMPLETED',
+                {},
+            );
+        });
+
+        it('maps coded errors to the right status', async () => {
+            mockUpdateStateExecute.mockRejectedValue(
+                Object.assign(new Error('Process not found: missing'), {
+                    code: 'PROCESS_NOT_FOUND',
+                }),
+            );
+
+            const commands = createProcessCommands();
+            const result = await commands.updateProcessState('missing', 'X');
+
+            expect(result).toEqual({
+                error: 404,
+                reason: 'Process not found: missing',
+                code: 'PROCESS_NOT_FOUND',
+            });
+        });
+    });
+
+    describe('updateProcessMetrics', () => {
+        it('delegates with processId and the metrics update', async () => {
+            const updated = { id: 'process-1' };
+            mockUpdateMetricsExecute.mockResolvedValue(updated);
+            const metricsUpdate = { processed: 100, success: 92, errors: 5 };
+
+            const commands = createProcessCommands();
+            const result = await commands.updateProcessMetrics(
+                'process-1',
+                metricsUpdate,
+            );
+
+            expect(mockUpdateMetricsExecute).toHaveBeenCalledWith(
+                'process-1',
+                metricsUpdate,
+            );
+            expect(result).toEqual(updated);
+        });
+
+        it('maps thrown errors to a response object', async () => {
+            mockUpdateMetricsExecute.mockRejectedValue(
+                new Error('Failed to update process metrics: boom'),
+            );
+
+            const commands = createProcessCommands();
+            const result = await commands.updateProcessMetrics('process-1', {});
+
+            expect(result).toEqual({
+                error: 500,
+                reason: 'Failed to update process metrics: boom',
+                code: undefined,
+            });
+        });
+    });
+});

--- a/packages/core/application/index.js
+++ b/packages/core/application/index.js
@@ -8,6 +8,9 @@ const {
     createCredentialCommands,
 } = require('./commands/credential-commands');
 const {
+    createProcessCommands,
+} = require('./commands/process-commands');
+const {
     createSchedulerCommands,
 } = require('./commands/scheduler-commands');
 
@@ -36,6 +39,8 @@ function createFriggCommands({ integrationClass }) {
 
     const credentialCommands = createCredentialCommands();
 
+    const processCommands = createProcessCommands();
+
     return {
         // Integration commands
         ...integrationCommands,
@@ -48,6 +53,9 @@ function createFriggCommands({ integrationClass }) {
 
         // Credential commands
         ...credentialCommands,
+
+        // Process commands
+        ...processCommands,
     };
 }
 
@@ -60,6 +68,7 @@ module.exports = {
     createUserCommands,
     createEntityCommands,
     createCredentialCommands,
+    createProcessCommands,
     createSchedulerCommands,
 
     // Legacy standalone function

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -146,6 +146,7 @@ module.exports = {
     createUserCommands: application.createUserCommands,
     createEntityCommands: application.createEntityCommands,
     createCredentialCommands: application.createCredentialCommands,
+    createProcessCommands: application.createProcessCommands,
     createSchedulerCommands: application.createSchedulerCommands,
     findIntegrationContextByExternalEntityId:
         application.findIntegrationContextByExternalEntityId,

--- a/packages/core/integrations/use-cases/create-process.js
+++ b/packages/core/integrations/use-cases/create-process.js
@@ -22,6 +22,8 @@
  *   results: { aggregateData: { totalSynced: 0, totalFailed: 0 } }
  * });
  */
+const { invalidProcessData } = require('./process-errors');
+
 class CreateProcess {
     /**
      * @param {Object} params
@@ -86,40 +88,40 @@ class CreateProcess {
         const missingFields = requiredFields.filter(field => !processData[field]);
 
         if (missingFields.length > 0) {
-            throw new Error(
+            throw invalidProcessData(
                 `Missing required fields for process creation: ${missingFields.join(', ')}`
             );
         }
 
         // Validate field types
         if (typeof processData.userId !== 'string') {
-            throw new Error('userId must be a string');
+            throw invalidProcessData('userId must be a string');
         }
         if (typeof processData.integrationId !== 'string') {
-            throw new Error('integrationId must be a string');
+            throw invalidProcessData('integrationId must be a string');
         }
         if (typeof processData.name !== 'string') {
-            throw new Error('name must be a string');
+            throw invalidProcessData('name must be a string');
         }
         if (typeof processData.type !== 'string') {
-            throw new Error('type must be a string');
+            throw invalidProcessData('type must be a string');
         }
 
         // Validate optional fields if provided
         if (processData.state && typeof processData.state !== 'string') {
-            throw new Error('state must be a string');
+            throw invalidProcessData('state must be a string');
         }
         if (processData.context && typeof processData.context !== 'object') {
-            throw new Error('context must be an object');
+            throw invalidProcessData('context must be an object');
         }
         if (processData.results && typeof processData.results !== 'object') {
-            throw new Error('results must be an object');
+            throw invalidProcessData('results must be an object');
         }
         if (processData.childProcesses && !Array.isArray(processData.childProcesses)) {
-            throw new Error('childProcesses must be an array');
+            throw invalidProcessData('childProcesses must be an array');
         }
         if (processData.parentProcessId && typeof processData.parentProcessId !== 'string') {
-            throw new Error('parentProcessId must be a string');
+            throw invalidProcessData('parentProcessId must be a string');
         }
     }
 }

--- a/packages/core/integrations/use-cases/create-process.test.js
+++ b/packages/core/integrations/use-cases/create-process.test.js
@@ -174,5 +174,32 @@ describe('CreateProcess', () => {
             await expect(createProcessUseCase.execute(validProcessData))
                 .rejects.toThrow('Failed to create process: Database connection failed');
         });
+
+        describe('error codes', () => {
+            it('tags validation errors with INVALID_PROCESS_DATA', async () => {
+                await expect(
+                    createProcessUseCase.execute({
+                        integrationId: 'int-123',
+                        name: 'test',
+                        type: 'CRM_SYNC',
+                    })
+                ).rejects.toHaveProperty('code', 'INVALID_PROCESS_DATA');
+
+                await expect(
+                    createProcessUseCase.execute({ ...validProcessData, userId: 123 })
+                ).rejects.toHaveProperty('code', 'INVALID_PROCESS_DATA');
+            });
+
+            it('leaves repository failures without a client error code', async () => {
+                mockProcessRepository.create.mockRejectedValue(
+                    new Error('Database connection failed')
+                );
+
+                const error = await createProcessUseCase
+                    .execute(validProcessData)
+                    .catch((e) => e);
+                expect(error.code).toBeUndefined();
+            });
+        });
     });
 });

--- a/packages/core/integrations/use-cases/get-process.js
+++ b/packages/core/integrations/use-cases/get-process.js
@@ -15,6 +15,8 @@
  * // or
  * const process = await getProcess.executeOrThrow(processId);
  */
+const { invalidProcessData, processNotFound } = require('./process-errors');
+
 class GetProcess {
     /**
      * @param {Object} params
@@ -36,7 +38,7 @@ class GetProcess {
     async execute(processId) {
         // Validate input
         if (!processId || typeof processId !== 'string') {
-            throw new Error('processId must be a non-empty string');
+            throw invalidProcessData('processId must be a non-empty string');
         }
 
         // Delegate to repository
@@ -58,7 +60,7 @@ class GetProcess {
         const process = await this.execute(processId);
 
         if (!process) {
-            throw new Error(`Process not found: ${processId}`);
+            throw processNotFound(`Process not found: ${processId}`);
         }
 
         return process;
@@ -71,7 +73,7 @@ class GetProcess {
      */
     async executeMany(processIds) {
         if (!Array.isArray(processIds)) {
-            throw new Error('processIds must be an array');
+            throw invalidProcessData('processIds must be an array');
         }
 
         const processes = await Promise.all(

--- a/packages/core/integrations/use-cases/get-process.test.js
+++ b/packages/core/integrations/use-cases/get-process.test.js
@@ -187,4 +187,27 @@ describe('GetProcess', () => {
             expect(result).toEqual([]);
         });
     });
+
+    describe('error codes', () => {
+        it('tags invalid processId with INVALID_PROCESS_DATA', async () => {
+            await expect(getProcessUseCase.execute('')).rejects.toHaveProperty(
+                'code',
+                'INVALID_PROCESS_DATA'
+            );
+        });
+
+        it('tags executeOrThrow not-found with PROCESS_NOT_FOUND', async () => {
+            mockProcessRepository.findById.mockResolvedValue(null);
+
+            await expect(
+                getProcessUseCase.executeOrThrow('process-123')
+            ).rejects.toHaveProperty('code', 'PROCESS_NOT_FOUND');
+        });
+
+        it('tags a non-array argument to executeMany with INVALID_PROCESS_DATA', async () => {
+            await expect(
+                getProcessUseCase.executeMany('not-an-array')
+            ).rejects.toHaveProperty('code', 'INVALID_PROCESS_DATA');
+        });
+    });
 });

--- a/packages/core/integrations/use-cases/process-errors.js
+++ b/packages/core/integrations/use-cases/process-errors.js
@@ -1,0 +1,28 @@
+/**
+ * Process Error Helpers
+ *
+ * Constructs Errors carrying a stable `code` so the application layer
+ * (`createProcessCommands` → `mapErrorToResponse`) can translate domain
+ * failures into HTTP statuses:
+ *   - INVALID_PROCESS_DATA → 400 (caller-supplied data is invalid)
+ *   - PROCESS_NOT_FOUND    → 404 (the referenced process does not exist)
+ *
+ * Repository/infrastructure failures are intentionally left uncoded so
+ * they surface as 500s.
+ */
+
+function createCodedError(message, code) {
+    const error = new Error(message);
+    error.code = code;
+    return error;
+}
+
+function invalidProcessData(message) {
+    return createCodedError(message, 'INVALID_PROCESS_DATA');
+}
+
+function processNotFound(message) {
+    return createCodedError(message, 'PROCESS_NOT_FOUND');
+}
+
+module.exports = { invalidProcessData, processNotFound };

--- a/packages/core/integrations/use-cases/update-process-metrics.js
+++ b/packages/core/integrations/use-cases/update-process-metrics.js
@@ -34,6 +34,8 @@
  *   errorDetails: [{ contactId: 'abc', error: 'Missing email', timestamp: '...' }]
  * });
  */
+const { invalidProcessData, processNotFound } = require('./process-errors');
+
 class UpdateProcessMetrics {
     /**
      * @param {Object} params
@@ -66,10 +68,10 @@ class UpdateProcessMetrics {
      */
     async execute(processId, metricsUpdate) {
         if (!processId || typeof processId !== 'string') {
-            throw new Error('processId must be a non-empty string');
+            throw invalidProcessData('processId must be a non-empty string');
         }
         if (!metricsUpdate || typeof metricsUpdate !== 'object') {
-            throw new Error('metricsUpdate must be an object');
+            throw invalidProcessData('metricsUpdate must be an object');
         }
 
         // Phase 1: atomic increments + bounded error history.
@@ -119,7 +121,7 @@ class UpdateProcessMetrics {
         }
 
         if (!updatedProcess) {
-            throw new Error(`Process not found: ${processId}`);
+            throw processNotFound(`Process not found: ${processId}`);
         }
 
         // Phase 2: derived metrics (non-atomic, best-effort). Preserved

--- a/packages/core/integrations/use-cases/update-process-metrics.test.js
+++ b/packages/core/integrations/use-cases/update-process-metrics.test.js
@@ -434,4 +434,25 @@ describe('UpdateProcessMetrics', () => {
             ).toBe(true);
         });
     });
+
+    describe('error codes', () => {
+        it('tags validation errors with INVALID_PROCESS_DATA', async () => {
+            await expect(useCase.execute('', {})).rejects.toHaveProperty(
+                'code',
+                'INVALID_PROCESS_DATA'
+            );
+            await expect(useCase.execute('p1', null)).rejects.toHaveProperty(
+                'code',
+                'INVALID_PROCESS_DATA'
+            );
+        });
+
+        it('tags not-found with PROCESS_NOT_FOUND', async () => {
+            mockProcessRepository.applyProcessUpdate.mockResolvedValue(null);
+
+            await expect(
+                useCase.execute('p1', { processed: 1 })
+            ).rejects.toHaveProperty('code', 'PROCESS_NOT_FOUND');
+        });
+    });
 });

--- a/packages/core/integrations/use-cases/update-process-state.js
+++ b/packages/core/integrations/use-cases/update-process-state.js
@@ -22,6 +22,8 @@
  *   pagination: { pageSize: 100 }
  * });
  */
+const { invalidProcessData, processNotFound } = require('./process-errors');
+
 class UpdateProcessState {
     /**
      * @param {Object} params
@@ -45,13 +47,13 @@ class UpdateProcessState {
     async execute(processId, newState, contextUpdates = {}) {
         // Validate inputs
         if (!processId || typeof processId !== 'string') {
-            throw new Error('processId must be a non-empty string');
+            throw invalidProcessData('processId must be a non-empty string');
         }
         if (!newState || typeof newState !== 'string') {
-            throw new Error('newState must be a non-empty string');
+            throw invalidProcessData('newState must be a non-empty string');
         }
         if (contextUpdates && typeof contextUpdates !== 'object') {
-            throw new Error('contextUpdates must be an object');
+            throw invalidProcessData('contextUpdates must be an object');
         }
 
         // Route through the atomic path when the repo supports it AND we
@@ -82,10 +84,13 @@ class UpdateProcessState {
                     { set, newState }
                 );
                 if (!updated) {
-                    throw new Error(`Process not found: ${processId}`);
+                    throw processNotFound(`Process not found: ${processId}`);
                 }
                 return updated;
             } catch (error) {
+                if (error.code === 'PROCESS_NOT_FOUND') {
+                    throw error;
+                }
                 throw new Error(
                     `Failed to update process state: ${error.message}`
                 );
@@ -100,7 +105,7 @@ class UpdateProcessState {
         try {
             const process = await this.processRepository.findById(processId);
             if (!process) {
-                throw new Error(`Process not found: ${processId}`);
+                throw processNotFound(`Process not found: ${processId}`);
             }
 
             const updates = { state: newState };
@@ -114,7 +119,7 @@ class UpdateProcessState {
             return await this.processRepository.update(processId, updates);
         } catch (error) {
             // Re-throw "Process not found" as-is; wrap other errors.
-            if (error.message && error.message.startsWith('Process not found')) {
+            if (error.code === 'PROCESS_NOT_FOUND') {
                 throw error;
             }
             throw new Error(`Failed to update process state: ${error.message}`);
@@ -140,7 +145,7 @@ class UpdateProcessState {
     async updateContextOnly(processId, contextUpdates) {
         const process = await this.processRepository.findById(processId);
         if (!process) {
-            throw new Error(`Process not found: ${processId}`);
+            throw processNotFound(`Process not found: ${processId}`);
         }
 
         const updates = {

--- a/packages/core/integrations/use-cases/update-process-state.test.js
+++ b/packages/core/integrations/use-cases/update-process-state.test.js
@@ -253,4 +253,50 @@ describe('UpdateProcessState', () => {
                 .rejects.toThrow('Process not found: process-123');
         });
     });
+
+    describe('error codes', () => {
+        const processId = 'process-123';
+
+        it('tags validation errors with INVALID_PROCESS_DATA', async () => {
+            await expect(
+                updateProcessStateUseCase.execute('', 'NEW_STATE')
+            ).rejects.toHaveProperty('code', 'INVALID_PROCESS_DATA');
+            await expect(
+                updateProcessStateUseCase.execute(processId, '')
+            ).rejects.toHaveProperty('code', 'INVALID_PROCESS_DATA');
+            await expect(
+                updateProcessStateUseCase.execute(processId, 'NEW_STATE', 'bad')
+            ).rejects.toHaveProperty('code', 'INVALID_PROCESS_DATA');
+        });
+
+        it('tags legacy-path not-found with PROCESS_NOT_FOUND', async () => {
+            mockProcessRepository.findById.mockResolvedValue(null);
+
+            await expect(
+                updateProcessStateUseCase.execute(processId, 'NEW_STATE')
+            ).rejects.toHaveProperty('code', 'PROCESS_NOT_FOUND');
+        });
+
+        it('tags atomic-path not-found with PROCESS_NOT_FOUND', async () => {
+            // Context keys + an applyProcessUpdate-capable repo routes
+            // through the atomic path; a null result means the row is gone.
+            mockProcessRepository.applyProcessUpdate = jest
+                .fn()
+                .mockResolvedValue(null);
+
+            await expect(
+                updateProcessStateUseCase.execute(processId, 'NEW_STATE', {
+                    currentPage: 1,
+                })
+            ).rejects.toHaveProperty('code', 'PROCESS_NOT_FOUND');
+        });
+
+        it('tags updateContextOnly not-found with PROCESS_NOT_FOUND', async () => {
+            mockProcessRepository.findById.mockResolvedValue(null);
+
+            await expect(
+                updateProcessStateUseCase.updateContextOnly(processId, {})
+            ).rejects.toHaveProperty('code', 'PROCESS_NOT_FOUND');
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Adds an application-layer command surface for Frigg's long-running **Process** tracking, and gives the Process use cases proper error-code semantics.

- **`createProcessCommands()`** (`packages/core/application/commands/process-commands.js`) — wraps the four existing Process use cases (`createProcess`, `getProcess`, `updateProcessState`, `updateProcessMetrics`) behind the same `createXCommands()` pattern used by the other domains, with a local `mapErrorToResponse`. Composed into `createFriggCommands()` and re-exported from `@friggframework/core`.
- **Error-code enrichment** — the four Process use cases now throw coded errors via a shared `process-errors` helper: validation failures → `INVALID_PROCESS_DATA` (400), missing process → `PROCESS_NOT_FOUND` (404). Repository/infrastructure failures stay uncoded so they surface as 500s.
- **Atomic-path fix** — `update-process-state`'s atomic `catch` previously re-wrapped its own "Process not found" into a generic 500; it now re-throws the coded error so it surfaces as 404 (the legacy and metrics paths already returned the coded error correctly).

No use-case business logic changed beyond error annotations; the command factory is a thin pass-through that builds the repository once and delegates to the use cases.

## Files

- New: `application/commands/process-commands.js`, its unit + integration test suites, and `integrations/use-cases/process-errors.js`
- Modified: `application/index.js`, package root `index.js`, and the four `integrations/use-cases/*-process*.js` use cases (+ their tests)

## Testing

- `process-commands` unit + integration suites: **16/16**
- `integrations/use-cases` (including 10 new error-code assertions): **113/113**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.605.2c6a0b2.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.605.2c6a0b2.0
  npm install @friggframework/devtools@2.0.0--canary.605.2c6a0b2.0
  npm install @friggframework/eslint-config@2.0.0--canary.605.2c6a0b2.0
  npm install @friggframework/prettier-config@2.0.0--canary.605.2c6a0b2.0
  npm install @friggframework/schemas@2.0.0--canary.605.2c6a0b2.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.605.2c6a0b2.0
  npm install @friggframework/test@2.0.0--canary.605.2c6a0b2.0
  npm install @friggframework/ui@2.0.0--canary.605.2c6a0b2.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.605.2c6a0b2.0
  yarn add @friggframework/devtools@2.0.0--canary.605.2c6a0b2.0
  yarn add @friggframework/eslint-config@2.0.0--canary.605.2c6a0b2.0
  yarn add @friggframework/prettier-config@2.0.0--canary.605.2c6a0b2.0
  yarn add @friggframework/schemas@2.0.0--canary.605.2c6a0b2.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.605.2c6a0b2.0
  yarn add @friggframework/test@2.0.0--canary.605.2c6a0b2.0
  yarn add @friggframework/ui@2.0.0--canary.605.2c6a0b2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
