### PR TITLE
feat(reporting): read-only integrations reporting API in core

### DIFF
--- a/docs/frigg-management-api.yml
+++ b/docs/frigg-management-api.yml
@@ -1,0 +1,1029 @@
+openapi: 3.0.3
+info:
+    title: Frigg Management API BASE
+    description: >-
+        This base management API comes out-of-the-box with every Frigg
+        implementation. It can be customized to your needs, but is intended to work
+        immediately once you've got some initial integrations configured and API
+        Modules installed.
+
+
+        All routes are mounted by `createIntegrationRouter`
+        (`@friggframework/core`). Every endpoint runs behind the app-supplied
+        `requireLoggedInUser` middleware and resolves the acting user via
+        `getUserId`, so a user context is always required. Depending on how your
+        Frigg app wires `getUserId`, that context is provided either via a bearer
+        token or the `x-frigg-appuserid` / `x-frigg-apporgid` headers.
+    version: 1.0.0
+    contact: {}
+servers:
+    - url: http://localhost:3001/dev
+      description: Local development (serverless-offline)
+    - url: https://{restApiId}.execute-api.{region}.amazonaws.com/{stage}
+      description: Deployed API Gateway endpoint
+      variables:
+          restApiId:
+              default: your-api-id
+          region:
+              default: us-east-1
+          stage:
+              default: dev
+security:
+    - bearerAuth: []
+tags:
+    - name: Authorization
+      description: Authorize API Modules / entities and handle auth callbacks.
+    - name: Integrations
+      description: Create, configure, inspect, and act on integrations.
+    - name: Entities
+      description: Manage the connected entities backing an integration.
+    - name: Reporting
+      description: >-
+          Read-only, deployment-wide reporting for admin/back-office callers.
+          Gated by a dedicated reporting API key (not the per-user auth used by
+          the rest of this API).
+paths:
+    /api/authorize:
+        parameters:
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        get:
+            tags:
+                - Authorization
+            summary: Get Auth Requirements
+            description: >-
+                Returns the authorization requirements for the given entity type
+                (for OAuth this is typically a redirect `url`; for API-key/basic
+                auth it is a `jsonSchema`/`uiSchema` form definition).
+            operationId: getAuthRequirements
+            parameters:
+                - name: entityType
+                  in: query
+                  required: true
+                  description: The API Module / entity type to authorize.
+                  schema:
+                      type: string
+                      example: hubspot
+                - name: state
+                  in: query
+                  required: false
+                  description: >-
+                      Optional OAuth `state` value forwarded into the
+                      authorization-requirements lookup.
+                  schema:
+                      type: string
+                      example: abc123
+            responses:
+                '200':
+                    description: Authorization requirements.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthorizationRequirements'
+        post:
+            tags:
+                - Authorization
+            summary: Auth (Callback)
+            description: >-
+                Processes an authorization callback (e.g. an OAuth `code` exchange
+                or submitted credential form) and creates/links the credential and
+                entity for the acting user.
+            operationId: authCallback
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - entityType
+                                - data
+                            properties:
+                                entityType:
+                                    type: string
+                                    example: hubspot
+                                data:
+                                    type: object
+                                    additionalProperties: true
+                                    description: >-
+                                        Provider-specific callback payload (OAuth
+                                        `code`, or credential fields such as
+                                        api keys / subdomains).
+                        examples:
+                            OAuth callback:
+                                value:
+                                    entityType: hubspot
+                                    data:
+                                        code: abc123def456
+                            API key callback:
+                                value:
+                                    entityType: quo
+                                    data:
+                                        apiKey: your-api-key
+            responses:
+                '200':
+                    description: Credential and entity created/linked.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthCallbackResult'
+    /api/integrations:
+        parameters:
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        get:
+            tags:
+                - Integrations
+            summary: List Integrations
+            description: >-
+                Returns integration options, the entities the user is authorized
+                to use, and the user's existing integrations (each annotated with
+                its available `userActions`).
+            operationId: listIntegrations
+            responses:
+                '200':
+                    description: Integration options, authorized entities, and integrations.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    entities:
+                                        type: object
+                                        properties:
+                                            options:
+                                                type: array
+                                                items:
+                                                    type: object
+                                                    additionalProperties: true
+                                            authorized:
+                                                type: array
+                                                items:
+                                                    type: object
+                                                    additionalProperties: true
+                                    integrations:
+                                        type: array
+                                        items:
+                                            $ref: '#/components/schemas/Integration'
+        post:
+            tags:
+                - Integrations
+            summary: Create Integration
+            description: >-
+                Creates an integration from a pair of entities and a config object,
+                then runs the integration's `onCreate` lifecycle hook.
+            operationId: createIntegration
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - entities
+                                - config
+                            properties:
+                                entities:
+                                    type: array
+                                    items:
+                                        type: string
+                                    example:
+                                        - "7"
+                                        - "11"
+                                config:
+                                    type: object
+                                    required:
+                                        - type
+                                    additionalProperties: true
+                                    properties:
+                                        type:
+                                            type: string
+                                            description: The integration type to create.
+                                            example: attio
+                        examples:
+                            Create Integration:
+                                value:
+                                    entities:
+                                        - "7"
+                                        - "11"
+                                    config:
+                                        type: attio
+            responses:
+                '201':
+                    description: The created, formatted integration.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Integration'
+                            examples:
+                                Create Integration:
+                                    value:
+                                        id: "16"
+                                        entities:
+                                            - "7"
+                                            - "11"
+                                        status: ENABLED
+                                        config:
+                                            type: attio
+                                            enable:
+                                                sync: true
+                                                webhooks: true
+                                            map:
+                                                syncMap:
+                                                    freshbooksEntityId:
+                                                        - name.first
+                                                        - name.last
+                                                    salesforceEntityId:
+                                                        - firstName
+                                                        - lastName
+    /api/integrations/{integrationId}:
+        parameters:
+            - $ref: '#/components/parameters/IntegrationIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        get:
+            tags:
+                - Integrations
+            summary: Get Integration
+            description: Returns the integration's id, entities, status, and config.
+            operationId: getIntegration
+            responses:
+                '200':
+                    description: The integration.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Integration'
+        patch:
+            tags:
+                - Integrations
+            summary: Update Integration
+            description: >-
+                Updates an integration's config and runs the integration's
+                `onUpdate` lifecycle hook.
+            operationId: updateIntegration
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - config
+                            properties:
+                                config:
+                                    type: object
+                                    additionalProperties: true
+                                    properties:
+                                        enable:
+                                            type: object
+                                            properties:
+                                                sync:
+                                                    type: boolean
+                                                    example: true
+                                                webhooks:
+                                                    type: boolean
+                                                    example: false
+                                        map:
+                                            type: object
+                                            additionalProperties: true
+                        examples:
+                            Update Integration:
+                                value:
+                                    config:
+                                        enable:
+                                            sync: true
+                                            webhooks: false
+                                        map:
+                                            syncMap:
+                                                freshbooksEntityId:
+                                                    - name.first
+                                                    - name.last
+                                                salesforceEntityId:
+                                                    - firstName
+                                                    - lastName
+            responses:
+                '200':
+                    description: The updated, formatted integration.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Integration'
+        delete:
+            tags:
+                - Integrations
+            summary: Delete Integration
+            description: >-
+                Runs the integration's `onDelete` lifecycle hook and removes the
+                integration for the acting user.
+            operationId: deleteIntegration
+            responses:
+                '204':
+                    description: Integration deleted. No content.
+    /api/integrations/{integrationId}/config/options:
+        parameters:
+            - $ref: '#/components/parameters/IntegrationIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        get:
+            tags:
+                - Integrations
+            summary: Get Integration Config Options
+            description: Returns the dynamic config-options form for the integration.
+            operationId: getIntegrationConfigOptions
+            responses:
+                '200':
+                    description: Config options.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Options'
+    /api/integrations/{integrationId}/config/options/refresh:
+        parameters:
+            - $ref: '#/components/parameters/IntegrationIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        post:
+            tags:
+                - Integrations
+            summary: Refresh Integration Config Options
+            description: >-
+                Re-evaluates the config-options form given the current (partial)
+                config submission, e.g. to populate dependent dropdowns.
+            operationId: refreshIntegrationConfigOptions
+            requestBody:
+                required: false
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            additionalProperties: true
+            responses:
+                '200':
+                    description: Refreshed config options.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Options'
+    /api/integrations/{integrationId}/actions:
+        parameters:
+            - $ref: '#/components/parameters/IntegrationIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        get:
+            tags:
+                - Integrations
+            summary: List User Actions
+            description: >-
+                Lists the user actions available for the integration. The route is
+                registered with `.all`, so it responds to any HTTP method; GET is
+                the typical call.
+            operationId: listUserActions
+            responses:
+                '200':
+                    description: Available user actions.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                additionalProperties: true
+    /api/integrations/{integrationId}/actions/{actionId}/options:
+        parameters:
+            - $ref: '#/components/parameters/IntegrationIdPath'
+            - $ref: '#/components/parameters/ActionIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        get:
+            tags:
+                - Integrations
+            summary: Get User Action Options
+            description: Returns the dynamic options form for a given user action.
+            operationId: getUserActionOptions
+            responses:
+                '200':
+                    description: Action options.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Options'
+    /api/integrations/{integrationId}/actions/{actionId}/options/refresh:
+        parameters:
+            - $ref: '#/components/parameters/IntegrationIdPath'
+            - $ref: '#/components/parameters/ActionIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        post:
+            tags:
+                - Integrations
+            summary: Refresh User Action Options
+            description: >-
+                Re-evaluates a user action's options form given the current
+                (partial) submission.
+            operationId: refreshUserActionOptions
+            requestBody:
+                required: false
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            additionalProperties: true
+            responses:
+                '200':
+                    description: Refreshed action options.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Options'
+    /api/integrations/{integrationId}/actions/{actionId}:
+        parameters:
+            - $ref: '#/components/parameters/IntegrationIdPath'
+            - $ref: '#/components/parameters/ActionIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        post:
+            tags:
+                - Integrations
+            summary: Submit User Action
+            description: >-
+                Submits/triggers a user action on the integration (calls the
+                integration's `notify(actionId, body)`). The request body is the
+                action-specific payload.
+            operationId: submitUserAction
+            requestBody:
+                required: false
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            additionalProperties: true
+                        examples:
+                            Submit User Action:
+                                value:
+                                    confirm: true
+            responses:
+                '200':
+                    description: Action result.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                additionalProperties: true
+    /api/integrations/{integrationId}/test-auth:
+        parameters:
+            - $ref: '#/components/parameters/IntegrationIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        get:
+            tags:
+                - Integrations
+            summary: Test Integration Auth
+            description: >-
+                Runs `testAuth` against the integration's entities and reports any
+                authentication errors raised during the check.
+            operationId: testIntegrationAuth
+            responses:
+                '200':
+                    description: Authentication is healthy.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/OkStatus'
+                '400':
+                    description: Authentication errors were detected.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorResponse'
+    /api/entity:
+        parameters:
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        post:
+            tags:
+                - Entities
+            summary: Create Entity
+            description: >-
+                Finds or creates an entity for a previously-created credential.
+                `data.credential_id` is required and must reference an existing
+                credential.
+            operationId: createEntity
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - entityType
+                                - data
+                            properties:
+                                entityType:
+                                    type: string
+                                    example: hubspot
+                                data:
+                                    type: object
+                                    required:
+                                        - credential_id
+                                    additionalProperties: true
+                                    properties:
+                                        credential_id:
+                                            type: string
+                                            example: "12"
+                        examples:
+                            Create Entity:
+                                value:
+                                    entityType: hubspot
+                                    data:
+                                        credential_id: "12"
+            responses:
+                '200':
+                    description: The found or created entity.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Entity'
+    /api/entity/options/{credentialId}:
+        parameters:
+            - $ref: '#/components/parameters/CredentialIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        get:
+            tags:
+                - Entities
+            summary: Get Entity Options (by Credential)
+            description: >-
+                Returns the entity-selection options available for a credential
+                (e.g. selectable accounts/workspaces). The credential must belong
+                to the acting user.
+            operationId: getEntityOptionsByCredential
+            parameters:
+                - name: entityType
+                  in: query
+                  required: true
+                  description: The API Module / entity type the credential belongs to.
+                  schema:
+                      type: string
+                      example: hubspot
+            responses:
+                '200':
+                    description: Entity options.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Options'
+                '403':
+                    description: The credential does not belong to the acting user.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorResponse'
+    /api/entities/{entityId}:
+        parameters:
+            - $ref: '#/components/parameters/EntityIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        get:
+            tags:
+                - Entities
+            summary: Get Entity
+            description: Returns the entity record for the given entity id.
+            operationId: getEntity
+            responses:
+                '200':
+                    description: The entity.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Entity'
+                '404':
+                    description: Entity not found for the acting user.
+    /api/entities/{entityId}/test-auth:
+        parameters:
+            - $ref: '#/components/parameters/EntityIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        get:
+            tags:
+                - Entities
+            summary: Test Entity Auth
+            description: Runs `testAuth` against a single entity's credential.
+            operationId: testEntityAuth
+            responses:
+                '200':
+                    description: Authentication is healthy.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/OkStatus'
+                '400':
+                    description: Authentication error for this entity.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorResponse'
+                '404':
+                    description: Entity not found for the acting user.
+    /api/entities/{entityId}/options:
+        parameters:
+            - $ref: '#/components/parameters/EntityIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        post:
+            tags:
+                - Entities
+            summary: Get Entity Options (by Entity)
+            description: Returns the options form for an existing entity.
+            operationId: getEntityOptions
+            requestBody:
+                required: false
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            additionalProperties: true
+            responses:
+                '200':
+                    description: Entity options.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Options'
+                '404':
+                    description: Entity not found for the acting user.
+    /api/entities/{entityId}/options/refresh:
+        parameters:
+            - $ref: '#/components/parameters/EntityIdPath'
+            - $ref: '#/components/parameters/AppUserIdHeader'
+            - $ref: '#/components/parameters/AppOrgIdHeader'
+        post:
+            tags:
+                - Entities
+            summary: Refresh Entity Options
+            description: >-
+                Re-evaluates an entity's options form given the current (partial)
+                submission.
+            operationId: refreshEntityOptions
+            requestBody:
+                required: false
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            additionalProperties: true
+            responses:
+                '200':
+                    description: Refreshed entity options.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Options'
+                '404':
+                    description: Entity not found for the acting user.
+    /api/v2/reports/integrations:
+        get:
+            tags:
+                - Reporting
+            summary: List integrations report
+            description: >-
+                Read-only, deployment-wide report of integrations: a total, a
+                breakdown by `IntegrationStatus`, a per-type breakdown, and a
+                lightweight per-integration row list (status, type, userId,
+                version, moduleCount, errorCount, mappedRecordCount, timestamps).
+                Gated by the reporting API key — not the per-user auth used by the
+                rest of this API.
+            operationId: listIntegrationsReport
+            security:
+                - reportingApiKey: []
+            parameters:
+                - name: status
+                  in: query
+                  required: false
+                  description: Filter by integration status.
+                  schema:
+                      type: string
+                      enum:
+                          - ENABLED
+                          - ERROR
+                          - NEEDS_CONFIG
+                          - PROCESSING
+                          - DISABLED
+                - name: type
+                  in: query
+                  required: false
+                  description: Filter by integration type (`config.type`).
+                  schema:
+                      type: string
+                      example: hubspot
+                - name: userId
+                  in: query
+                  required: false
+                  description: Filter to a single user's integrations.
+                  schema:
+                      type: string
+            responses:
+                '200':
+                    description: The integrations report (versioned envelope).
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/IntegrationsReport'
+                '401':
+                    description: Missing or invalid reporting API key.
+components:
+    securitySchemes:
+        bearerAuth:
+            type: http
+            scheme: bearer
+            description: >-
+                Bearer token for the acting user, when the Frigg app's `getUserId`
+                resolves the user from an Authorization header.
+        reportingApiKey:
+            type: apiKey
+            in: header
+            name: x-frigg-reporting-api-key
+            description: >-
+                Dedicated admin key for the read-only reporting endpoints,
+                validated against the `REPORTING_API_KEY` environment variable.
+    parameters:
+        AppUserIdHeader:
+            name: x-frigg-appuserid
+            in: header
+            required: false
+            description: >-
+                Identifies the acting end user, when the Frigg app's `getUserId`
+                resolves the user from this header instead of a bearer token.
+            schema:
+                type: string
+                example: '{{appUserId}}'
+        AppOrgIdHeader:
+            name: x-frigg-apporgid
+            in: header
+            required: false
+            description: Identifies the acting end user's organization (app-specific).
+            schema:
+                type: string
+                example: '{{appOrgId}}'
+        IntegrationIdPath:
+            name: integrationId
+            in: path
+            required: true
+            description: The integration's id.
+            schema:
+                type: string
+                example: '{{integrationId}}'
+        ActionIdPath:
+            name: actionId
+            in: path
+            required: true
+            description: The user action identifier.
+            schema:
+                type: string
+                example: DELETE_ALL_CUSTOM_OBJECTS
+        EntityIdPath:
+            name: entityId
+            in: path
+            required: true
+            description: The entity's id.
+            schema:
+                type: string
+                example: '{{entityId}}'
+        CredentialIdPath:
+            name: credentialId
+            in: path
+            required: true
+            description: The credential's id.
+            schema:
+                type: string
+                example: '{{credentialId}}'
+    schemas:
+        IntegrationStatus:
+            type: string
+            enum:
+                - ENABLED
+                - DISABLED
+                - NEEDS_CONFIG
+                - PROCESSING
+                - ERROR
+        IntegrationsReport:
+            type: object
+            properties:
+                schemaVersion:
+                    type: integer
+                    example: 1
+                service:
+                    type: string
+                    example: frigg-core-api
+                generatedAt:
+                    type: string
+                    format: date-time
+                filters:
+                    type: object
+                    properties:
+                        status:
+                            type: string
+                            nullable: true
+                        type:
+                            type: string
+                            nullable: true
+                        userId:
+                            type: string
+                            nullable: true
+                metrics:
+                    type: object
+                    properties:
+                        total:
+                            type: integer
+                            example: 12
+                        byStatus:
+                            type: object
+                            description: Count keyed by IntegrationStatus value.
+                            additionalProperties:
+                                type: integer
+                        byType:
+                            type: array
+                            items:
+                                type: object
+                                properties:
+                                    type:
+                                        type: string
+                                        example: hubspot
+                                    total:
+                                        type: integer
+                                    byStatus:
+                                        type: object
+                                        additionalProperties:
+                                            type: integer
+                        integrations:
+                            type: array
+                            items:
+                                $ref: '#/components/schemas/IntegrationReportRow'
+        IntegrationReportRow:
+            type: object
+            properties:
+                id:
+                    type: string
+                    example: "17"
+                type:
+                    type: string
+                    example: hubspot
+                status:
+                    $ref: '#/components/schemas/IntegrationStatus'
+                userId:
+                    type: string
+                    nullable: true
+                version:
+                    type: string
+                    nullable: true
+                    example: "1.0.0"
+                moduleCount:
+                    type: integer
+                    example: 2
+                errorCount:
+                    type: integer
+                    example: 0
+                mappedRecordCount:
+                    type: integer
+                    example: 412
+                createdAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                updatedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+        Integration:
+            type: object
+            properties:
+                id:
+                    type: string
+                    example: "16"
+                entities:
+                    type: array
+                    items:
+                        type: string
+                    example:
+                        - "7"
+                        - "11"
+                status:
+                    $ref: '#/components/schemas/IntegrationStatus'
+                config:
+                    type: object
+                    additionalProperties: true
+                    example:
+                        type: attio
+                userActions:
+                    type: array
+                    items:
+                        type: object
+                        additionalProperties: true
+        Entity:
+            type: object
+            additionalProperties: true
+            description: >-
+                A persisted entity — an authorized connection to an external system,
+                backed by a credential. Fields mirror the Entity model; some
+                endpoints also serialize a nested `credential` object.
+            properties:
+                id:
+                    type: string
+                    example: "7"
+                userId:
+                    type: string
+                    example: "3"
+                credentialId:
+                    type: string
+                    example: "12"
+                name:
+                    type: string
+                    example: Acme HubSpot
+                moduleName:
+                    type: string
+                    description: The API module / entity type.
+                    example: hubspot
+                externalId:
+                    type: string
+                    example: hub_98531
+                data:
+                    type: object
+                    additionalProperties: true
+                createdAt:
+                    type: string
+                    format: date-time
+                updatedAt:
+                    type: string
+                    format: date-time
+        AuthorizationRequirements:
+            type: object
+            additionalProperties: true
+            description: >-
+                Auth requirements for the entity type. OAuth modules return
+                `{ type: "oauth2", url }`; API-key modules return
+                `{ type: "apiKey", jsonSchema, ... }` describing the credential form.
+            properties:
+                type:
+                    type: string
+                    example: oauth2
+                url:
+                    type: string
+                    description: Authorization redirect URL (OAuth modules).
+                    example: https://app.hubspot.com/oauth/authorize?client_id=...&redirect_uri=...&scope=...&state=...
+                jsonSchema:
+                    type: object
+                    additionalProperties: true
+                    description: JSON Schema describing the credential form (API-key modules).
+                uiSchema:
+                    type: object
+                    additionalProperties: true
+        AuthCallbackResult:
+            type: object
+            additionalProperties: true
+            description: >-
+                Returned by the authorize callback after it creates/links the
+                credential and entity for the user.
+            properties:
+                credential_id:
+                    type: string
+                    example: "12"
+                entity_id:
+                    type: string
+                    example: "7"
+                type:
+                    type: string
+                    description: The API module / entity type (the module's name).
+                    example: hubspot
+        Options:
+            type: object
+            additionalProperties: true
+            description: >-
+                An integration- or module-defined options payload. The exact shape
+                is provider-specific; it is commonly an `options` array of
+                selectable values.
+            properties:
+                options:
+                    type: array
+                    items:
+                        type: object
+                        additionalProperties: true
+        OkStatus:
+            type: object
+            properties:
+                status:
+                    type: string
+                    example: ok
+        ErrorResponse:
+            type: object
+            properties:
+                errors:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            title:
+                                type: string
+                                example: Authentication Error
+                            message:
+                                type: string
+                            timestamp:
+                                type: integer
+                                format: int64

--- a/docs/frigg-management-api.yml
+++ b/docs/frigg-management-api.yml
@@ -753,11 +753,14 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/IntegrationsReport'
                 '400':
-                    description: Malformed query parameter.
+                    description: Malformed or invalid query parameter.
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/ReportingError'
+                                type: object
+                                properties:
+                                    error:
+                                        type: string
                 '401':
                     description: Missing or invalid reporting API key.
                     content:

--- a/docs/frigg-management-api.yml
+++ b/docs/frigg-management-api.yml
@@ -679,6 +679,37 @@ paths:
                                 $ref: '#/components/schemas/Options'
                 '404':
                     description: Entity not found for the acting user.
+    /api/v2/reports:
+        get:
+            tags:
+                - Reporting
+            summary: Reporting index
+            description: Lists the available reports on this instance.
+            operationId: reportsIndex
+            security:
+                - reportingApiKey: []
+            responses:
+                '200':
+                    description: The available reports.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    service:
+                                        type: string
+                                        example: frigg-core-api
+                                    reports:
+                                        type: array
+                                        items:
+                                            type: string
+                                        example: [integrations]
+                '401':
+                    description: Missing or invalid reporting API key.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ReportingError'
     /api/v2/reports/integrations:
         get:
             tags:
@@ -700,13 +731,7 @@ paths:
                   required: false
                   description: Filter by integration status.
                   schema:
-                      type: string
-                      enum:
-                          - ENABLED
-                          - ERROR
-                          - NEEDS_CONFIG
-                          - PROCESSING
-                          - DISABLED
+                      $ref: '#/components/schemas/IntegrationStatus'
                 - name: type
                   in: query
                   required: false
@@ -727,8 +752,18 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/IntegrationsReport'
+                '400':
+                    description: Malformed query parameter.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ReportingError'
                 '401':
                     description: Missing or invalid reporting API key.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ReportingError'
 components:
     securitySchemes:
         bearerAuth:
@@ -867,7 +902,9 @@ components:
                     type: string
                     example: hubspot
                 status:
-                    $ref: '#/components/schemas/IntegrationStatus'
+                    allOf:
+                        - $ref: '#/components/schemas/IntegrationStatus'
+                    nullable: true
                 userId:
                     type: string
                     nullable: true
@@ -892,6 +929,15 @@ components:
                     type: string
                     format: date-time
                     nullable: true
+        ReportingError:
+            type: object
+            properties:
+                status:
+                    type: string
+                    example: error
+                message:
+                    type: string
+                    example: Unauthorized - x-frigg-reporting-api-key header required
         Integration:
             type: object
             properties:

--- a/packages/core/__tests__/documentdb-factory-selection.test.js
+++ b/packages/core/__tests__/documentdb-factory-selection.test.js
@@ -32,6 +32,11 @@ const FACTORIES = [
         exportName: 'ProcessRepositoryDocumentDB',
     },
     {
+        modulePath: '../reporting/repositories/reporting-repository-factory',
+        factoryName: 'createReportingRepository',
+        exportName: 'ReportingRepositoryDocumentDB',
+    },
+    {
         modulePath: '../syncs/repositories/sync-repository-factory',
         factoryName: 'createSyncRepository',
         exportName: 'SyncRepositoryDocumentDB',

--- a/packages/core/handlers/routers/reporting.js
+++ b/packages/core/handlers/routers/reporting.js
@@ -3,8 +3,7 @@ const { createAppHandler } = require('./../app-handler-helpers');
 
 const router = createReportingRouter();
 
-// shouldUseDatabase = true: the reporting endpoints read the DB, so eager-connect
-// Prisma in the handler wrapper.
+// true → eager-connect Prisma; the reporting endpoints read the DB.
 const handler = createAppHandler('HTTP Event: Reporting', router, true);
 
 module.exports = { handler, router };

--- a/packages/core/handlers/routers/reporting.js
+++ b/packages/core/handlers/routers/reporting.js
@@ -1,0 +1,10 @@
+const { createReportingRouter } = require('@friggframework/core');
+const { createAppHandler } = require('./../app-handler-helpers');
+
+const router = createReportingRouter();
+
+// shouldUseDatabase = true: the reporting endpoints read the DB, so eager-connect
+// Prisma in the handler wrapper.
+const handler = createAppHandler('HTTP Event: Reporting', router, true);
+
+module.exports = { handler, router };

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -71,6 +71,10 @@ const {
     getModulesDefinitionFromIntegrationClasses,
     LoadIntegrationContextUseCase,
 } = require('./integrations/index');
+const {
+    createReportingRouter,
+    createReportingRepository,
+} = require('./reporting/index');
 const { TimeoutCatcher } = require('./lambda/index');
 const { debug, initDebugLog, flushDebugLog } = require('./logs/index');
 const {
@@ -138,6 +142,10 @@ module.exports = {
     UpdateProcessState,
     UpdateProcessMetrics,
     GetProcess,
+
+    // reporting
+    createReportingRouter,
+    createReportingRepository,
 
     // application - Command factories for integration developers
     application,

--- a/packages/core/reporting/index.js
+++ b/packages/core/reporting/index.js
@@ -1,0 +1,17 @@
+const { createReportingRouter } = require('./reporting-router');
+const {
+    createReportingRepository,
+    ReportingRepositoryMongo,
+    ReportingRepositoryPostgres,
+    ReportingRepositoryDocumentDB,
+} = require('./repositories/reporting-repository-factory');
+const { ListIntegrationsReport } = require('./use-cases');
+
+module.exports = {
+    createReportingRouter,
+    createReportingRepository,
+    ReportingRepositoryMongo,
+    ReportingRepositoryPostgres,
+    ReportingRepositoryDocumentDB,
+    ListIntegrationsReport,
+};

--- a/packages/core/reporting/reporting-router.js
+++ b/packages/core/reporting/reporting-router.js
@@ -3,7 +3,10 @@ const catchAsyncError = require('express-async-handler');
 const {
     createReportingRepository,
 } = require('./repositories/reporting-repository-factory');
-const { ListIntegrationsReport } = require('./use-cases/list-integrations-report');
+const {
+    ListIntegrationsReport,
+    KNOWN_STATUSES,
+} = require('./use-cases/list-integrations-report');
 
 /**
  * Admin API key validation middleware.
@@ -45,6 +48,26 @@ function createReportingRouter() {
         '/api/v2/reports/integrations',
         catchAsyncError(async (req, res) => {
             const { status, type, userId } = req.query;
+
+            // Reject malformed input with 400 (a 500 would otherwise surface from
+            // the repository/Prisma layer on object/array-shaped query params).
+            for (const [key, value] of Object.entries({ status, type, userId })) {
+                if (value !== undefined && typeof value !== 'string') {
+                    return res.status(400).json({
+                        status: 'error',
+                        message: `Invalid query parameter '${key}': expected a string`,
+                    });
+                }
+            }
+            if (status && !KNOWN_STATUSES.includes(status)) {
+                return res.status(400).json({
+                    status: 'error',
+                    message: `Invalid status '${status}'. Expected one of: ${KNOWN_STATUSES.join(
+                        ', '
+                    )}`,
+                });
+            }
+
             const result = await listIntegrationsReport.execute({
                 status: status || undefined,
                 type: type || undefined,

--- a/packages/core/reporting/reporting-router.js
+++ b/packages/core/reporting/reporting-router.js
@@ -5,20 +5,6 @@ const {
 } = require('./repositories/reporting-repository-factory');
 const { ListIntegrationsReport } = require('./use-cases/list-integrations-report');
 
-const validateApiKey = (req, res, next) => {
-    const apiKey = req.headers['x-frigg-reporting-api-key'];
-
-    if (!apiKey || apiKey !== process.env.REPORTING_API_KEY) {
-        console.error('Unauthorized access attempt to reporting endpoint');
-        return res.status(401).json({
-            status: 'error',
-            message: 'Unauthorized - x-frigg-reporting-api-key header required',
-        });
-    }
-
-    next();
-};
-
 function createReportingRouter() {
     const reportingRepository = createReportingRepository();
     const listIntegrationsReport = new ListIntegrationsReport({
@@ -43,6 +29,20 @@ function createReportingRouter() {
     );
 
     return router;
+}
+
+function validateApiKey(req, res, next) {
+    const apiKey = req.headers['x-frigg-reporting-api-key'];
+
+    if (!apiKey || apiKey !== process.env.REPORTING_API_KEY) {
+        console.error('Unauthorized access attempt to reporting endpoint');
+        return res.status(401).json({
+            status: 'error',
+            message: 'Unauthorized - x-frigg-reporting-api-key header required',
+        });
+    }
+
+    next();
 }
 
 module.exports = { createReportingRouter, validateApiKey };

--- a/packages/core/reporting/reporting-router.js
+++ b/packages/core/reporting/reporting-router.js
@@ -8,10 +8,6 @@ const {
     KNOWN_STATUSES,
 } = require('./use-cases/list-integrations-report');
 
-/**
- * Admin API key validation middleware.
- * Mirrors the db-migration.js pattern, but with a dedicated reporting key.
- */
 const validateApiKey = (req, res, next) => {
     const apiKey = req.headers['x-frigg-reporting-api-key'];
 
@@ -26,11 +22,6 @@ const validateApiKey = (req, res, next) => {
     next();
 };
 
-/**
- * Composition root for the reporting API. Wires the DB-specific repository
- * (via the factory) into the use case, gates every route behind the reporting
- * admin key, and exposes the versioned read-only endpoints.
- */
 function createReportingRouter() {
     const reportingRepository = createReportingRepository();
     const listIntegrationsReport = new ListIntegrationsReport({
@@ -49,8 +40,8 @@ function createReportingRouter() {
         catchAsyncError(async (req, res) => {
             const { status, type, userId } = req.query;
 
-            // Reject malformed input with 400 (a 500 would otherwise surface from
-            // the repository/Prisma layer on object/array-shaped query params).
+            // 400 on malformed params; an object/array value would otherwise 500
+            // from the Prisma layer.
             for (const [key, value] of Object.entries({ status, type, userId })) {
                 if (value !== undefined && typeof value !== 'string') {
                     return res.status(400).json({

--- a/packages/core/reporting/reporting-router.js
+++ b/packages/core/reporting/reporting-router.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const catchAsyncError = require('express-async-handler');
+const {
+    createReportingRepository,
+} = require('./repositories/reporting-repository-factory');
+const { ListIntegrationsReport } = require('./use-cases/list-integrations-report');
+
+/**
+ * Admin API key validation middleware.
+ * Mirrors the db-migration.js pattern, but with a dedicated reporting key.
+ */
+const validateApiKey = (req, res, next) => {
+    const apiKey = req.headers['x-frigg-reporting-api-key'];
+
+    if (!apiKey || apiKey !== process.env.REPORTING_API_KEY) {
+        console.error('Unauthorized access attempt to reporting endpoint');
+        return res.status(401).json({
+            status: 'error',
+            message: 'Unauthorized - x-frigg-reporting-api-key header required',
+        });
+    }
+
+    next();
+};
+
+/**
+ * Composition root for the reporting API. Wires the DB-specific repository
+ * (via the factory) into the use case, gates every route behind the reporting
+ * admin key, and exposes the versioned read-only endpoints.
+ */
+function createReportingRouter() {
+    const reportingRepository = createReportingRepository();
+    const listIntegrationsReport = new ListIntegrationsReport({
+        reportingRepository,
+    });
+
+    const router = express.Router();
+    router.use(validateApiKey);
+
+    router.get('/api/v2/reports', (_req, res) => {
+        res.json({ service: 'frigg-core-api', reports: ['integrations'] });
+    });
+
+    router.get(
+        '/api/v2/reports/integrations',
+        catchAsyncError(async (req, res) => {
+            const { status, type, userId } = req.query;
+            const result = await listIntegrationsReport.execute({
+                status: status || undefined,
+                type: type || undefined,
+                userId: userId || undefined,
+            });
+            res.json(result);
+        })
+    );
+
+    return router;
+}
+
+module.exports = { createReportingRouter, validateApiKey };

--- a/packages/core/reporting/reporting-router.js
+++ b/packages/core/reporting/reporting-router.js
@@ -3,10 +3,7 @@ const catchAsyncError = require('express-async-handler');
 const {
     createReportingRepository,
 } = require('./repositories/reporting-repository-factory');
-const {
-    ListIntegrationsReport,
-    KNOWN_STATUSES,
-} = require('./use-cases/list-integrations-report');
+const { ListIntegrationsReport } = require('./use-cases/list-integrations-report');
 
 const validateApiKey = (req, res, next) => {
     const apiKey = req.headers['x-frigg-reporting-api-key'];
@@ -39,32 +36,9 @@ function createReportingRouter() {
         '/api/v2/reports/integrations',
         catchAsyncError(async (req, res) => {
             const { status, type, userId } = req.query;
-
-            // 400 on malformed params; an object/array value would otherwise 500
-            // from the Prisma layer.
-            for (const [key, value] of Object.entries({ status, type, userId })) {
-                if (value !== undefined && typeof value !== 'string') {
-                    return res.status(400).json({
-                        status: 'error',
-                        message: `Invalid query parameter '${key}': expected a string`,
-                    });
-                }
-            }
-            if (status && !KNOWN_STATUSES.includes(status)) {
-                return res.status(400).json({
-                    status: 'error',
-                    message: `Invalid status '${status}'. Expected one of: ${KNOWN_STATUSES.join(
-                        ', '
-                    )}`,
-                });
-            }
-
-            const result = await listIntegrationsReport.execute({
-                status: status || undefined,
-                type: type || undefined,
-                userId: userId || undefined,
-            });
-            res.json(result);
+            res.json(
+                await listIntegrationsReport.execute({ status, type, userId })
+            );
         })
     );
 

--- a/packages/core/reporting/reporting-router.test.js
+++ b/packages/core/reporting/reporting-router.test.js
@@ -107,27 +107,7 @@ describe('reporting-router', () => {
         const integrationsHandler = () =>
             findRouteHandler(router, '/api/v2/reports/integrations');
 
-        it('returns 400 for an object-shaped query param', async () => {
-            const res = mockRes();
-            await integrationsHandler()(
-                { query: { userId: { $oid: 'x' } } },
-                res,
-                jest.fn()
-            );
-            expect(res.status).toHaveBeenCalledWith(400);
-        });
-
-        it('returns 400 for an unknown status value', async () => {
-            const res = mockRes();
-            await integrationsHandler()(
-                { query: { status: 'BOGUS' } },
-                res,
-                jest.fn()
-            );
-            expect(res.status).toHaveBeenCalledWith(400);
-        });
-
-        it('forwards filters and coerces empty strings to undefined', async () => {
+        it('forwards query params to the use case and echoes filters', async () => {
             const res = mockRes();
             await integrationsHandler()(
                 { query: { status: 'ENABLED', type: '', userId: '7' } },

--- a/packages/core/reporting/reporting-router.test.js
+++ b/packages/core/reporting/reporting-router.test.js
@@ -103,5 +103,43 @@ describe('reporting-router', () => {
             expect(body.metrics.total).toBe(1);
             expect(body.metrics.integrations[0].mappedRecordCount).toBe(5);
         });
+
+        const integrationsHandler = () =>
+            findRouteHandler(router, '/api/v2/reports/integrations');
+
+        it('returns 400 for an object-shaped query param', async () => {
+            const res = mockRes();
+            await integrationsHandler()(
+                { query: { userId: { $oid: 'x' } } },
+                res,
+                jest.fn()
+            );
+            expect(res.status).toHaveBeenCalledWith(400);
+        });
+
+        it('returns 400 for an unknown status value', async () => {
+            const res = mockRes();
+            await integrationsHandler()(
+                { query: { status: 'BOGUS' } },
+                res,
+                jest.fn()
+            );
+            expect(res.status).toHaveBeenCalledWith(400);
+        });
+
+        it('forwards filters and coerces empty strings to undefined', async () => {
+            const res = mockRes();
+            await integrationsHandler()(
+                { query: { status: 'ENABLED', type: '', userId: '7' } },
+                res,
+                jest.fn()
+            );
+            const body = res.json.mock.calls[0][0];
+            expect(body.filters).toEqual({
+                status: 'ENABLED',
+                type: null,
+                userId: '7',
+            });
+        });
     });
 });

--- a/packages/core/reporting/reporting-router.test.js
+++ b/packages/core/reporting/reporting-router.test.js
@@ -1,0 +1,107 @@
+process.env.REPORTING_API_KEY = 'test-reporting-key';
+
+jest.mock('./repositories/reporting-repository-factory', () => ({
+    createReportingRepository: jest.fn(() => ({
+        findIntegrationsForReport: jest.fn().mockResolvedValue([
+            {
+                id: '1',
+                type: 'hubspot',
+                status: 'ENABLED',
+                userId: '3',
+                version: '1',
+                moduleCount: 1,
+                errorCount: 0,
+                createdAt: null,
+                updatedAt: null,
+            },
+        ]),
+        countMappingsByIntegrationIds: jest
+            .fn()
+            .mockResolvedValue(new Map([['1', 5]])),
+    })),
+}));
+
+const { createReportingRouter, validateApiKey } = require('./reporting-router');
+
+const mockRes = () => {
+    const res = {};
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+    return res;
+};
+
+const findRouteHandler = (router, path) => {
+    for (const layer of router.stack) {
+        if (layer.route && layer.route.path === path) {
+            const stack = layer.route.stack;
+            return stack[stack.length - 1].handle;
+        }
+    }
+    return null;
+};
+
+describe('reporting-router', () => {
+    describe('validateApiKey', () => {
+        it('returns 401 when the reporting key is missing', () => {
+            const res = mockRes();
+            const next = jest.fn();
+            validateApiKey({ headers: {} }, res, next);
+            expect(res.status).toHaveBeenCalledWith(401);
+            expect(next).not.toHaveBeenCalled();
+        });
+
+        it('returns 401 when the reporting key is wrong', () => {
+            const res = mockRes();
+            const next = jest.fn();
+            validateApiKey(
+                { headers: { 'x-frigg-reporting-api-key': 'nope' } },
+                res,
+                next
+            );
+            expect(res.status).toHaveBeenCalledWith(401);
+            expect(next).not.toHaveBeenCalled();
+        });
+
+        it('calls next when the reporting key matches', () => {
+            const res = mockRes();
+            const next = jest.fn();
+            validateApiKey(
+                { headers: { 'x-frigg-reporting-api-key': 'test-reporting-key' } },
+                res,
+                next
+            );
+            expect(next).toHaveBeenCalled();
+            expect(res.status).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('routes', () => {
+        const router = createReportingRouter();
+
+        it('GET /api/v2/reports returns the index', async () => {
+            const handler = findRouteHandler(router, '/api/v2/reports');
+            expect(handler).toBeTruthy();
+            const res = mockRes();
+            await handler({ query: {} }, res, jest.fn());
+            expect(res.json).toHaveBeenCalledWith({
+                service: 'frigg-core-api',
+                reports: ['integrations'],
+            });
+        });
+
+        it('GET /api/v2/reports/integrations returns the versioned envelope', async () => {
+            const handler = findRouteHandler(
+                router,
+                '/api/v2/reports/integrations'
+            );
+            expect(handler).toBeTruthy();
+            const res = mockRes();
+            await handler({ query: {} }, res, jest.fn());
+            expect(res.json).toHaveBeenCalled();
+            const body = res.json.mock.calls[0][0];
+            expect(body.schemaVersion).toBe(1);
+            expect(body.metrics.total).toBe(1);
+            expect(body.metrics.integrations[0].mappedRecordCount).toBe(5);
+        });
+    });
+});

--- a/packages/core/reporting/repositories/reporting-repository-documentdb.js
+++ b/packages/core/reporting/repositories/reporting-repository-documentdb.js
@@ -61,7 +61,7 @@ class ReportingRepositoryDocumentDB extends ReportingRepositoryInterface {
         // IntegrationMapping.integrationId is persisted as a PLAIN STRING in
         // DocumentDB (see integration-mapping-repository-documentdb.js), so match
         // by string — an ObjectId `$in` would never match and silently yield 0.
-        const stringIds = ids.map((id) => String(id));
+        const stringIds = ids.map(String);
 
         const rows = await this._aggregateDrained('IntegrationMapping', [
             { $match: { integrationId: { $in: stringIds } } },

--- a/packages/core/reporting/repositories/reporting-repository-documentdb.js
+++ b/packages/core/reporting/repositories/reporting-repository-documentdb.js
@@ -28,7 +28,10 @@ class ReportingRepositoryDocumentDB extends ReportingRepositoryInterface {
         if (status) filter.status = status;
         if (userId !== undefined && userId !== null) {
             const objectId = toObjectId(userId);
-            if (objectId) filter.userId = objectId;
+            // A userId was requested but is not a valid id → no matches.
+            // (Do NOT drop the filter, which would return the whole deployment.)
+            if (!objectId) return [];
+            filter.userId = objectId;
         }
 
         const docs = await findMany(this.prisma, 'Integration', filter);
@@ -55,16 +58,18 @@ class ReportingRepositoryDocumentDB extends ReportingRepositoryInterface {
         const counts = new Map();
         if (!ids || ids.length === 0) return counts;
 
-        const objectIds = ids.map((id) => toObjectId(id)).filter(Boolean);
-        if (objectIds.length === 0) return counts;
+        // IntegrationMapping.integrationId is persisted as a PLAIN STRING in
+        // DocumentDB (see integration-mapping-repository-documentdb.js), so match
+        // by string — an ObjectId `$in` would never match and silently yield 0.
+        const stringIds = ids.map((id) => String(id));
 
         const rows = await aggregate(this.prisma, 'IntegrationMapping', [
-            { $match: { integrationId: { $in: objectIds } } },
+            { $match: { integrationId: { $in: stringIds } } },
             { $group: { _id: '$integrationId', count: { $sum: 1 } } },
         ]);
 
         for (const row of rows) {
-            counts.set(fromObjectId(row?._id), row?.count ?? 0);
+            counts.set(String(row?._id), row?.count ?? 0);
         }
         return counts;
     }

--- a/packages/core/reporting/repositories/reporting-repository-documentdb.js
+++ b/packages/core/reporting/repositories/reporting-repository-documentdb.js
@@ -5,18 +5,11 @@ const {
 } = require('./reporting-repository-interface');
 
 const DRAIN_BATCH_SIZE = 1000;
-// Defensive guard so a misbehaving cursor can never loop forever.
 const MAX_BATCHES = 100000;
 
-/**
- * DocumentDB Reporting Repository Adapter
- *
- * DocumentDB has no Prisma `groupBy`/`include`, so it uses raw `$runCommandRaw`.
- * Unlike `documentdb-utils.findMany`/`aggregate` (which only return the cursor's
- * first batch, ~101 docs), the reporting reads must be deployment-complete, so
- * these helpers follow the cursor with `getMore` until it is exhausted. No
- * encrypted field (`mapping`/`data`) is read.
- */
+// Drains cursors via getMore rather than reusing documentdb-utils.findMany/
+// aggregate, which return only the first batch (~101 docs) and would silently
+// truncate a deployment-wide report.
 class ReportingRepositoryDocumentDB extends ReportingRepositoryInterface {
     constructor() {
         super();
@@ -28,8 +21,8 @@ class ReportingRepositoryDocumentDB extends ReportingRepositoryInterface {
         if (status) filter.status = status;
         if (userId !== undefined && userId !== null) {
             const objectId = toObjectId(userId);
-            // A userId was requested but is not a valid id → no matches.
-            // (Do NOT drop the filter, which would return the whole deployment.)
+            // An invalid userId means no matches — must not fall through to an
+            // unfiltered query that returns the whole deployment.
             if (!objectId) return [];
             filter.userId = objectId;
         }
@@ -58,9 +51,8 @@ class ReportingRepositoryDocumentDB extends ReportingRepositoryInterface {
         const counts = new Map();
         if (!ids || ids.length === 0) return counts;
 
-        // IntegrationMapping.integrationId is persisted as a PLAIN STRING in
-        // DocumentDB (see integration-mapping-repository-documentdb.js), so match
-        // by string — an ObjectId `$in` would never match and silently yield 0.
+        // IntegrationMapping.integrationId is stored as a string in DocumentDB,
+        // so match by string — an ObjectId $in would never match (always 0).
         const stringIds = ids.map(String);
 
         const rows = await this._aggregateDrained('IntegrationMapping', [

--- a/packages/core/reporting/repositories/reporting-repository-documentdb.js
+++ b/packages/core/reporting/repositories/reporting-repository-documentdb.js
@@ -1,0 +1,79 @@
+const { prisma } = require('../../database/prisma');
+const {
+    toObjectId,
+    fromObjectId,
+    findMany,
+    aggregate,
+} = require('../../database/documentdb-utils');
+const {
+    ReportingRepositoryInterface,
+} = require('./reporting-repository-interface');
+
+/**
+ * DocumentDB Reporting Repository Adapter
+ *
+ * DocumentDB has no Prisma `groupBy`/`include`, so it uses raw `$runCommandRaw`
+ * helpers: a filtered `find` for the integration list (module count comes from
+ * the `entityIds` array on the document) and a `$group` aggregation for mapping
+ * counts. No encrypted field (`mapping`/`data`) is read.
+ */
+class ReportingRepositoryDocumentDB extends ReportingRepositoryInterface {
+    constructor() {
+        super();
+        this.prisma = prisma;
+    }
+
+    async findIntegrationsForReport({ status, userId } = {}) {
+        const filter = {};
+        if (status) filter.status = status;
+        if (userId !== undefined && userId !== null) {
+            const objectId = toObjectId(userId);
+            if (objectId) filter.userId = objectId;
+        }
+
+        const docs = await findMany(this.prisma, 'Integration', filter);
+
+        return docs.map((doc) => {
+            const errors = this._extractErrors(doc);
+            return {
+                id: fromObjectId(doc?._id),
+                type: doc?.config?.type ?? null,
+                status: doc?.status ?? null,
+                userId: fromObjectId(doc?.userId) ?? null,
+                version: doc?.version ?? null,
+                errorCount: Array.isArray(errors) ? errors.length : 0,
+                moduleCount: Array.isArray(doc?.entityIds)
+                    ? doc.entityIds.length
+                    : 0,
+                createdAt: doc?.createdAt ?? null,
+                updatedAt: doc?.updatedAt ?? null,
+            };
+        });
+    }
+
+    async countMappingsByIntegrationIds(ids = []) {
+        const counts = new Map();
+        if (!ids || ids.length === 0) return counts;
+
+        const objectIds = ids.map((id) => toObjectId(id)).filter(Boolean);
+        if (objectIds.length === 0) return counts;
+
+        const rows = await aggregate(this.prisma, 'IntegrationMapping', [
+            { $match: { integrationId: { $in: objectIds } } },
+            { $group: { _id: '$integrationId', count: { $sum: 1 } } },
+        ]);
+
+        for (const row of rows) {
+            counts.set(fromObjectId(row?._id), row?.count ?? 0);
+        }
+        return counts;
+    }
+
+    _extractErrors(doc) {
+        if (Array.isArray(doc?.errors)) return doc.errors;
+        if (Array.isArray(doc?.messages?.errors)) return doc.messages.errors;
+        return [];
+    }
+}
+
+module.exports = { ReportingRepositoryDocumentDB };

--- a/packages/core/reporting/repositories/reporting-repository-documentdb.js
+++ b/packages/core/reporting/repositories/reporting-repository-documentdb.js
@@ -1,21 +1,21 @@
 const { prisma } = require('../../database/prisma');
-const {
-    toObjectId,
-    fromObjectId,
-    findMany,
-    aggregate,
-} = require('../../database/documentdb-utils');
+const { toObjectId, fromObjectId } = require('../../database/documentdb-utils');
 const {
     ReportingRepositoryInterface,
 } = require('./reporting-repository-interface');
 
+const DRAIN_BATCH_SIZE = 1000;
+// Defensive guard so a misbehaving cursor can never loop forever.
+const MAX_BATCHES = 100000;
+
 /**
  * DocumentDB Reporting Repository Adapter
  *
- * DocumentDB has no Prisma `groupBy`/`include`, so it uses raw `$runCommandRaw`
- * helpers: a filtered `find` for the integration list (module count comes from
- * the `entityIds` array on the document) and a `$group` aggregation for mapping
- * counts. No encrypted field (`mapping`/`data`) is read.
+ * DocumentDB has no Prisma `groupBy`/`include`, so it uses raw `$runCommandRaw`.
+ * Unlike `documentdb-utils.findMany`/`aggregate` (which only return the cursor's
+ * first batch, ~101 docs), the reporting reads must be deployment-complete, so
+ * these helpers follow the cursor with `getMore` until it is exhausted. No
+ * encrypted field (`mapping`/`data`) is read.
  */
 class ReportingRepositoryDocumentDB extends ReportingRepositoryInterface {
     constructor() {
@@ -34,7 +34,7 @@ class ReportingRepositoryDocumentDB extends ReportingRepositoryInterface {
             filter.userId = objectId;
         }
 
-        const docs = await findMany(this.prisma, 'Integration', filter);
+        const docs = await this._findDrained('Integration', filter);
 
         return docs.map((doc) => {
             const errors = this._extractErrors(doc);
@@ -63,7 +63,7 @@ class ReportingRepositoryDocumentDB extends ReportingRepositoryInterface {
         // by string — an ObjectId `$in` would never match and silently yield 0.
         const stringIds = ids.map((id) => String(id));
 
-        const rows = await aggregate(this.prisma, 'IntegrationMapping', [
+        const rows = await this._aggregateDrained('IntegrationMapping', [
             { $match: { integrationId: { $in: stringIds } } },
             { $group: { _id: '$integrationId', count: { $sum: 1 } } },
         ]);
@@ -72,6 +72,57 @@ class ReportingRepositoryDocumentDB extends ReportingRepositoryInterface {
             counts.set(String(row?._id), row?.count ?? 0);
         }
         return counts;
+    }
+
+    async _findDrained(collection, filter) {
+        const first = await this.prisma.$runCommandRaw({
+            find: collection,
+            filter,
+            batchSize: DRAIN_BATCH_SIZE,
+        });
+        return this._drain(collection, first);
+    }
+
+    async _aggregateDrained(collection, pipeline) {
+        const first = await this.prisma.$runCommandRaw({
+            aggregate: collection,
+            pipeline,
+            cursor: { batchSize: DRAIN_BATCH_SIZE },
+        });
+        return this._drain(collection, first);
+    }
+
+    async _drain(collection, firstResult) {
+        const cursor = firstResult?.cursor || {};
+        const docs = [...(cursor.firstBatch || [])];
+        let cursorId = cursor.id;
+        let batches = 0;
+
+        while (this._cursorOpen(cursorId) && batches < MAX_BATCHES) {
+            batches += 1;
+            const next = await this.prisma.$runCommandRaw({
+                getMore: cursorId,
+                collection,
+                batchSize: DRAIN_BATCH_SIZE,
+            });
+            const nextCursor = next?.cursor || {};
+            const nextBatch = nextCursor.nextBatch || [];
+            docs.push(...nextBatch);
+            cursorId = nextCursor.id;
+            if (nextBatch.length === 0) break;
+        }
+        return docs;
+    }
+
+    _cursorOpen(id) {
+        if (id === undefined || id === null) return false;
+        if (typeof id === 'number') return id !== 0;
+        if (typeof id === 'bigint') return id !== 0n;
+        // Extended JSON can surface a 64-bit cursor id as { $numberLong: "..." }.
+        if (typeof id === 'object' && id.$numberLong !== undefined) {
+            return id.$numberLong !== '0';
+        }
+        return String(id) !== '0';
     }
 
     _extractErrors(doc) {

--- a/packages/core/reporting/repositories/reporting-repository-documentdb.test.js
+++ b/packages/core/reporting/repositories/reporting-repository-documentdb.test.js
@@ -1,17 +1,21 @@
-jest.mock('../../database/prisma', () => ({ prisma: {} }));
+const mockRunCommandRaw = jest.fn();
+
+jest.mock('../../database/prisma', () => ({
+    prisma: { $runCommandRaw: mockRunCommandRaw },
+}));
 jest.mock('../../database/documentdb-utils', () => ({
     toObjectId: jest.fn((v) => (v == null || v === '' ? undefined : `oid:${v}`)),
     fromObjectId: jest.fn((v) =>
         typeof v === 'string' && v.startsWith('oid:') ? v.slice(4) : v
     ),
-    findMany: jest.fn(),
-    aggregate: jest.fn(),
 }));
 
-const { findMany, aggregate } = require('../../database/documentdb-utils');
 const {
     ReportingRepositoryDocumentDB,
 } = require('./reporting-repository-documentdb');
+
+// Single-batch cursor result (id 0 → exhausted, no getMore).
+const singleBatch = (firstBatch) => ({ cursor: { firstBatch, id: 0 } });
 
 describe('ReportingRepositoryDocumentDB', () => {
     let repo;
@@ -22,27 +26,30 @@ describe('ReportingRepositoryDocumentDB', () => {
     });
 
     it('filters by status/userId and derives moduleCount from entityIds', async () => {
-        findMany.mockResolvedValue([
-            {
-                _id: 'i1',
-                config: { type: 'hubspot' },
-                status: 'ENABLED',
-                userId: 'u1',
-                version: '1',
-                errors: [{ title: 'boom' }],
-                entityIds: ['e1', 'e2', 'e3'],
-                createdAt: null,
-                updatedAt: null,
-            },
-        ]);
+        mockRunCommandRaw.mockResolvedValueOnce(
+            singleBatch([
+                {
+                    _id: 'i1',
+                    config: { type: 'hubspot' },
+                    status: 'ENABLED',
+                    userId: 'u1',
+                    version: '1',
+                    errors: [{ title: 'boom' }],
+                    entityIds: ['e1', 'e2', 'e3'],
+                    createdAt: null,
+                    updatedAt: null,
+                },
+            ])
+        );
 
         const rows = await repo.findIntegrationsForReport({
             status: 'ENABLED',
             userId: 'u1',
         });
 
-        const filterArg = findMany.mock.calls[0][2];
-        expect(filterArg).toEqual({ status: 'ENABLED', userId: 'oid:u1' });
+        const command = mockRunCommandRaw.mock.calls[0][0];
+        expect(command.find).toBe('Integration');
+        expect(command.filter).toEqual({ status: 'ENABLED', userId: 'oid:u1' });
         expect(rows[0]).toMatchObject({
             id: 'i1',
             type: 'hubspot',
@@ -51,24 +58,47 @@ describe('ReportingRepositoryDocumentDB', () => {
         });
     });
 
-    it('returns an empty list (does not drop the filter) when userId is not a valid id', async () => {
+    it('returns an empty list (does not query) when userId is not a valid id', async () => {
         const rows = await repo.findIntegrationsForReport({ userId: '' });
         expect(rows).toEqual([]);
-        expect(findMany).not.toHaveBeenCalled();
+        expect(mockRunCommandRaw).not.toHaveBeenCalled();
     });
 
-    it('counts mappings by matching integrationId as a STRING (it is stored as a string)', async () => {
-        aggregate.mockResolvedValue([{ _id: 'i1', count: 9 }]);
+    it('drains the cursor across multiple batches (does not stop at firstBatch)', async () => {
+        mockRunCommandRaw
+            .mockResolvedValueOnce({
+                cursor: {
+                    firstBatch: [{ _id: 'i1', entityIds: [] }],
+                    id: { $numberLong: '42' },
+                },
+            })
+            .mockResolvedValueOnce({
+                cursor: { nextBatch: [{ _id: 'i2', entityIds: [] }], id: 0 },
+            });
+
+        const rows = await repo.findIntegrationsForReport({});
+
+        expect(rows.map((r) => r.id)).toEqual(['i1', 'i2']);
+        // first command = find, second command = getMore on the open cursor
+        expect(mockRunCommandRaw.mock.calls[0][0].find).toBe('Integration');
+        const getMore = mockRunCommandRaw.mock.calls[1][0];
+        expect(getMore.getMore).toEqual({ $numberLong: '42' });
+        expect(getMore.collection).toBe('Integration');
+    });
+
+    it('counts mappings by matching integrationId as a STRING via aggregation', async () => {
+        mockRunCommandRaw.mockResolvedValueOnce(
+            singleBatch([{ _id: 'i1', count: 9 }])
+        );
 
         const counts = await repo.countMappingsByIntegrationIds(['i1']);
 
-        const [, collection, pipeline] = aggregate.mock.calls[0];
-        expect(collection).toBe('IntegrationMapping');
-        // string match, NOT toObjectId — matches how the mapping writer persists it
-        expect(pipeline[0]).toEqual({
+        const command = mockRunCommandRaw.mock.calls[0][0];
+        expect(command.aggregate).toBe('IntegrationMapping');
+        expect(command.pipeline[0]).toEqual({
             $match: { integrationId: { $in: ['i1'] } },
         });
-        expect(pipeline[1]).toEqual({
+        expect(command.pipeline[1]).toEqual({
             $group: { _id: '$integrationId', count: { $sum: 1 } },
         });
         expect(counts.get('i1')).toBe(9);

--- a/packages/core/reporting/repositories/reporting-repository-documentdb.test.js
+++ b/packages/core/reporting/repositories/reporting-repository-documentdb.test.js
@@ -1,0 +1,66 @@
+jest.mock('../../database/prisma', () => ({ prisma: {} }));
+jest.mock('../../database/documentdb-utils', () => ({
+    toObjectId: jest.fn((v) => (v == null || v === '' ? undefined : `oid:${v}`)),
+    fromObjectId: jest.fn((v) =>
+        typeof v === 'string' && v.startsWith('oid:') ? v.slice(4) : v
+    ),
+    findMany: jest.fn(),
+    aggregate: jest.fn(),
+}));
+
+const { findMany, aggregate } = require('../../database/documentdb-utils');
+const {
+    ReportingRepositoryDocumentDB,
+} = require('./reporting-repository-documentdb');
+
+describe('ReportingRepositoryDocumentDB', () => {
+    let repo;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        repo = new ReportingRepositoryDocumentDB();
+    });
+
+    it('filters by status/userId and derives moduleCount from entityIds', async () => {
+        findMany.mockResolvedValue([
+            {
+                _id: 'i1',
+                config: { type: 'hubspot' },
+                status: 'ENABLED',
+                userId: 'u1',
+                version: '1',
+                errors: [{ title: 'boom' }],
+                entityIds: ['e1', 'e2', 'e3'],
+                createdAt: null,
+                updatedAt: null,
+            },
+        ]);
+
+        const rows = await repo.findIntegrationsForReport({
+            status: 'ENABLED',
+            userId: 'u1',
+        });
+
+        const filterArg = findMany.mock.calls[0][2];
+        expect(filterArg).toEqual({ status: 'ENABLED', userId: 'oid:u1' });
+        expect(rows[0]).toMatchObject({
+            id: 'i1',
+            type: 'hubspot',
+            moduleCount: 3,
+            errorCount: 1,
+        });
+    });
+
+    it('counts mappings with a $group aggregation pipeline', async () => {
+        aggregate.mockResolvedValue([{ _id: 'oid:i1', count: 9 }]);
+
+        const counts = await repo.countMappingsByIntegrationIds(['i1']);
+
+        const [, collection, pipeline] = aggregate.mock.calls[0];
+        expect(collection).toBe('IntegrationMapping');
+        expect(pipeline[1]).toEqual({
+            $group: { _id: '$integrationId', count: { $sum: 1 } },
+        });
+        expect(counts.get('i1')).toBe(9);
+    });
+});

--- a/packages/core/reporting/repositories/reporting-repository-documentdb.test.js
+++ b/packages/core/reporting/repositories/reporting-repository-documentdb.test.js
@@ -51,13 +51,23 @@ describe('ReportingRepositoryDocumentDB', () => {
         });
     });
 
-    it('counts mappings with a $group aggregation pipeline', async () => {
-        aggregate.mockResolvedValue([{ _id: 'oid:i1', count: 9 }]);
+    it('returns an empty list (does not drop the filter) when userId is not a valid id', async () => {
+        const rows = await repo.findIntegrationsForReport({ userId: '' });
+        expect(rows).toEqual([]);
+        expect(findMany).not.toHaveBeenCalled();
+    });
+
+    it('counts mappings by matching integrationId as a STRING (it is stored as a string)', async () => {
+        aggregate.mockResolvedValue([{ _id: 'i1', count: 9 }]);
 
         const counts = await repo.countMappingsByIntegrationIds(['i1']);
 
         const [, collection, pipeline] = aggregate.mock.calls[0];
         expect(collection).toBe('IntegrationMapping');
+        // string match, NOT toObjectId — matches how the mapping writer persists it
+        expect(pipeline[0]).toEqual({
+            $match: { integrationId: { $in: ['i1'] } },
+        });
         expect(pipeline[1]).toEqual({
             $group: { _id: '$integrationId', count: { $sum: 1 } },
         });

--- a/packages/core/reporting/repositories/reporting-repository-factory.js
+++ b/packages/core/reporting/repositories/reporting-repository-factory.js
@@ -7,12 +7,6 @@ const {
 } = require('./reporting-repository-documentdb');
 const config = require('../../database/config');
 
-/**
- * Reporting Repository Factory
- * Creates the appropriate reporting adapter based on database type.
- *
- * @returns {ReportingRepositoryInterface} Configured repository adapter
- */
 function createReportingRepository() {
     const dbType = config.DB_TYPE;
 
@@ -35,7 +29,6 @@ function createReportingRepository() {
 
 module.exports = {
     createReportingRepository,
-    // Export adapters for direct testing
     ReportingRepositoryMongo,
     ReportingRepositoryPostgres,
     ReportingRepositoryDocumentDB,

--- a/packages/core/reporting/repositories/reporting-repository-factory.js
+++ b/packages/core/reporting/repositories/reporting-repository-factory.js
@@ -1,0 +1,42 @@
+const { ReportingRepositoryMongo } = require('./reporting-repository-mongo');
+const {
+    ReportingRepositoryPostgres,
+} = require('./reporting-repository-postgres');
+const {
+    ReportingRepositoryDocumentDB,
+} = require('./reporting-repository-documentdb');
+const config = require('../../database/config');
+
+/**
+ * Reporting Repository Factory
+ * Creates the appropriate reporting adapter based on database type.
+ *
+ * @returns {ReportingRepositoryInterface} Configured repository adapter
+ */
+function createReportingRepository() {
+    const dbType = config.DB_TYPE;
+
+    switch (dbType) {
+        case 'mongodb':
+            return new ReportingRepositoryMongo();
+
+        case 'postgresql':
+            return new ReportingRepositoryPostgres();
+
+        case 'documentdb':
+            return new ReportingRepositoryDocumentDB();
+
+        default:
+            throw new Error(
+                `Unsupported database type: ${dbType}. Supported values: 'mongodb', 'documentdb', 'postgresql'`
+            );
+    }
+}
+
+module.exports = {
+    createReportingRepository,
+    // Export adapters for direct testing
+    ReportingRepositoryMongo,
+    ReportingRepositoryPostgres,
+    ReportingRepositoryDocumentDB,
+};

--- a/packages/core/reporting/repositories/reporting-repository-interface.js
+++ b/packages/core/reporting/repositories/reporting-repository-interface.js
@@ -1,0 +1,52 @@
+/**
+ * Reporting Repository Interface
+ * Abstract base class defining the contract for read-only reporting adapters.
+ *
+ * Port in Hexagonal Architecture:
+ * - The reporting use cases depend on this abstraction
+ * - Concrete adapters (PostgreSQL, MongoDB, DocumentDB) implement it
+ * - Adapters expose only aggregate/projection reads — never decrypting
+ *   encrypted fields (mapping/data); counts use passthrough operations.
+ *
+ * @abstract
+ */
+class ReportingRepositoryInterface {
+    /**
+     * List integrations (deployment-wide) for reporting, optionally filtered.
+     *
+     * @param {{ status?: string, userId?: string }} [filter]
+     * @returns {Promise<Array<{
+     *   id: string,
+     *   type: string|null,
+     *   status: string|null,
+     *   userId: string|null,
+     *   version: string|null,
+     *   errorCount: number,
+     *   moduleCount: number,
+     *   createdAt: (Date|string|null),
+     *   updatedAt: (Date|string|null),
+     * }>>}
+     * @abstract
+     */
+    async findIntegrationsForReport(filter) {
+        throw new Error(
+            'Method findIntegrationsForReport must be implemented by subclass'
+        );
+    }
+
+    /**
+     * Count IntegrationMapping rows per integration id (passthrough count — the
+     * encrypted `mapping` field is never read).
+     *
+     * @param {Array<string>} ids - Integration ids
+     * @returns {Promise<Map<string, number>>} Map of integration id -> mapping count
+     * @abstract
+     */
+    async countMappingsByIntegrationIds(ids) {
+        throw new Error(
+            'Method countMappingsByIntegrationIds must be implemented by subclass'
+        );
+    }
+}
+
+module.exports = { ReportingRepositoryInterface };

--- a/packages/core/reporting/repositories/reporting-repository-interface.js
+++ b/packages/core/reporting/repositories/reporting-repository-interface.js
@@ -1,47 +1,11 @@
-/**
- * Reporting Repository Interface
- * Abstract base class defining the contract for read-only reporting adapters.
- *
- * Port in Hexagonal Architecture:
- * - The reporting use cases depend on this abstraction
- * - Concrete adapters (PostgreSQL, MongoDB, DocumentDB) implement it
- * - Adapters expose only aggregate/projection reads — never decrypting
- *   encrypted fields (mapping/data); counts use passthrough operations.
- *
- * @abstract
- */
 class ReportingRepositoryInterface {
-    /**
-     * List integrations (deployment-wide) for reporting, optionally filtered.
-     *
-     * @param {{ status?: string, userId?: string }} [filter]
-     * @returns {Promise<Array<{
-     *   id: string,
-     *   type: string|null,
-     *   status: string|null,
-     *   userId: string|null,
-     *   version: string|null,
-     *   errorCount: number,
-     *   moduleCount: number,
-     *   createdAt: (Date|string|null),
-     *   updatedAt: (Date|string|null),
-     * }>>}
-     * @abstract
-     */
+    // returns: [{ id, type, status, userId, version, errorCount, moduleCount, createdAt, updatedAt }]
     async findIntegrationsForReport(filter) {
         throw new Error(
             'Method findIntegrationsForReport must be implemented by subclass'
         );
     }
 
-    /**
-     * Count IntegrationMapping rows per integration id (passthrough count — the
-     * encrypted `mapping` field is never read).
-     *
-     * @param {Array<string>} ids - Integration ids
-     * @returns {Promise<Map<string, number>>} Map of integration id -> mapping count
-     * @abstract
-     */
     async countMappingsByIntegrationIds(ids) {
         throw new Error(
             'Method countMappingsByIntegrationIds must be implemented by subclass'

--- a/packages/core/reporting/repositories/reporting-repository-interface.test.js
+++ b/packages/core/reporting/repositories/reporting-repository-interface.test.js
@@ -1,0 +1,19 @@
+const {
+    ReportingRepositoryInterface,
+} = require('./reporting-repository-interface');
+
+describe('ReportingRepositoryInterface', () => {
+    const repo = new ReportingRepositoryInterface();
+
+    it('findIntegrationsForReport is abstract', async () => {
+        await expect(repo.findIntegrationsForReport({})).rejects.toThrow(
+            /must be implemented by subclass/
+        );
+    });
+
+    it('countMappingsByIntegrationIds is abstract', async () => {
+        await expect(repo.countMappingsByIntegrationIds([])).rejects.toThrow(
+            /must be implemented by subclass/
+        );
+    });
+});

--- a/packages/core/reporting/repositories/reporting-repository-mongo.js
+++ b/packages/core/reporting/repositories/reporting-repository-mongo.js
@@ -3,14 +3,6 @@ const {
     ReportingRepositoryInterface,
 } = require('./reporting-repository-interface');
 
-/**
- * MongoDB Reporting Repository Adapter
- *
- * MongoDB-specific characteristics:
- * - String ObjectId ids (no conversion needed)
- * - Reads only non-encrypted scalar fields + entity ids; mapping counts use
- *   `groupBy` (encryption-extension passthrough), so nothing is ever decrypted.
- */
 class ReportingRepositoryMongo extends ReportingRepositoryInterface {
     constructor() {
         super();

--- a/packages/core/reporting/repositories/reporting-repository-mongo.js
+++ b/packages/core/reporting/repositories/reporting-repository-mongo.js
@@ -1,0 +1,62 @@
+const { prisma } = require('../../database/prisma');
+const {
+    ReportingRepositoryInterface,
+} = require('./reporting-repository-interface');
+
+/**
+ * MongoDB Reporting Repository Adapter
+ *
+ * MongoDB-specific characteristics:
+ * - String ObjectId ids (no conversion needed)
+ * - Reads only non-encrypted scalar fields + entity ids; mapping counts use
+ *   `groupBy` (encryption-extension passthrough), so nothing is ever decrypted.
+ */
+class ReportingRepositoryMongo extends ReportingRepositoryInterface {
+    constructor() {
+        super();
+        this.prisma = prisma;
+    }
+
+    async findIntegrationsForReport({ status, userId } = {}) {
+        const where = {};
+        if (status) where.status = status;
+        if (userId !== undefined && userId !== null) where.userId = userId;
+
+        const integrations = await this.prisma.integration.findMany({
+            where,
+            include: { entities: { select: { id: true } } },
+        });
+
+        return integrations.map((integration) => ({
+            id: integration.id,
+            type: integration.config?.type ?? null,
+            status: integration.status ?? null,
+            userId: integration.userId ?? null,
+            version: integration.version ?? null,
+            errorCount: Array.isArray(integration.errors)
+                ? integration.errors.length
+                : 0,
+            moduleCount: integration.entities?.length ?? 0,
+            createdAt: integration.createdAt ?? null,
+            updatedAt: integration.updatedAt ?? null,
+        }));
+    }
+
+    async countMappingsByIntegrationIds(ids = []) {
+        const counts = new Map();
+        if (!ids || ids.length === 0) return counts;
+
+        const groups = await this.prisma.integrationMapping.groupBy({
+            by: ['integrationId'],
+            where: { integrationId: { in: ids } },
+            _count: { _all: true },
+        });
+
+        for (const group of groups) {
+            counts.set(group.integrationId, group._count._all);
+        }
+        return counts;
+    }
+}
+
+module.exports = { ReportingRepositoryMongo };

--- a/packages/core/reporting/repositories/reporting-repository-mongo.test.js
+++ b/packages/core/reporting/repositories/reporting-repository-mongo.test.js
@@ -1,0 +1,64 @@
+jest.mock('../../database/prisma', () => ({
+    prisma: {
+        integration: { findMany: jest.fn() },
+        integrationMapping: { groupBy: jest.fn() },
+    },
+}));
+
+const { prisma } = require('../../database/prisma');
+const { ReportingRepositoryMongo } = require('./reporting-repository-mongo');
+
+describe('ReportingRepositoryMongo', () => {
+    let repo;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        repo = new ReportingRepositoryMongo();
+    });
+
+    it('uses string ids in the where clause and maps rows', async () => {
+        prisma.integration.findMany.mockResolvedValue([
+            {
+                id: 'abc',
+                config: { type: 'salesforce' },
+                status: 'ERROR',
+                userId: 'u1',
+                version: '1',
+                errors: [{}, {}],
+                entities: [{ id: 'e1' }],
+                createdAt: null,
+                updatedAt: null,
+            },
+        ]);
+
+        const rows = await repo.findIntegrationsForReport({
+            status: 'ERROR',
+            userId: 'u1',
+        });
+
+        expect(prisma.integration.findMany.mock.calls[0][0].where).toEqual({
+            status: 'ERROR',
+            userId: 'u1',
+        });
+        expect(rows[0]).toMatchObject({
+            id: 'abc',
+            type: 'salesforce',
+            status: 'ERROR',
+            moduleCount: 1,
+            errorCount: 2,
+        });
+    });
+
+    it('keys the mapping-count map by string id', async () => {
+        prisma.integrationMapping.groupBy.mockResolvedValue([
+            { integrationId: 'abc', _count: { _all: 7 } },
+        ]);
+
+        const counts = await repo.countMappingsByIntegrationIds(['abc']);
+
+        expect(prisma.integrationMapping.groupBy.mock.calls[0][0].where).toEqual(
+            { integrationId: { in: ['abc'] } }
+        );
+        expect(counts.get('abc')).toBe(7);
+    });
+});

--- a/packages/core/reporting/repositories/reporting-repository-postgres.js
+++ b/packages/core/reporting/repositories/reporting-repository-postgres.js
@@ -3,32 +3,16 @@ const {
     ReportingRepositoryInterface,
 } = require('./reporting-repository-interface');
 
-/**
- * PostgreSQL Reporting Repository Adapter
- *
- * PostgreSQL-specific characteristics:
- * - Int IDs with autoincrement; converted to/from strings at the app boundary
- * - Many-to-many entities via implicit join table (counted via included relation)
- * - Reads only non-encrypted scalar fields + entity ids; mapping counts use
- *   `groupBy` (encryption-extension passthrough), so nothing is ever decrypted.
- */
 class ReportingRepositoryPostgres extends ReportingRepositoryInterface {
     constructor() {
         super();
         this.prisma = prisma;
     }
 
-    /**
-     * Convert string ID to integer for PostgreSQL queries
-     * @private
-     * @param {string|number|null|undefined} id - ID to convert
-     * @returns {number|null|undefined} Integer ID or null/undefined
-     * @throws {Error} If ID cannot be converted to integer
-     */
     _convertId(id) {
         if (id === null || id === undefined) return id;
-        // Require an exact integer string — `parseInt` would otherwise coerce
-        // '12abc'/'12.9' to 12 and silently return the wrong record.
+        // Reject anything that isn't an exact integer — parseInt would coerce
+        // '12abc'/'12.9' to 12 and return the wrong record.
         const str = String(id).trim();
         if (!/^-?\d+$/.test(str)) {
             throw new TypeError(

--- a/packages/core/reporting/repositories/reporting-repository-postgres.js
+++ b/packages/core/reporting/repositories/reporting-repository-postgres.js
@@ -31,9 +31,11 @@ class ReportingRepositoryPostgres extends ReportingRepositoryInterface {
         // '12abc'/'12.9' to 12 and silently return the wrong record.
         const str = String(id).trim();
         if (!/^-?\d+$/.test(str)) {
-            throw new Error(`Invalid ID: ${id} cannot be converted to integer`);
+            throw new TypeError(
+                `Invalid ID: ${id} cannot be converted to integer`
+            );
         }
-        return parseInt(str, 10);
+        return Number.parseInt(str, 10);
     }
 
     async findIntegrationsForReport({ status, userId } = {}) {

--- a/packages/core/reporting/repositories/reporting-repository-postgres.js
+++ b/packages/core/reporting/repositories/reporting-repository-postgres.js
@@ -9,19 +9,6 @@ class ReportingRepositoryPostgres extends ReportingRepositoryInterface {
         this.prisma = prisma;
     }
 
-    _convertId(id) {
-        if (id === null || id === undefined) return id;
-        // Reject anything that isn't an exact integer — parseInt would coerce
-        // '12abc'/'12.9' to 12 and return the wrong record.
-        const str = String(id).trim();
-        if (!/^-?\d+$/.test(str)) {
-            throw new TypeError(
-                `Invalid ID: ${id} cannot be converted to integer`
-            );
-        }
-        return Number.parseInt(str, 10);
-    }
-
     async findIntegrationsForReport({ status, userId } = {}) {
         const where = {};
         if (status) where.status = status;
@@ -64,6 +51,19 @@ class ReportingRepositoryPostgres extends ReportingRepositoryInterface {
             counts.set(group.integrationId?.toString(), group._count._all);
         }
         return counts;
+    }
+
+    _convertId(id) {
+        if (id === null || id === undefined) return id;
+        // Reject anything that isn't an exact integer — parseInt would coerce
+        // '12abc'/'12.9' to 12 and return the wrong record.
+        const str = String(id).trim();
+        if (!/^-?\d+$/.test(str)) {
+            throw new TypeError(
+                `Invalid ID: ${id} cannot be converted to integer`
+            );
+        }
+        return Number.parseInt(str, 10);
     }
 }
 

--- a/packages/core/reporting/repositories/reporting-repository-postgres.js
+++ b/packages/core/reporting/repositories/reporting-repository-postgres.js
@@ -1,0 +1,75 @@
+const { prisma } = require('../../database/prisma');
+const {
+    ReportingRepositoryInterface,
+} = require('./reporting-repository-interface');
+
+/**
+ * PostgreSQL Reporting Repository Adapter
+ *
+ * PostgreSQL-specific characteristics:
+ * - Int IDs with autoincrement; converted to/from strings at the app boundary
+ * - Many-to-many entities via implicit join table (counted via included relation)
+ * - Reads only non-encrypted scalar fields + entity ids; mapping counts use
+ *   `groupBy` (encryption-extension passthrough), so nothing is ever decrypted.
+ */
+class ReportingRepositoryPostgres extends ReportingRepositoryInterface {
+    constructor() {
+        super();
+        this.prisma = prisma;
+    }
+
+    _convertId(id) {
+        if (id === null || id === undefined) return id;
+        const parsed = parseInt(id, 10);
+        if (isNaN(parsed)) {
+            throw new Error(`Invalid ID: ${id} cannot be converted to integer`);
+        }
+        return parsed;
+    }
+
+    async findIntegrationsForReport({ status, userId } = {}) {
+        const where = {};
+        if (status) where.status = status;
+        if (userId !== undefined && userId !== null) {
+            where.userId = this._convertId(userId);
+        }
+
+        const integrations = await this.prisma.integration.findMany({
+            where,
+            include: { entities: { select: { id: true } } },
+        });
+
+        return integrations.map((integration) => ({
+            id: integration.id?.toString(),
+            type: integration.config?.type ?? null,
+            status: integration.status ?? null,
+            userId: integration.userId?.toString() ?? null,
+            version: integration.version ?? null,
+            errorCount: Array.isArray(integration.errors)
+                ? integration.errors.length
+                : 0,
+            moduleCount: integration.entities?.length ?? 0,
+            createdAt: integration.createdAt ?? null,
+            updatedAt: integration.updatedAt ?? null,
+        }));
+    }
+
+    async countMappingsByIntegrationIds(ids = []) {
+        const counts = new Map();
+        if (!ids || ids.length === 0) return counts;
+
+        const intIds = ids.map((id) => this._convertId(id));
+        const groups = await this.prisma.integrationMapping.groupBy({
+            by: ['integrationId'],
+            where: { integrationId: { in: intIds } },
+            _count: { _all: true },
+        });
+
+        for (const group of groups) {
+            counts.set(group.integrationId?.toString(), group._count._all);
+        }
+        return counts;
+    }
+}
+
+module.exports = { ReportingRepositoryPostgres };

--- a/packages/core/reporting/repositories/reporting-repository-postgres.js
+++ b/packages/core/reporting/repositories/reporting-repository-postgres.js
@@ -27,11 +27,13 @@ class ReportingRepositoryPostgres extends ReportingRepositoryInterface {
      */
     _convertId(id) {
         if (id === null || id === undefined) return id;
-        const parsed = parseInt(id, 10);
-        if (isNaN(parsed)) {
+        // Require an exact integer string — `parseInt` would otherwise coerce
+        // '12abc'/'12.9' to 12 and silently return the wrong record.
+        const str = String(id).trim();
+        if (!/^-?\d+$/.test(str)) {
             throw new Error(`Invalid ID: ${id} cannot be converted to integer`);
         }
-        return parsed;
+        return parseInt(str, 10);
     }
 
     async findIntegrationsForReport({ status, userId } = {}) {

--- a/packages/core/reporting/repositories/reporting-repository-postgres.js
+++ b/packages/core/reporting/repositories/reporting-repository-postgres.js
@@ -18,6 +18,13 @@ class ReportingRepositoryPostgres extends ReportingRepositoryInterface {
         this.prisma = prisma;
     }
 
+    /**
+     * Convert string ID to integer for PostgreSQL queries
+     * @private
+     * @param {string|number|null|undefined} id - ID to convert
+     * @returns {number|null|undefined} Integer ID or null/undefined
+     * @throws {Error} If ID cannot be converted to integer
+     */
     _convertId(id) {
         if (id === null || id === undefined) return id;
         const parsed = parseInt(id, 10);

--- a/packages/core/reporting/repositories/reporting-repository-postgres.test.js
+++ b/packages/core/reporting/repositories/reporting-repository-postgres.test.js
@@ -1,0 +1,87 @@
+jest.mock('../../database/prisma', () => ({
+    prisma: {
+        integration: { findMany: jest.fn() },
+        integrationMapping: { groupBy: jest.fn() },
+    },
+}));
+
+const { prisma } = require('../../database/prisma');
+const {
+    ReportingRepositoryPostgres,
+} = require('./reporting-repository-postgres');
+
+describe('ReportingRepositoryPostgres', () => {
+    let repo;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        repo = new ReportingRepositoryPostgres();
+    });
+
+    it('applies status/userId to the where clause and maps rows (only scalar + entity ids)', async () => {
+        prisma.integration.findMany.mockResolvedValue([
+            {
+                id: 17,
+                config: { type: 'hubspot' },
+                status: 'ENABLED',
+                userId: 3,
+                version: '1.0.0',
+                errors: [],
+                entities: [{ id: 1 }, { id: 2 }],
+                createdAt: new Date('2026-01-01T00:00:00Z'),
+                updatedAt: new Date('2026-01-02T00:00:00Z'),
+            },
+        ]);
+
+        const rows = await repo.findIntegrationsForReport({
+            status: 'ENABLED',
+            userId: '3',
+        });
+
+        const callArg = prisma.integration.findMany.mock.calls[0][0];
+        expect(callArg.where).toEqual({ status: 'ENABLED', userId: 3 });
+        expect(callArg.include).toEqual({ entities: { select: { id: true } } });
+        expect(rows[0]).toMatchObject({
+            id: '17',
+            type: 'hubspot',
+            status: 'ENABLED',
+            userId: '3',
+            moduleCount: 2,
+            errorCount: 0,
+        });
+    });
+
+    it('counts errors from the errors array', async () => {
+        prisma.integration.findMany.mockResolvedValue([
+            {
+                id: 1,
+                config: { type: 'x' },
+                status: 'ERROR',
+                errors: [{ title: 'a' }, { title: 'b' }, { title: 'c' }],
+                entities: [],
+            },
+        ]);
+        const rows = await repo.findIntegrationsForReport({});
+        expect(rows[0].errorCount).toBe(3);
+        expect(rows[0].moduleCount).toBe(0);
+    });
+
+    it('groups mapping counts by integrationId into a Map keyed by string id', async () => {
+        prisma.integrationMapping.groupBy.mockResolvedValue([
+            { integrationId: 17, _count: { _all: 412 } },
+        ]);
+
+        const counts = await repo.countMappingsByIntegrationIds(['17']);
+
+        const arg = prisma.integrationMapping.groupBy.mock.calls[0][0];
+        expect(arg.by).toEqual(['integrationId']);
+        expect(arg.where).toEqual({ integrationId: { in: [17] } });
+        expect(counts.get('17')).toBe(412);
+    });
+
+    it('returns an empty map and skips the query for no ids', async () => {
+        const counts = await repo.countMappingsByIntegrationIds([]);
+        expect(counts.size).toBe(0);
+        expect(prisma.integrationMapping.groupBy).not.toHaveBeenCalled();
+    });
+});

--- a/packages/core/reporting/repositories/reporting-repository-postgres.test.js
+++ b/packages/core/reporting/repositories/reporting-repository-postgres.test.js
@@ -91,6 +91,16 @@ describe('ReportingRepositoryPostgres', () => {
         ).rejects.toThrow(/Invalid ID/);
     });
 
+    it('rejects partially-numeric / decimal userId instead of coercing it', async () => {
+        await expect(
+            repo.findIntegrationsForReport({ userId: '12abc' })
+        ).rejects.toThrow(/Invalid ID/);
+        await expect(
+            repo.findIntegrationsForReport({ userId: '12.9' })
+        ).rejects.toThrow(/Invalid ID/);
+        expect(prisma.integration.findMany).not.toHaveBeenCalled();
+    });
+
     it('throws on a non-numeric id in countMappingsByIntegrationIds', async () => {
         await expect(
             repo.countMappingsByIntegrationIds(['abc'])

--- a/packages/core/reporting/repositories/reporting-repository-postgres.test.js
+++ b/packages/core/reporting/repositories/reporting-repository-postgres.test.js
@@ -84,4 +84,16 @@ describe('ReportingRepositoryPostgres', () => {
         expect(counts.size).toBe(0);
         expect(prisma.integrationMapping.groupBy).not.toHaveBeenCalled();
     });
+
+    it('throws on a non-numeric userId filter', async () => {
+        await expect(
+            repo.findIntegrationsForReport({ userId: 'abc' })
+        ).rejects.toThrow(/Invalid ID/);
+    });
+
+    it('throws on a non-numeric id in countMappingsByIntegrationIds', async () => {
+        await expect(
+            repo.countMappingsByIntegrationIds(['abc'])
+        ).rejects.toThrow(/Invalid ID/);
+    });
 });

--- a/packages/core/reporting/use-cases/index.js
+++ b/packages/core/reporting/use-cases/index.js
@@ -1,0 +1,6 @@
+const {
+    ListIntegrationsReport,
+    SCHEMA_VERSION,
+} = require('./list-integrations-report');
+
+module.exports = { ListIntegrationsReport, SCHEMA_VERSION };

--- a/packages/core/reporting/use-cases/list-integrations-report.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.js
@@ -13,54 +13,12 @@ const KNOWN_STATUSES = [
     'DISABLED',
 ];
 
-function emptyStatusCounts() {
-    return KNOWN_STATUSES.reduce((acc, status) => {
-        acc[status] = 0;
-        return acc;
-    }, {});
-}
-
-function toIso(value) {
-    if (!value) return null;
-    if (value instanceof Date) return value.toISOString();
-    // DocumentDB raw reads surface dates as { $date: ... }
-    if (typeof value === 'object' && value.$date) {
-        const date = new Date(value.$date);
-        return Number.isNaN(date.getTime()) ? null : date.toISOString();
-    }
-    return String(value);
-}
-
 class ListIntegrationsReport {
     constructor({ reportingRepository } = {}) {
         if (!reportingRepository) {
             throw new Error('reportingRepository is required');
         }
         this.reportingRepository = reportingRepository;
-    }
-
-    _validateQuery({ status, type, userId } = {}) {
-        for (const [key, value] of Object.entries({ status, type, userId })) {
-            if (value !== undefined && value !== null && typeof value !== 'string') {
-                throw Boom.badRequest(
-                    `Invalid query parameter '${key}': expected a string`
-                );
-            }
-        }
-        const normalize = (value) => (value ? value : undefined);
-        const normalized = {
-            status: normalize(status),
-            type: normalize(type),
-            userId: normalize(userId),
-        };
-        if (normalized.status && !KNOWN_STATUSES.includes(normalized.status)) {
-            throw Boom.badRequest(
-                `Invalid status '${normalized.status}'. Expected one of: ${KNOWN_STATUSES.join(
-                    ', '
-                )}`
-            );
-        }
-        return normalized;
     }
 
     async execute(query = {}) {
@@ -132,6 +90,48 @@ class ListIntegrationsReport {
             },
         };
     }
+
+    _validateQuery({ status, type, userId } = {}) {
+        for (const [key, value] of Object.entries({ status, type, userId })) {
+            if (value !== undefined && value !== null && typeof value !== 'string') {
+                throw Boom.badRequest(
+                    `Invalid query parameter '${key}': expected a string`
+                );
+            }
+        }
+        const normalize = (value) => (value ? value : undefined);
+        const normalized = {
+            status: normalize(status),
+            type: normalize(type),
+            userId: normalize(userId),
+        };
+        if (normalized.status && !KNOWN_STATUSES.includes(normalized.status)) {
+            throw Boom.badRequest(
+                `Invalid status '${normalized.status}'. Expected one of: ${KNOWN_STATUSES.join(
+                    ', '
+                )}`
+            );
+        }
+        return normalized;
+    }
 }
 
-module.exports = { ListIntegrationsReport, SCHEMA_VERSION, KNOWN_STATUSES };
+function emptyStatusCounts() {
+    return KNOWN_STATUSES.reduce((acc, status) => {
+        acc[status] = 0;
+        return acc;
+    }, {});
+}
+
+function toIso(value) {
+    if (!value) return null;
+    if (value instanceof Date) return value.toISOString();
+    // DocumentDB raw reads surface dates as { $date: ... }
+    if (typeof value === 'object' && value.$date) {
+        const date = new Date(value.$date);
+        return Number.isNaN(date.getTime()) ? null : date.toISOString();
+    }
+    return String(value);
+}
+
+module.exports = { ListIntegrationsReport, SCHEMA_VERSION };

--- a/packages/core/reporting/use-cases/list-integrations-report.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.js
@@ -80,8 +80,10 @@ class ListIntegrationsReport {
         const byStatus = emptyStatusCounts();
         const byTypeMap = new Map();
         for (const integration of integrations) {
-            byStatus[integration.status] =
-                (byStatus[integration.status] ?? 0) + 1;
+            // Bucket under a sentinel when status is missing so a null never
+            // becomes a literal "null" key (only reachable for malformed rows).
+            const statusKey = integration.status ?? 'UNKNOWN';
+            byStatus[statusKey] = (byStatus[statusKey] ?? 0) + 1;
 
             if (!byTypeMap.has(integration.type)) {
                 byTypeMap.set(integration.type, {
@@ -92,8 +94,7 @@ class ListIntegrationsReport {
             }
             const bucket = byTypeMap.get(integration.type);
             bucket.total += 1;
-            bucket.byStatus[integration.status] =
-                (bucket.byStatus[integration.status] ?? 0) + 1;
+            bucket.byStatus[statusKey] = (bucket.byStatus[statusKey] ?? 0) + 1;
         }
 
         return {
@@ -115,4 +116,4 @@ class ListIntegrationsReport {
     }
 }
 
-module.exports = { ListIntegrationsReport, SCHEMA_VERSION };
+module.exports = { ListIntegrationsReport, SCHEMA_VERSION, KNOWN_STATUSES };

--- a/packages/core/reporting/use-cases/list-integrations-report.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.js
@@ -1,0 +1,118 @@
+const SCHEMA_VERSION = 1;
+const SERVICE = 'frigg-core-api';
+
+// Display seed so every known status appears in the output (even at zero).
+// Increments are dynamic, so a NEW IntegrationStatus value added to the schema
+// is still picked up — it just won't be pre-seeded at zero.
+const KNOWN_STATUSES = [
+    'ENABLED',
+    'ERROR',
+    'NEEDS_CONFIG',
+    'PROCESSING',
+    'DISABLED',
+];
+
+function emptyStatusCounts() {
+    return KNOWN_STATUSES.reduce((acc, status) => {
+        acc[status] = 0;
+        return acc;
+    }, {});
+}
+
+function toIso(value) {
+    if (!value) return null;
+    if (value instanceof Date) return value.toISOString();
+    // DocumentDB raw reads can surface extended-JSON dates: { $date: ... }
+    if (typeof value === 'object' && value.$date) {
+        const date = new Date(value.$date);
+        return isNaN(date.getTime()) ? null : date.toISOString();
+    }
+    return String(value);
+}
+
+/**
+ * ListIntegrationsReport
+ *
+ * Read-only, deployment-wide report of integrations: total + status breakdown +
+ * per-type breakdown + lightweight per-integration rows (status, type, userId,
+ * version, moduleCount, errorCount, mappedRecordCount, timestamps).
+ *
+ * `status` and `userId` are pushed to the repository query; `type` is filtered
+ * here (it lives in `config.type`, a JSON path that is not portably groupable).
+ */
+class ListIntegrationsReport {
+    constructor({ reportingRepository } = {}) {
+        if (!reportingRepository) {
+            throw new Error('reportingRepository is required');
+        }
+        this.reportingRepository = reportingRepository;
+    }
+
+    async execute({ status, type, userId } = {}) {
+        const rows = await this.reportingRepository.findIntegrationsForReport({
+            status,
+            userId,
+        });
+
+        const filtered =
+            type === undefined || type === null
+                ? rows
+                : rows.filter((row) => (row.type ?? 'unknown') === type);
+
+        const ids = filtered.map((row) => row.id);
+        const mappingCounts = ids.length
+            ? await this.reportingRepository.countMappingsByIntegrationIds(ids)
+            : new Map();
+
+        const integrations = filtered.map((row) => ({
+            id: row.id,
+            type: row.type ?? 'unknown',
+            status: row.status ?? null,
+            userId: row.userId ?? null,
+            version: row.version ?? null,
+            moduleCount: row.moduleCount ?? 0,
+            errorCount: row.errorCount ?? 0,
+            mappedRecordCount: mappingCounts.get(row.id) ?? 0,
+            createdAt: toIso(row.createdAt),
+            updatedAt: toIso(row.updatedAt),
+        }));
+
+        const byStatus = emptyStatusCounts();
+        const byTypeMap = new Map();
+        for (const integration of integrations) {
+            byStatus[integration.status] =
+                (byStatus[integration.status] ?? 0) + 1;
+
+            if (!byTypeMap.has(integration.type)) {
+                byTypeMap.set(integration.type, {
+                    type: integration.type,
+                    total: 0,
+                    byStatus: emptyStatusCounts(),
+                });
+            }
+            const bucket = byTypeMap.get(integration.type);
+            bucket.total += 1;
+            bucket.byStatus[integration.status] =
+                (bucket.byStatus[integration.status] ?? 0) + 1;
+        }
+
+        return {
+            schemaVersion: SCHEMA_VERSION,
+            service: SERVICE,
+            generatedAt: new Date().toISOString(),
+            filters: {
+                status: status ?? null,
+                type: type ?? null,
+                userId: userId ?? null,
+            },
+            metrics: {
+                total: integrations.length,
+                byStatus,
+                byType: Array.from(byTypeMap.values()),
+                integrations,
+            },
+        };
+    }
+}
+
+module.exports = { ListIntegrationsReport, SCHEMA_VERSION };

--- a/packages/core/reporting/use-cases/list-integrations-report.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.js
@@ -25,7 +25,7 @@ function toIso(value) {
     // DocumentDB raw reads can surface extended-JSON dates: { $date: ... }
     if (typeof value === 'object' && value.$date) {
         const date = new Date(value.$date);
-        return isNaN(date.getTime()) ? null : date.toISOString();
+        return Number.isNaN(date.getTime()) ? null : date.toISOString();
     }
     return String(value);
 }

--- a/packages/core/reporting/use-cases/list-integrations-report.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.js
@@ -1,9 +1,8 @@
 const SCHEMA_VERSION = 1;
 const SERVICE = 'frigg-core-api';
 
-// Display seed so every known status appears in the output (even at zero).
-// Increments are dynamic, so a NEW IntegrationStatus value added to the schema
-// is still picked up — it just won't be pre-seeded at zero.
+// Seeded so every known status appears (even at 0); unknown values added to
+// the schema later are still counted dynamically.
 const KNOWN_STATUSES = [
     'ENABLED',
     'ERROR',
@@ -22,7 +21,7 @@ function emptyStatusCounts() {
 function toIso(value) {
     if (!value) return null;
     if (value instanceof Date) return value.toISOString();
-    // DocumentDB raw reads can surface extended-JSON dates: { $date: ... }
+    // DocumentDB raw reads surface dates as { $date: ... }
     if (typeof value === 'object' && value.$date) {
         const date = new Date(value.$date);
         return Number.isNaN(date.getTime()) ? null : date.toISOString();
@@ -30,16 +29,6 @@ function toIso(value) {
     return String(value);
 }
 
-/**
- * ListIntegrationsReport
- *
- * Read-only, deployment-wide report of integrations: total + status breakdown +
- * per-type breakdown + lightweight per-integration rows (status, type, userId,
- * version, moduleCount, errorCount, mappedRecordCount, timestamps).
- *
- * `status` and `userId` are pushed to the repository query; `type` is filtered
- * here (it lives in `config.type`, a JSON path that is not portably groupable).
- */
 class ListIntegrationsReport {
     constructor({ reportingRepository } = {}) {
         if (!reportingRepository) {
@@ -54,6 +43,8 @@ class ListIntegrationsReport {
             userId,
         });
 
+        // type lives in config.type (a JSON path not portably groupable across
+        // DBs), so it is filtered here rather than in the repository query.
         const filtered =
             type === undefined || type === null
                 ? rows
@@ -80,8 +71,7 @@ class ListIntegrationsReport {
         const byStatus = emptyStatusCounts();
         const byTypeMap = new Map();
         for (const integration of integrations) {
-            // Bucket under a sentinel when status is missing so a null never
-            // becomes a literal "null" key (only reachable for malformed rows).
+            // sentinel so a missing status never becomes a literal "null" key
             const statusKey = integration.status ?? 'UNKNOWN';
             byStatus[statusKey] = (byStatus[statusKey] ?? 0) + 1;
 

--- a/packages/core/reporting/use-cases/list-integrations-report.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.js
@@ -99,7 +99,7 @@ class ListIntegrationsReport {
                 );
             }
         }
-        const normalize = (value) => (value ? value : undefined);
+        const normalize = (value) => value || undefined;
         const normalized = {
             status: normalize(status),
             type: normalize(type),

--- a/packages/core/reporting/use-cases/list-integrations-report.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.js
@@ -1,3 +1,5 @@
+const Boom = require('@hapi/boom');
+
 const SCHEMA_VERSION = 1;
 const SERVICE = 'frigg-core-api';
 
@@ -37,7 +39,33 @@ class ListIntegrationsReport {
         this.reportingRepository = reportingRepository;
     }
 
-    async execute({ status, type, userId } = {}) {
+    _validateQuery({ status, type, userId } = {}) {
+        for (const [key, value] of Object.entries({ status, type, userId })) {
+            if (value !== undefined && value !== null && typeof value !== 'string') {
+                throw Boom.badRequest(
+                    `Invalid query parameter '${key}': expected a string`
+                );
+            }
+        }
+        const normalize = (value) => (value ? value : undefined);
+        const normalized = {
+            status: normalize(status),
+            type: normalize(type),
+            userId: normalize(userId),
+        };
+        if (normalized.status && !KNOWN_STATUSES.includes(normalized.status)) {
+            throw Boom.badRequest(
+                `Invalid status '${normalized.status}'. Expected one of: ${KNOWN_STATUSES.join(
+                    ', '
+                )}`
+            );
+        }
+        return normalized;
+    }
+
+    async execute(query = {}) {
+        const { status, type, userId } = this._validateQuery(query);
+
         const rows = await this.reportingRepository.findIntegrationsForReport({
             status,
             userId,
@@ -46,7 +74,7 @@ class ListIntegrationsReport {
         // type lives in config.type (a JSON path not portably groupable across
         // DBs), so it is filtered here rather than in the repository query.
         const filtered =
-            type === undefined || type === null
+            type === undefined
                 ? rows
                 : rows.filter((row) => (row.type ?? 'unknown') === type);
 

--- a/packages/core/reporting/use-cases/list-integrations-report.test.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.test.js
@@ -12,6 +12,25 @@ describe('ListIntegrationsReport', () => {
         );
     });
 
+    it('rejects an unknown status with a 400 (Boom) error', async () => {
+        const repo = makeRepo([]);
+        const useCase = new ListIntegrationsReport({ reportingRepository: repo });
+        await expect(useCase.execute({ status: 'BOGUS' })).rejects.toMatchObject({
+            isBoom: true,
+            output: { statusCode: 400 },
+        });
+        expect(repo.findIntegrationsForReport).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-string query param with a 400 (Boom) error', async () => {
+        const repo = makeRepo([]);
+        const useCase = new ListIntegrationsReport({ reportingRepository: repo });
+        await expect(
+            useCase.execute({ userId: { $oid: 'x' } })
+        ).rejects.toMatchObject({ isBoom: true, output: { statusCode: 400 } });
+        expect(repo.findIntegrationsForReport).not.toHaveBeenCalled();
+    });
+
     it('builds the versioned envelope with totals, byStatus, byType and per-row counts', async () => {
         const rows = [
             {

--- a/packages/core/reporting/use-cases/list-integrations-report.test.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.test.js
@@ -1,0 +1,147 @@
+const { ListIntegrationsReport } = require('./list-integrations-report');
+
+const makeRepo = (rows, mappingCounts = new Map()) => ({
+    findIntegrationsForReport: jest.fn().mockResolvedValue(rows),
+    countMappingsByIntegrationIds: jest.fn().mockResolvedValue(mappingCounts),
+});
+
+describe('ListIntegrationsReport', () => {
+    it('requires a reportingRepository', () => {
+        expect(() => new ListIntegrationsReport({})).toThrow(
+            /reportingRepository is required/
+        );
+    });
+
+    it('builds the versioned envelope with totals, byStatus, byType and per-row counts', async () => {
+        const rows = [
+            {
+                id: '1',
+                type: 'hubspot',
+                status: 'ENABLED',
+                userId: '3',
+                version: '1.0.0',
+                moduleCount: 2,
+                errorCount: 0,
+                createdAt: new Date('2026-01-01T00:00:00Z'),
+                updatedAt: new Date('2026-01-02T00:00:00Z'),
+            },
+            {
+                id: '2',
+                type: 'hubspot',
+                status: 'ERROR',
+                userId: '3',
+                version: '1.0.0',
+                moduleCount: 1,
+                errorCount: 3,
+            },
+            {
+                id: '3',
+                type: 'salesforce',
+                status: 'ENABLED',
+                userId: '4',
+                version: '2.0.0',
+                moduleCount: 1,
+                errorCount: 0,
+            },
+        ];
+        const counts = new Map([
+            ['1', 412],
+            ['2', 5],
+        ]);
+        const useCase = new ListIntegrationsReport({
+            reportingRepository: makeRepo(rows, counts),
+        });
+
+        const out = await useCase.execute({});
+
+        expect(out.schemaVersion).toBe(1);
+        expect(out.service).toBe('frigg-core-api');
+        expect(typeof out.generatedAt).toBe('string');
+        expect(out.metrics.total).toBe(3);
+        expect(out.metrics.byStatus).toEqual({
+            ENABLED: 2,
+            ERROR: 1,
+            NEEDS_CONFIG: 0,
+            PROCESSING: 0,
+            DISABLED: 0,
+        });
+
+        const hub = out.metrics.byType.find((t) => t.type === 'hubspot');
+        expect(hub.total).toBe(2);
+        expect(hub.byStatus).toEqual({
+            ENABLED: 1,
+            ERROR: 1,
+            NEEDS_CONFIG: 0,
+            PROCESSING: 0,
+            DISABLED: 0,
+        });
+
+        const row1 = out.metrics.integrations.find((i) => i.id === '1');
+        expect(row1.mappedRecordCount).toBe(412);
+        expect(row1.moduleCount).toBe(2);
+        expect(row1.createdAt).toBe('2026-01-01T00:00:00.000Z');
+
+        const row3 = out.metrics.integrations.find((i) => i.id === '3');
+        expect(row3.mappedRecordCount).toBe(0);
+        expect(row3.createdAt).toBeNull();
+    });
+
+    it('filters by type in the use-case and only counts mappings for matching ids', async () => {
+        const rows = [
+            { id: '1', type: 'hubspot', status: 'ENABLED', moduleCount: 1, errorCount: 0 },
+            { id: '2', type: 'salesforce', status: 'ENABLED', moduleCount: 1, errorCount: 0 },
+        ];
+        const repo = makeRepo(rows, new Map([['1', 10]]));
+        const useCase = new ListIntegrationsReport({ reportingRepository: repo });
+
+        const out = await useCase.execute({ type: 'hubspot' });
+
+        expect(out.metrics.total).toBe(1);
+        expect(out.metrics.integrations[0].id).toBe('1');
+        expect(repo.countMappingsByIntegrationIds).toHaveBeenCalledWith(['1']);
+        expect(out.filters.type).toBe('hubspot');
+    });
+
+    it('passes status/userId to the repository, echoes filters, and skips mapping count when empty', async () => {
+        const repo = makeRepo([]);
+        const useCase = new ListIntegrationsReport({ reportingRepository: repo });
+
+        const out = await useCase.execute({ status: 'ERROR', userId: '7' });
+
+        expect(repo.findIntegrationsForReport).toHaveBeenCalledWith({
+            status: 'ERROR',
+            userId: '7',
+        });
+        expect(out.metrics.total).toBe(0);
+        expect(out.filters).toEqual({ status: 'ERROR', type: null, userId: '7' });
+        expect(repo.countMappingsByIntegrationIds).not.toHaveBeenCalled();
+    });
+
+    it('buckets null type as "unknown"', async () => {
+        const rows = [
+            { id: '1', type: null, status: 'ENABLED', moduleCount: 0, errorCount: 0 },
+        ];
+        const useCase = new ListIntegrationsReport({
+            reportingRepository: makeRepo(rows),
+        });
+
+        const out = await useCase.execute({});
+
+        expect(out.metrics.integrations[0].type).toBe('unknown');
+        expect(out.metrics.byType[0].type).toBe('unknown');
+    });
+
+    it('picks up an unknown status value dynamically (new enum member)', async () => {
+        const rows = [
+            { id: '1', type: 'x', status: 'ARCHIVED', moduleCount: 0, errorCount: 0 },
+        ];
+        const useCase = new ListIntegrationsReport({
+            reportingRepository: makeRepo(rows),
+        });
+
+        const out = await useCase.execute({});
+
+        expect(out.metrics.byStatus.ARCHIVED).toBe(1);
+        expect(out.metrics.byStatus.ENABLED).toBe(0);
+    });
+});

--- a/packages/core/reporting/use-cases/list-integrations-report.test.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.test.js
@@ -144,4 +144,58 @@ describe('ListIntegrationsReport', () => {
         expect(out.metrics.byStatus.ARCHIVED).toBe(1);
         expect(out.metrics.byStatus.ENABLED).toBe(0);
     });
+
+    it('buckets a missing status under UNKNOWN, never a literal "null" key', async () => {
+        const rows = [
+            { id: '1', type: 'x', status: null, moduleCount: 0, errorCount: 0 },
+        ];
+        const useCase = new ListIntegrationsReport({
+            reportingRepository: makeRepo(rows),
+        });
+
+        const out = await useCase.execute({});
+
+        expect(out.metrics.byStatus.UNKNOWN).toBe(1);
+        expect(out.metrics.byStatus).not.toHaveProperty('null');
+        expect(out.metrics.byType[0].byStatus.UNKNOWN).toBe(1);
+        expect(out.metrics.byType[0].byStatus).not.toHaveProperty('null');
+    });
+
+    it('asserts byType buckets are independent across types', async () => {
+        const rows = [
+            { id: '1', type: 'hubspot', status: 'ENABLED', moduleCount: 1, errorCount: 0 },
+            { id: '2', type: 'salesforce', status: 'ERROR', moduleCount: 1, errorCount: 1 },
+        ];
+        const out = await new ListIntegrationsReport({
+            reportingRepository: makeRepo(rows),
+        }).execute({});
+
+        expect(out.metrics.byType).toHaveLength(2);
+        const sf = out.metrics.byType.find((t) => t.type === 'salesforce');
+        expect(sf.total).toBe(1);
+        expect(sf.byStatus).toEqual({
+            ENABLED: 0,
+            ERROR: 1,
+            NEEDS_CONFIG: 0,
+            PROCESSING: 0,
+            DISABLED: 0,
+        });
+    });
+
+    it('normalizes timestamps from Date, extended-JSON {$date}, string, and null', async () => {
+        const rows = [
+            { id: '1', type: 'x', status: 'ENABLED', moduleCount: 0, errorCount: 0, createdAt: { $date: '2026-03-04T05:06:07Z' }, updatedAt: { $date: 'not-a-date' } },
+            { id: '2', type: 'x', status: 'ENABLED', moduleCount: 0, errorCount: 0, createdAt: '2026-03-04T05:06:07.000Z', updatedAt: null },
+        ];
+        const out = await new ListIntegrationsReport({
+            reportingRepository: makeRepo(rows),
+        }).execute({});
+
+        const r1 = out.metrics.integrations.find((i) => i.id === '1');
+        expect(r1.createdAt).toBe('2026-03-04T05:06:07.000Z');
+        expect(r1.updatedAt).toBeNull();
+        const r2 = out.metrics.integrations.find((i) => i.id === '2');
+        expect(r2.createdAt).toBe('2026-03-04T05:06:07.000Z');
+        expect(r2.updatedAt).toBeNull();
+    });
 });

--- a/packages/devtools/infrastructure/domains/shared/utilities/base-definition-factory.js
+++ b/packages/devtools/infrastructure/domains/shared/utilities/base-definition-factory.js
@@ -311,6 +311,16 @@ function createBaseDefinition(
                     { httpApi: { path: '/health/{proxy+}', method: 'GET' } },
                 ],
             },
+            reporting: {
+                handler: 'node_modules/@friggframework/core/handlers/routers/reporting.handler',
+                ...(usePrismaLayer && { layers: [{ Ref: 'PrismaLambdaLayer' }] }),
+                skipEsbuild: true,  // Handlers in node_modules don't need bundling
+                package: skipEsbuildPackageConfig,
+                events: [
+                    { httpApi: { path: '/api/v2/reports', method: 'GET' } },
+                    { httpApi: { path: '/api/v2/reports/{proxy+}', method: 'GET' } },
+                ],
+            },
             // Note: dbMigrate removed - MigrationBuilder now handles migration infrastructure
             // See: packages/devtools/infrastructure/domains/database/migration-builder.js
         },


### PR DESCRIPTION
## Why

Frigg apps are commonly deployed one instance per tenant/customer (each in its own account + database). Operating a fleet of them means you often need to pull lightweight, per-instance operational data into an external admin tool or dashboard — **without** granting that tool direct database access to every account.

Frigg's management API is a **public API Gateway v2** endpoint (the VPC only governs Lambda *outbound* networking), so an external caller can reach each instance over HTTPS, gated by an API key. This adds a read-only **reporting** domain to `@friggframework/core` that every instance exposes. First metric: integrations, broken down by status and type, with per-integration counts.

## What changed

New self-contained hexagonal domain `packages/core/reporting/`:
- **Repository triad** — port interface + `postgres`/`mongo`/`documentdb` adapters + factory (`config.DB_TYPE`).
- **Use case** `ListIntegrationsReport` — pushes `status`/`userId` to the query, JS-filters `type`, reduces to a versioned envelope (`byStatus`/`byType` keyed on raw `IntegrationStatus`; new enum values picked up dynamically).
- **Router** `createReportingRouter()` — `validateApiKey` middleware + routes; thin Lambda wrapper at `handlers/routers/reporting.js`.

Wiring (3 edits): `packages/core/index.js` (re-exports), `base-definition-factory.js` (`reporting` function → `/api/v2/reports` + `{proxy+}`), `docs/frigg-management-api.yml` (OpenAPI path, schemas, security scheme).

### API

```
GET /api/v2/reports/integrations        header: x-frigg-reporting-api-key
  ?status=ENABLED|ERROR|NEEDS_CONFIG|PROCESSING|DISABLED  &type=<config.type>  &userId=<id>
→ { schemaVersion, service, generatedAt, filters,
    metrics: { total, byStatus, byType:[{type,total,byStatus}],
               integrations:[{id,type,status,userId,version,moduleCount,errorCount,mappedRecordCount,createdAt,updatedAt}] } }
GET /api/v2/reports   → { service, reports: ["integrations"] }
```

- **Auth:** dedicated `REPORTING_API_KEY` (header `x-frigg-reporting-api-key`), fail-closed. Models the `db-migration.js` pattern with its own key (narrower blast radius than reusing `ADMIN_API_KEY`).
- **Versioning:** mounted under `/api/v2/...` per ADR-006.
- **Encryption:** reads **no** encrypted fields — counts via `groupBy`/`$group` (passthrough), `moduleCount` from entity ids, `errorCount` from the `errors` array.

## Reviewer notes

- This is the **first `/api/v2/*` route** — ADR-006's `/api/v2` prefix and OpenAPI/Scalar infra aren't in `next` yet; reporting is its own admin Lambda (not folded into the per-user integration router, which would mix auth models).
- Adding the route required **two** edits (router file + `base-definition-factory.js` functions block) — editing only the core router exposes nothing.
- Multi-DB: all three adapters implemented. `config.type` is JSON (not portably groupable), so type-filter + aggregation happen in the use case. The DocumentDB adapter drains cursors via `getMore` (the shared `documentdb-utils` only returns the first batch).
- **Rollout:** ships to a deployment only after publish → each adopter bumps `@friggframework/core`, redeploys, and sets `REPORTING_API_KEY` in its secrets. No fleet deploy.

## Verification

- `npx jest packages/core/reporting packages/core/__tests__/documentdb-factory-selection.test.js` → green; `base-definition-factory` + `health`/`integration-router` regression checks green; OpenAPI is valid YAML.
- **Recommended before adopting on a live deployment:** full `npm test` and a **canary against real Postgres + Mongo** (the gate that proves the Prisma `groupBy`/`include`, and the DocumentDB `getMore` drain, on real engines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)