### PR TITLE
feat(core,devtools): per-event dispatch axis (sync|queue) + app-level FIFO queue

### DIFF
--- a/packages/core/handlers/workers/user-action-worker.js
+++ b/packages/core/handlers/workers/user-action-worker.js
@@ -1,0 +1,146 @@
+const { Worker } = require('../../core/Worker');
+// Direct path (not the package index) avoids a circular require.
+const { createHandler } = require('../../core/create-handler');
+const {
+    GetIntegrationInstance,
+} = require('../../integrations/use-cases/get-integration-instance');
+const { ModuleFactory } = require('../../modules/module-factory');
+const {
+    createIntegrationRepository,
+} = require('../../integrations/repositories/integration-repository-factory');
+const {
+    createModuleRepository,
+} = require('../../modules/repositories/module-repository-factory');
+const {
+    getModulesDefinitionFromIntegrationClasses,
+} = require('../../integrations/utils/map-integration-dto');
+
+/**
+ * App-level worker for `dispatch: 'queue'` events. One Lambda serves every
+ * integration; the FIFO queue serializes per integrationId. Re-hydrates by id +
+ * owning user, then runs `instance.send(event, data)` (identical to the sync path).
+ * Terminal failures discard; everything else retries → FIFO DLQ. DISABLED/ERROR
+ * integrations are still processed (these are user-initiated mutations).
+ */
+class UserActionWorker extends Worker {
+    constructor({ getIntegrationInstance } = {}) {
+        super();
+        this._getIntegrationInstance = getIntegrationInstance || null;
+    }
+
+    _validateParams(params) {
+        this._verifyParamExists(params, 'event');
+        this._verifyParamExists(params, 'data');
+    }
+
+    _resolveGetIntegrationInstance() {
+        if (this._getIntegrationInstance) return this._getIntegrationInstance;
+
+        const { loadAppDefinition } = require('../app-definition-loader');
+        const { integrations: integrationClasses } = loadAppDefinition();
+        const integrationRepository = createIntegrationRepository();
+        const moduleRepository = createModuleRepository();
+        const moduleFactory = new ModuleFactory({
+            moduleRepository,
+            moduleDefinitions:
+                getModulesDefinitionFromIntegrationClasses(integrationClasses),
+        });
+
+        this._getIntegrationInstance = new GetIntegrationInstance({
+            integrationRepository,
+            integrationClasses,
+            moduleFactory,
+        });
+        return this._getIntegrationInstance;
+    }
+
+    async _run(params) {
+        const { event, data = {}, integrationId, userId, requestId } = params;
+        const logCtx = { event, integrationId, userId, requestId };
+
+        if (!integrationId || !userId) {
+            const err = new Error(
+                '[UserActionWorker] message missing integrationId/userId'
+            );
+            err.isHaltError = true;
+            console.error(err.message, logCtx);
+            throw err;
+        }
+
+        const getIntegrationInstance = this._resolveGetIntegrationInstance();
+
+        let instance;
+        try {
+            instance = await getIntegrationInstance.execute(
+                integrationId,
+                userId
+            );
+        } catch (error) {
+            // Only terminal failures discard; transient ones (DB/Prisma/KMS
+            // blips) retry → FIFO DLQ rather than being silently dropped.
+            if (error.isTerminal) {
+                error.isHaltError = true;
+                console.warn(
+                    `[UserActionWorker] integration ${integrationId} gone/invalid — discarding`,
+                    { ...logCtx, reason: error.message }
+                );
+            } else {
+                console.error(
+                    `[UserActionWorker] transient hydration failure for ${integrationId} — will retry`,
+                    { ...logCtx, reason: error.message }
+                );
+            }
+            throw error;
+        }
+
+        if (String(instance.id) !== String(integrationId)) {
+            const err = new Error(
+                `[UserActionWorker] hydrated id ${instance.id} != message integrationId ${integrationId}`
+            );
+            err.isHaltError = true;
+            console.error(err.message, logCtx);
+            throw err;
+        }
+
+        try {
+            console.log(`[UserActionWorker] dispatching ${event}`, logCtx);
+            const result = await instance.send(event, data);
+            console.log(`[UserActionWorker] ${event} ok`, logCtx);
+            return result;
+        } catch (error) {
+            try {
+                await instance.updateIntegrationStatus.execute(
+                    integrationId,
+                    'ERROR'
+                );
+                await instance.updateIntegrationMessages.execute(
+                    integrationId,
+                    'warnings',
+                    `Queued ${event} failed`,
+                    error.message,
+                    new Date().toISOString()
+                );
+            } catch (statusErr) {
+                console.error(
+                    '[UserActionWorker] failed to record error status/messages',
+                    { ...logCtx, statusErr: statusErr.message }
+                );
+            }
+            console.error(`[UserActionWorker] ${event} failed`, {
+                ...logCtx,
+                error: error.message,
+            });
+            throw error; // → SQS retry → FIFO DLQ
+        }
+    }
+}
+
+// createHandler gives the Lambda the standard worker setup (secretsToEnv,
+// connectPrisma, callbackWaitsForEmptyEventLoop) and passes the result through.
+const userActionQueueWorker = createHandler({
+    eventName: 'UserActionQueueWorker',
+    isUserFacingResponse: false,
+    method: async (event, context) => new UserActionWorker().run(event, context),
+});
+
+module.exports = { UserActionWorker, userActionQueueWorker };

--- a/packages/core/handlers/workers/user-action-worker.test.js
+++ b/packages/core/handlers/workers/user-action-worker.test.js
@@ -1,0 +1,170 @@
+jest.mock('../../database/config', () => ({
+    DB_TYPE: 'mongodb',
+    getDatabaseType: jest.fn(() => 'mongodb'),
+    PRISMA_LOG_LEVEL: 'error,warn',
+    PRISMA_QUERY_LOGGING: false,
+}));
+
+const { UserActionWorker } = require('./user-action-worker');
+
+const sqsEventFor = (params) => ({
+    Records: [
+        { messageId: 'm-1', body: JSON.stringify(params), attributes: {} },
+    ],
+});
+
+const makeInstance = (overrides = {}) => ({
+    id: 'int-1',
+    status: 'ENABLED',
+    send: jest.fn().mockResolvedValue({ ok: true }),
+    updateIntegrationStatus: { execute: jest.fn().mockResolvedValue({}) },
+    updateIntegrationMessages: { execute: jest.fn().mockResolvedValue({}) },
+    ...overrides,
+});
+
+const workerWith = (instanceOrError) => {
+    const execute = jest.fn(async () => {
+        if (instanceOrError instanceof Error) throw instanceOrError;
+        return instanceOrError;
+    });
+    const worker = new UserActionWorker({
+        getIntegrationInstance: { execute },
+    });
+    return { worker, execute };
+};
+
+describe('UserActionWorker', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    // Mirrors the producer envelope: routing metadata top-level, `data` is the payload.
+    const envelope = ({
+        event = 'ON_UPDATE',
+        integrationId = 'int-1',
+        userId = 'user-1',
+        requestId = 'r-1',
+        data = {},
+    }) => ({ schemaVersion: 1, event, integrationId, userId, requestId, data });
+
+    const terminalError = (message) => {
+        const err = new Error(message);
+        err.isTerminal = true;
+        return err;
+    };
+
+    it('resolves by id+userId and runs send(event, data) with the BYTE-IDENTICAL handler payload', async () => {
+        const instance = makeInstance();
+        const { worker, execute } = workerWith(instance);
+
+        const result = await worker.run(
+            sqsEventFor(
+                envelope({ event: 'ON_UPDATE', data: { config: { a: 1 } } })
+            ),
+            {}
+        );
+
+        expect(execute).toHaveBeenCalledWith('int-1', 'user-1');
+        // Handler gets only the original payload — no routing keys leaked.
+        expect(instance.send).toHaveBeenCalledWith('ON_UPDATE', {
+            config: { a: 1 },
+        });
+        expect(result).toEqual({ batchItemFailures: [] });
+    });
+
+    it('processes DISABLED/ERROR integrations (no discard)', async () => {
+        const instance = makeInstance({ status: 'ERROR' });
+        const { worker } = workerWith(instance);
+
+        await worker.run(sqsEventFor(envelope({})), {});
+
+        expect(instance.send).toHaveBeenCalled();
+    });
+
+    it('discards (HaltError) when integrationId/userId are missing — no retry', async () => {
+        const { worker, execute } = workerWith(makeInstance());
+
+        const result = await worker.run(
+            sqsEventFor({
+                schemaVersion: 1,
+                event: 'ON_UPDATE',
+                data: { config: {} },
+            }),
+            {}
+        );
+
+        expect(execute).not.toHaveBeenCalled();
+        expect(result).toEqual({ batchItemFailures: [] }); // halted = discarded
+    });
+
+    it('discards (HaltError) on a TERMINAL hydration failure (gone / not owned)', async () => {
+        const { worker } = workerWith(terminalError('No integration found'));
+
+        const result = await worker.run(
+            sqsEventFor(envelope({ integrationId: 'gone' })),
+            {}
+        );
+
+        expect(result).toEqual({ batchItemFailures: [] }); // halted = discarded
+    });
+
+    it('RETRIES (batch failure) on a TRANSIENT hydration failure — not discarded', async () => {
+        // No isTerminal marker → a DB/KMS blip must retry, not be silently lost.
+        const { worker } = workerWith(new Error('ECONNRESET'));
+
+        const result = await worker.run(
+            sqsEventFor(envelope({ integrationId: 'int-1' })),
+            {}
+        );
+
+        expect(result).toEqual({
+            batchItemFailures: [{ itemIdentifier: 'm-1' }],
+        });
+    });
+
+    it('discards (HaltError) on hydrated-id mismatch', async () => {
+        const instance = makeInstance({ id: 'different-id' });
+        const { worker } = workerWith(instance);
+
+        const result = await worker.run(
+            sqsEventFor(envelope({ integrationId: 'int-1' })),
+            {}
+        );
+
+        expect(instance.send).not.toHaveBeenCalled();
+        expect(result).toEqual({ batchItemFailures: [] });
+    });
+
+    it('on handler failure: records ERROR status + warning message and retries (batch failure)', async () => {
+        const instance = makeInstance({
+            send: jest.fn().mockRejectedValue(new Error('reconcile boom')),
+        });
+        const { worker } = workerWith(instance);
+
+        const result = await worker.run(
+            sqsEventFor(envelope({ integrationId: 'int-1' })),
+            {}
+        );
+
+        expect(instance.updateIntegrationStatus.execute).toHaveBeenCalledWith(
+            'int-1',
+            'ERROR'
+        );
+        expect(instance.updateIntegrationMessages.execute).toHaveBeenCalledWith(
+            'int-1',
+            'warnings',
+            expect.any(String),
+            'reconcile boom',
+            expect.any(String)
+        );
+        expect(result).toEqual({
+            batchItemFailures: [{ itemIdentifier: 'm-1' }],
+        });
+    });
+});

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -91,6 +91,12 @@ const application = require('./application');
 const utils = require('./utils');
 
 const { QueuerUtil } = require('./queues');
+const {
+    dispatchIntegrationEvent,
+} = require('./integrations/use-cases/dispatch-integration-event');
+const {
+    userActionQueueWorker,
+} = require('./handlers/workers/user-action-worker');
 
 module.exports = {
     // assertions
@@ -137,6 +143,7 @@ module.exports = {
     checkRequiredParams,
     createIntegrationRouter,
     getModulesDefinitionFromIntegrationClasses,
+    dispatchIntegrationEvent,
     LoadIntegrationContextUseCase,
     CreateProcess,
     UpdateProcessState,
@@ -179,6 +186,9 @@ module.exports = {
     ModuleFactory,
     // queues
     QueuerUtil,
+
+    // workers
+    userActionQueueWorker,
 
     // utils
     ...utils,

--- a/packages/core/integrations/integration-base.dispatch.test.js
+++ b/packages/core/integrations/integration-base.dispatch.test.js
@@ -1,0 +1,139 @@
+/**
+ * Tests for the per-event `dispatch` axis on IntegrationBase.
+ *
+ * `dispatch: 'sync'` (default) runs the handler in-process; `dispatch: 'queue'`
+ * is read by the dispatch helper to route the event through the FIFO queue.
+ * Here we only assert that the flag is resolved correctly onto `this.on`.
+ */
+
+jest.mock('../database/config', () => ({
+    DB_TYPE: 'mongodb',
+    getDatabaseType: jest.fn(() => 'mongodb'),
+    PRISMA_LOG_LEVEL: 'error,warn',
+    PRISMA_QUERY_LOGGING: false,
+}));
+
+const { IntegrationBase } = require('./integration-base');
+
+describe('IntegrationBase - dispatch axis', () => {
+    it('defaults to no dispatch flag (sync) when nothing is declared', async () => {
+        class TestIntegration extends IntegrationBase {
+            static Definition = { name: 'test', version: '1.0.0', modules: {} };
+        }
+
+        const integration = new TestIntegration();
+        await integration.initialize();
+
+        expect(integration.on.ON_UPDATE.dispatch).toBeUndefined();
+    });
+
+    it('applies Definition.eventDispatch onto default lifecycle events', async () => {
+        class TestIntegration extends IntegrationBase {
+            static Definition = {
+                name: 'test',
+                version: '1.0.0',
+                modules: {},
+                eventDispatch: { ON_UPDATE: 'queue' },
+            };
+        }
+
+        const integration = new TestIntegration();
+        await integration.initialize();
+
+        expect(integration.on.ON_UPDATE.dispatch).toBe('queue');
+        // Untargeted events stay sync (no flag).
+        expect(integration.on.ON_CREATE.dispatch).toBeUndefined();
+    });
+
+    it('preserves an inline dispatch flag on a custom event', async () => {
+        class TestIntegration extends IntegrationBase {
+            constructor(params) {
+                super(params);
+                this.events = {
+                    ...this.events,
+                    MY_ACTION: {
+                        type: 'USER_ACTION',
+                        dispatch: 'queue',
+                        handler: () => 'ok',
+                    },
+                };
+            }
+            static Definition = { name: 'test', version: '1.0.0', modules: {} };
+        }
+
+        const integration = new TestIntegration();
+        await integration.initialize();
+
+        expect(integration.on.MY_ACTION.dispatch).toBe('queue');
+    });
+
+    it('lets an inline dispatch flag win over the eventDispatch map', async () => {
+        class TestIntegration extends IntegrationBase {
+            constructor(params) {
+                super(params);
+                // Re-declare ON_UPDATE inline as sync; the map says queue.
+                this.events = {
+                    ...this.events,
+                    ON_UPDATE: {
+                        type: 'LIFE_CYCLE_EVENT',
+                        dispatch: 'sync',
+                        handler: () => 'ok',
+                    },
+                };
+            }
+            static Definition = {
+                name: 'test',
+                version: '1.0.0',
+                modules: {},
+                eventDispatch: { ON_UPDATE: 'queue' },
+            };
+        }
+
+        const integration = new TestIntegration();
+        await integration.initialize();
+
+        expect(integration.on.ON_UPDATE.dispatch).toBe('sync');
+    });
+
+    it('ignores unknown event names in eventDispatch without crashing', async () => {
+        class TestIntegration extends IntegrationBase {
+            static Definition = {
+                name: 'test',
+                version: '1.0.0',
+                modules: {},
+                eventDispatch: { NOPE_NOT_A_REAL_EVENT: 'queue' },
+            };
+        }
+
+        const integration = new TestIntegration();
+        await expect(integration.initialize()).resolves.not.toThrow();
+        expect(integration.on.NOPE_NOT_A_REAL_EVENT).toBeUndefined();
+    });
+
+    it('preserves dispatch on events merged from a Tier 3 extension', async () => {
+        const extension = {
+            name: 'my-extension',
+            events: {
+                EXT_ACTION: {
+                    type: 'USER_ACTION',
+                    dispatch: 'queue',
+                    handler: () => 'ext',
+                },
+            },
+        };
+
+        class TestIntegration extends IntegrationBase {
+            static Definition = {
+                name: 'test',
+                version: '1.0.0',
+                modules: {},
+                extensions: { myBinding: { extension } },
+            };
+        }
+
+        const integration = new TestIntegration();
+        await integration.initialize();
+
+        expect(integration.on.EXT_ACTION.dispatch).toBe('queue');
+    });
+});

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -31,6 +31,11 @@ const constantsToBeMigrated = {
         LIFE_CYCLE_EVENT: 'LIFE_CYCLE_EVENT',
         USER_ACTION: 'USER_ACTION',
     },
+    // 'sync' runs in-process (default); 'queue' routes through the FIFO queue.
+    dispatch: {
+        SYNC: 'sync',
+        QUEUE: 'queue',
+    },
 };
 
 class IntegrationBase {
@@ -521,6 +526,18 @@ class IntegrationBase {
             ...this.defaultEvents,
             ...this.events,
         };
+
+        // Definition.eventDispatch marks default events; inline dispatch wins,
+        // unknown names are ignored.
+        const eventDispatch = this.constructor.Definition?.eventDispatch || {};
+        for (const [eventName, mode] of Object.entries(eventDispatch)) {
+            if (this.on[eventName] && this.on[eventName].dispatch === undefined) {
+                this.on[eventName] = {
+                    ...this.on[eventName],
+                    dispatch: mode,
+                };
+            }
+        }
     }
 
     /**
@@ -608,6 +625,9 @@ class IntegrationBase {
                 this.events[eventName] = {
                     type: eventDef.type,
                     handler: fn.bind(this),
+                    ...(eventDef.dispatch !== undefined && {
+                        dispatch: eventDef.dispatch,
+                    }),
                 };
                 mergedByExtension.set(eventName, bindingName);
             }

--- a/packages/core/integrations/integration-router.js
+++ b/packages/core/integrations/integration-router.js
@@ -31,6 +31,9 @@ const {
 } = require('./use-cases/get-integration-instance');
 const { UpdateIntegration } = require('./use-cases/update-integration');
 const {
+    dispatchIntegrationEvent,
+} = require('./use-cases/dispatch-integration-event');
+const {
     getModulesDefinitionFromIntegrationClasses,
 } = require('./utils/map-integration-dto');
 const {
@@ -293,6 +296,9 @@ function setIntegrationRoutes(router, authenticateUser, useCases) {
                 params.config
             );
 
+            if (integration?.queued) {
+                return res.status(202).json(integration);
+            }
             res.status(201).json(integration);
         })
     );
@@ -308,6 +314,9 @@ function setIntegrationRoutes(router, authenticateUser, useCases) {
                 userId,
                 params.config
             );
+            if (integration?.queued) {
+                return res.status(202).json(integration);
+            }
             res.json(integration);
         })
     );
@@ -425,7 +434,21 @@ function setIntegrationRoutes(router, authenticateUser, useCases) {
                 params.integrationId,
                 user.getId()
             );
-            res.json(await integration.send(params.actionId, req.body));
+            const outcome = await dispatchIntegrationEvent({
+                instance: integration,
+                event: params.actionId,
+                data: req.body,
+                userId: user.getId(),
+            });
+            if (outcome.queued) {
+                return res.status(202).json({
+                    queued: true,
+                    integrationId: integration.id,
+                    messageId: outcome.messageId,
+                    requestId: outcome.requestId,
+                });
+            }
+            res.json(outcome.result);
         })
     );
 

--- a/packages/core/integrations/tests/use-cases/dispatch-queued-branch.test.js
+++ b/packages/core/integrations/tests/use-cases/dispatch-queued-branch.test.js
@@ -1,0 +1,135 @@
+/**
+ * Covers the producer "queued" branch in the create/update use cases: when the
+ * dispatch helper enqueues the event (dispatch:'queue'), the use case must
+ * return a { queued } ack instead of the integration DTO. The HTTP layer maps
+ * that ack to a 202. The default (sync) branch must still return the DTO.
+ */
+
+jest.mock('../../../database/config', () => ({
+    DB_TYPE: 'mongodb',
+    getDatabaseType: jest.fn(() => 'mongodb'),
+    PRISMA_LOG_LEVEL: 'error,warn',
+    PRISMA_QUERY_LOGGING: false,
+}));
+
+// Mock the dispatch helper so we control the queued vs sync outcome directly
+// and assert the use case maps each outcome to the right return shape.
+const mockDispatch = jest.fn();
+jest.mock('../../use-cases/dispatch-integration-event', () => ({
+    dispatchIntegrationEvent: (...args) => mockDispatch(...args),
+}));
+
+const { UpdateIntegration } = require('../../use-cases/update-integration');
+const { CreateIntegration } = require('../../use-cases/create-integration');
+const {
+    TestIntegrationRepository,
+} = require('../doubles/test-integration-repository');
+const {
+    TestModuleFactory,
+} = require('../../../modules/tests/doubles/test-module-factory');
+const { DummyIntegration } = require('../doubles/dummy-integration-class');
+
+describe('producer queued-branch return shape', () => {
+    let integrationRepository;
+    let moduleFactory;
+
+    beforeEach(() => {
+        mockDispatch.mockReset();
+        integrationRepository = new TestIntegrationRepository();
+        moduleFactory = new TestModuleFactory();
+    });
+
+    describe('UpdateIntegration', () => {
+        let useCase;
+        beforeEach(() => {
+            useCase = new UpdateIntegration({
+                integrationRepository,
+                integrationClasses: [DummyIntegration],
+                moduleFactory,
+            });
+        });
+
+        it('returns a { queued } ack when the event was enqueued', async () => {
+            const record = await integrationRepository.createIntegration(
+                ['e1'],
+                'user-1',
+                { type: 'dummy' }
+            );
+            mockDispatch.mockResolvedValue({
+                queued: true,
+                messageId: 'msg-1',
+                requestId: 'req-1',
+            });
+
+            const result = await useCase.execute(record.id, 'user-1', {
+                type: 'dummy',
+                foo: 'baz',
+            });
+
+            expect(result).toEqual({
+                queued: true,
+                integrationId: record.id,
+                messageId: 'msg-1',
+                requestId: 'req-1',
+            });
+        });
+
+        it('returns the integration DTO when the event ran in-process', async () => {
+            const record = await integrationRepository.createIntegration(
+                ['e1'],
+                'user-1',
+                { type: 'dummy' }
+            );
+            mockDispatch.mockResolvedValue({ result: { ran: true } });
+
+            const result = await useCase.execute(record.id, 'user-1', {
+                type: 'dummy',
+                foo: 'baz',
+            });
+
+            expect(result.queued).toBeUndefined();
+            expect(result.id).toBe(record.id);
+        });
+    });
+
+    describe('CreateIntegration', () => {
+        let useCase;
+        beforeEach(() => {
+            useCase = new CreateIntegration({
+                integrationRepository,
+                integrationClasses: [DummyIntegration],
+                moduleFactory,
+            });
+        });
+
+        it('returns a { queued } ack when the event was enqueued', async () => {
+            mockDispatch.mockResolvedValue({
+                queued: true,
+                messageId: 'msg-2',
+                requestId: 'req-2',
+            });
+
+            const result = await useCase.execute(['e1'], 'user-1', {
+                type: 'dummy',
+            });
+
+            expect(result).toMatchObject({
+                queued: true,
+                messageId: 'msg-2',
+                requestId: 'req-2',
+            });
+            expect(result.integrationId).toBeDefined();
+        });
+
+        it('returns the integration DTO when the event ran in-process', async () => {
+            mockDispatch.mockResolvedValue({ result: undefined });
+
+            const result = await useCase.execute(['e1'], 'user-1', {
+                type: 'dummy',
+            });
+
+            expect(result.queued).toBeUndefined();
+            expect(result.id).toBeDefined();
+        });
+    });
+});

--- a/packages/core/integrations/use-cases/create-integration.js
+++ b/packages/core/integrations/use-cases/create-integration.js
@@ -2,6 +2,7 @@
 const {
     mapIntegrationClassToIntegrationDTO,
 } = require('../utils/map-integration-dto');
+const { dispatchIntegrationEvent } = require('./dispatch-integration-event');
 
 /**
  * Use case for creating a new integration instance.
@@ -72,9 +73,21 @@ class CreateIntegration {
         });
 
         await integrationInstance.initialize();
-        await integrationInstance.send('ON_CREATE', {
-            integrationId: integrationRecord.id,
+        const outcome = await dispatchIntegrationEvent({
+            instance: integrationInstance,
+            event: 'ON_CREATE',
+            data: { integrationId: integrationRecord.id },
+            userId,
         });
+
+        if (outcome.queued) {
+            return {
+                queued: true,
+                integrationId: integrationInstance.id,
+                messageId: outcome.messageId,
+                requestId: outcome.requestId,
+            };
+        }
 
         return mapIntegrationClassToIntegrationDTO(integrationInstance);
     }

--- a/packages/core/integrations/use-cases/dispatch-integration-event.js
+++ b/packages/core/integrations/use-cases/dispatch-integration-event.js
@@ -1,0 +1,54 @@
+const { v4: uuid } = require('uuid');
+const { QueuerUtil } = require('../../queues');
+
+const SCHEMA_VERSION = 1;
+
+// ON_DELETE is excluded: it dispatches directly and the record is gone before a
+// queued worker could re-hydrate it. Custom (non-default) events are mutating.
+const MUTATING_DEFAULT_EVENTS = new Set(['ON_CREATE', 'ON_UPDATE']);
+
+function isMutatingEvent(instance, event) {
+    if (!instance.defaultEvents || !instance.defaultEvents[event]) {
+        return true;
+    }
+    return MUTATING_DEFAULT_EVENTS.has(event);
+}
+
+// Enqueues the event (returning a { queued } ack) when it opts into
+// dispatch:'queue' and the queue is configured; otherwise runs it in-process
+// and returns the result. Missing queue URL degrades to in-process.
+async function dispatchIntegrationEvent({ instance, event, data, userId }) {
+    const mode = instance.on?.[event]?.dispatch;
+    const queueUrl = process.env.USER_ACTION_QUEUE_URL;
+
+    const eligible = mode === 'queue' && isMutatingEvent(instance, event);
+
+    if (eligible && !queueUrl) {
+        console.warn(
+            `[dispatchIntegrationEvent] event "${event}" requested dispatch:'queue' ` +
+                `but USER_ACTION_QUEUE_URL is not set — running in-process (sync)`
+        );
+    }
+
+    if (eligible && queueUrl) {
+        const requestId = uuid();
+        // Routing metadata at the top level keeps `data` identical to the sync path.
+        const envelope = {
+            schemaVersion: SCHEMA_VERSION,
+            event,
+            integrationId: instance.id,
+            userId,
+            requestId,
+            data,
+        };
+        const result = await QueuerUtil.send(envelope, queueUrl, {
+            messageGroupId: instance.id,
+            messageDeduplicationId: requestId,
+        });
+        return { queued: true, messageId: result?.MessageId, requestId };
+    }
+
+    return { result: await instance.send(event, data) };
+}
+
+module.exports = { dispatchIntegrationEvent, SCHEMA_VERSION };

--- a/packages/core/integrations/use-cases/dispatch-integration-event.test.js
+++ b/packages/core/integrations/use-cases/dispatch-integration-event.test.js
@@ -1,0 +1,149 @@
+/**
+ * Tests for dispatchIntegrationEvent — the central producer decision that runs
+ * an event in-process (sync) or enqueues it on the FIFO queue (queue).
+ */
+
+const mockSend = jest.fn();
+jest.mock('../../queues', () => ({
+    QueuerUtil: { send: (...args) => mockSend(...args) },
+}));
+
+const { dispatchIntegrationEvent } = require('./dispatch-integration-event');
+
+const makeInstance = ({ on = {}, defaultEvents = {}, id = 'int-1' } = {}) => ({
+    id,
+    on,
+    defaultEvents,
+    send: jest.fn().mockResolvedValue({ ran: true }),
+});
+
+describe('dispatchIntegrationEvent', () => {
+    const ORIGINAL_ENV = process.env.USER_ACTION_QUEUE_URL;
+
+    beforeEach(() => {
+        mockSend.mockReset().mockResolvedValue({ MessageId: 'msg-123' });
+        process.env.USER_ACTION_QUEUE_URL =
+            'https://sqs.us-east-1.amazonaws.com/1/q.fifo';
+    });
+
+    afterAll(() => {
+        if (ORIGINAL_ENV === undefined)
+            delete process.env.USER_ACTION_QUEUE_URL;
+        else process.env.USER_ACTION_QUEUE_URL = ORIGINAL_ENV;
+    });
+
+    it('runs the handler in-process for a sync event and returns its result', async () => {
+        const instance = makeInstance({
+            on: { ON_UPDATE: { dispatch: 'sync', handler: () => {} } },
+            defaultEvents: { ON_UPDATE: {} },
+        });
+
+        const outcome = await dispatchIntegrationEvent({
+            instance,
+            event: 'ON_UPDATE',
+            data: { config: { a: 1 } },
+            userId: 'user-1',
+        });
+
+        expect(instance.send).toHaveBeenCalledWith('ON_UPDATE', {
+            config: { a: 1 },
+        });
+        expect(outcome).toEqual({ result: { ran: true } });
+        expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('enqueues a queue event with messageGroupId=instance.id and does not run inline', async () => {
+        const instance = makeInstance({
+            on: { ON_UPDATE: { dispatch: 'queue', handler: () => {} } },
+            defaultEvents: { ON_UPDATE: {} },
+            id: 'int-42',
+        });
+
+        const outcome = await dispatchIntegrationEvent({
+            instance,
+            event: 'ON_UPDATE',
+            data: { config: { a: 1 } },
+            userId: 'user-1',
+        });
+
+        expect(instance.send).not.toHaveBeenCalled();
+        expect(mockSend).toHaveBeenCalledTimes(1);
+
+        const [envelope, queueUrl, opts] = mockSend.mock.calls[0];
+        expect(queueUrl).toBe(process.env.USER_ACTION_QUEUE_URL);
+        expect(opts.messageGroupId).toBe('int-42');
+        expect(opts.messageDeduplicationId).toEqual(expect.any(String));
+        expect(envelope).toMatchObject({
+            event: 'ON_UPDATE',
+            integrationId: 'int-42',
+            userId: 'user-1',
+        });
+        expect(envelope.requestId).toBe(opts.messageDeduplicationId);
+        // data is the exact handler payload — no framework keys leaked.
+        expect(envelope.data).toEqual({ config: { a: 1 } });
+        expect(outcome).toMatchObject({
+            queued: true,
+            messageId: 'msg-123',
+        });
+    });
+
+    it('falls back to sync (with a warning) when the queue URL is not configured', async () => {
+        delete process.env.USER_ACTION_QUEUE_URL;
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const instance = makeInstance({
+            on: { ON_UPDATE: { dispatch: 'queue', handler: () => {} } },
+            defaultEvents: { ON_UPDATE: {} },
+        });
+
+        const outcome = await dispatchIntegrationEvent({
+            instance,
+            event: 'ON_UPDATE',
+            data: { config: {} },
+            userId: 'user-1',
+        });
+
+        expect(mockSend).not.toHaveBeenCalled();
+        expect(instance.send).toHaveBeenCalled();
+        expect(outcome).toEqual({ result: { ran: true } });
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it('ignores queue mode on read-shaped default events and runs them in-process', async () => {
+        const instance = makeInstance({
+            on: {
+                GET_CONFIG_OPTIONS: { dispatch: 'queue', handler: () => {} },
+            },
+            defaultEvents: { GET_CONFIG_OPTIONS: {} },
+        });
+
+        const outcome = await dispatchIntegrationEvent({
+            instance,
+            event: 'GET_CONFIG_OPTIONS',
+            data: {},
+            userId: 'user-1',
+        });
+
+        expect(mockSend).not.toHaveBeenCalled();
+        expect(instance.send).toHaveBeenCalled();
+        expect(outcome).toEqual({ result: { ran: true } });
+    });
+
+    it('treats a custom user action (not a default event) as mutating and enqueues it', async () => {
+        const instance = makeInstance({
+            on: { PUSH_DEAL: { dispatch: 'queue', handler: () => {} } },
+            defaultEvents: {}, // PUSH_DEAL is custom, not a default event
+        });
+
+        const outcome = await dispatchIntegrationEvent({
+            instance,
+            event: 'PUSH_DEAL',
+            data: { foo: 'bar' },
+            userId: 'user-1',
+        });
+
+        expect(mockSend).toHaveBeenCalledTimes(1);
+        expect(outcome).toMatchObject({ queued: true });
+    });
+});

--- a/packages/core/integrations/use-cases/get-integration-instance.js
+++ b/packages/core/integrations/use-cases/get-integration-instance.js
@@ -31,9 +31,12 @@ class GetIntegrationInstance {
             await this.integrationRepository.findIntegrationById(integrationId);
 
         if (!integrationRecord) {
-            throw new Error(
+            const error = new Error(
                 `No integration found by the ID of ${integrationId}`
             );
+            // isTerminal → the queue worker discards these (no retry can succeed).
+            error.isTerminal = true;
+            throw error;
         }
 
         const integrationClass = this.integrationClasses.find(
@@ -43,15 +46,19 @@ class GetIntegrationInstance {
         );
 
         if (!integrationClass) {
-            throw new Error(
+            const error = new Error(
                 `No integration class found for type: ${integrationRecord.config.type}`
             );
+            error.isTerminal = true;
+            throw error;
         }
 
         if (integrationRecord.userId !== userId) {
-            throw new Error(
+            const error = new Error(
                 `Integration ${integrationId} does not belong to User ${userId}`
             );
+            error.isTerminal = true;
+            throw error;
         }
 
         const modules = [];

--- a/packages/core/integrations/use-cases/update-integration.js
+++ b/packages/core/integrations/use-cases/update-integration.js
@@ -1,6 +1,7 @@
 const {
     mapIntegrationClassToIntegrationDTO,
 } = require('../utils/map-integration-dto');
+const { dispatchIntegrationEvent } = require('./dispatch-integration-event');
 
 /**
  * Use case for updating a single integration by ID and user.
@@ -81,9 +82,22 @@ class UpdateIntegration {
             modules,
         });
 
-        // 5. Complete async initialization and trigger update event
         await integrationInstance.initialize();
-        await integrationInstance.send('ON_UPDATE', { config });
+        const outcome = await dispatchIntegrationEvent({
+            instance: integrationInstance,
+            event: 'ON_UPDATE',
+            data: { config },
+            userId,
+        });
+
+        if (outcome.queued) {
+            return {
+                queued: true,
+                integrationId: integrationInstance.id,
+                messageId: outcome.messageId,
+                requestId: outcome.requestId,
+            };
+        }
 
         return mapIntegrationClassToIntegrationDTO(integrationInstance);
     }

--- a/packages/core/queues/queuer-util.js
+++ b/packages/core/queues/queuer-util.js
@@ -90,10 +90,16 @@ const inspectBatchResult = (result, queueUrl, buffer) => {
 };
 
 const QueuerUtil = {
-    send: async (message, queueUrl) => {
+    // FIFO-only: default a unique dedup id so identical bodies aren't dropped.
+    // Standard sends pass no opts and stay unchanged.
+    send: async (message, queueUrl, { messageGroupId, messageDeduplicationId } = {}) => {
         const command = new SendMessageCommand({
             MessageBody: JSON.stringify(message),
             QueueUrl: queueUrl,
+            ...(messageGroupId !== undefined && {
+                MessageGroupId: messageGroupId,
+                MessageDeduplicationId: messageDeduplicationId || uuid(),
+            }),
         });
         const result = await sqs.send(command);
         console.log(

--- a/packages/core/queues/queuer-util.test.js
+++ b/packages/core/queues/queuer-util.test.js
@@ -49,6 +49,42 @@ describe('QueuerUtil - AWS SDK v3', () => {
 
             await expect(QueuerUtil.send(message, queueUrl)).rejects.toThrow('SQS Error');
         });
+
+        it('should NOT include FIFO fields when no options are passed', async () => {
+            sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' });
+
+            await QueuerUtil.send({ a: 1 }, 'https://queue-url');
+
+            const input = sqsMock.call(0).args[0].input;
+            expect(input).not.toHaveProperty('MessageGroupId');
+            expect(input).not.toHaveProperty('MessageDeduplicationId');
+        });
+
+        it('should include MessageGroupId when provided (FIFO)', async () => {
+            sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' });
+
+            await QueuerUtil.send({ a: 1 }, 'https://queue-url.fifo', {
+                messageGroupId: 'integration-123',
+                messageDeduplicationId: 'req-abc',
+            });
+
+            const input = sqsMock.call(0).args[0].input;
+            expect(input.MessageGroupId).toBe('integration-123');
+            expect(input.MessageDeduplicationId).toBe('req-abc');
+        });
+
+        it('should default MessageDeduplicationId to a unique value when group set without one', async () => {
+            sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm-1' });
+
+            await QueuerUtil.send({ a: 1 }, 'https://queue-url.fifo', {
+                messageGroupId: 'integration-123',
+            });
+
+            const input = sqsMock.call(0).args[0].input;
+            expect(input.MessageGroupId).toBe('integration-123');
+            expect(typeof input.MessageDeduplicationId).toBe('string');
+            expect(input.MessageDeduplicationId.length).toBeGreaterThan(0);
+        });
     });
 
     describe('batchSend()', () => {

--- a/packages/devtools/infrastructure/domains/integration/integration-builder.js
+++ b/packages/devtools/infrastructure/domains/integration/integration-builder.js
@@ -196,6 +196,8 @@ class IntegrationBuilder extends InfrastructureBuilder {
             );
         }
 
+        this.createUserActionQueue(result, functionPackageConfig, usePrismaLayer);
+
         for (const integration of appDefinition.integrations) {
             const integrationName = integration.Definition.name;
             const queueDecision = decisions.integrations[integrationName].queue;
@@ -470,6 +472,99 @@ class IntegrationBuilder extends InfrastructureBuilder {
         );
 
         console.log('  ✓ Created InternalErrorQueue resource');
+    }
+
+    /**
+     * App-level FIFO queue + DLQ + worker for `dispatch: 'queue'` events. One
+     * queue serves all integrations; MessageGroupId = integrationId serializes
+     * per integration. Always created, like the InternalErrorQueue.
+     */
+    createUserActionQueue(result, functionPackageConfig, usePrismaLayer = true) {
+        const queueName =
+            '${self:service}-${self:provider.stage}-FriggUserActionQueue.fifo';
+        const dlqName =
+            '${self:service}-${self:provider.stage}-FriggUserActionDLQ.fifo';
+
+        result.custom.FriggUserActionQueue = queueName;
+        result.custom.FriggUserActionDLQ = dlqName;
+
+        // A FIFO source queue can only redrive to a FIFO DLQ.
+        result.resources.FriggUserActionDLQ = {
+            Type: 'AWS::SQS::Queue',
+            Properties: {
+                QueueName: '${self:custom.FriggUserActionDLQ}',
+                FifoQueue: true,
+                MessageRetentionPeriod: 1209600, // 14 days
+            },
+        };
+
+        // No ContentBasedDeduplication: the producer sends a unique dedup id so
+        // two distinct requests with identical bodies both run (not deduped).
+        result.resources.FriggUserActionQueue = {
+            Type: 'AWS::SQS::Queue',
+            Properties: {
+                QueueName: '${self:custom.FriggUserActionQueue}',
+                FifoQueue: true,
+                MessageRetentionPeriod: 345600, // 4 days
+                VisibilityTimeout: 1800, // >= worker timeout (900s)
+                RedrivePolicy: {
+                    maxReceiveCount: 2,
+                    deadLetterTargetArn: {
+                        'Fn::GetAtt': ['FriggUserActionDLQ', 'Arn'],
+                    },
+                },
+            },
+        };
+
+        result.environment.USER_ACTION_QUEUE_URL = {
+            Ref: 'FriggUserActionQueue',
+        };
+
+        result.resources.FriggUserActionDLQAlarm = {
+            Type: 'AWS::CloudWatch::Alarm',
+            Properties: {
+                AlarmDescription:
+                    'Messages in FriggUserActionDLQ — eventual (queued) integration event failures',
+                Namespace: 'AWS/SQS',
+                MetricName: 'ApproximateNumberOfMessagesVisible',
+                Statistic: 'Maximum',
+                Threshold: 0,
+                ComparisonOperator: 'GreaterThanThreshold',
+                EvaluationPeriods: 1,
+                Period: 300,
+                AlarmActions: [{ Ref: 'InternalErrorBridgeTopic' }],
+                Dimensions: [
+                    {
+                        Name: 'QueueName',
+                        Value: {
+                            'Fn::GetAtt': ['FriggUserActionDLQ', 'QueueName'],
+                        },
+                    },
+                ],
+            },
+        };
+
+        // No reservedConcurrency: FIFO already serializes per group; capping
+        // would serialize across all integrations.
+        result.functions.userActionQueueWorker = {
+            handler:
+                'node_modules/@friggframework/core/handlers/workers/user-action-worker.userActionQueueWorker',
+            skipEsbuild: true,
+            package: functionPackageConfig,
+            ...(usePrismaLayer && { layers: [{ Ref: 'PrismaLambdaLayer' }] }),
+            timeout: 900,
+            events: [
+                {
+                    sqs: {
+                        arn: { 'Fn::GetAtt': ['FriggUserActionQueue', 'Arn'] },
+                        batchSize: 1,
+                        functionResponseType: 'ReportBatchItemFailures',
+                    },
+                },
+            ],
+        };
+
+        console.log('  ✓ Created FriggUserActionQueue (.fifo) + DLQ + worker');
     }
 
     /**

--- a/packages/devtools/infrastructure/domains/integration/integration-builder.test.js
+++ b/packages/devtools/infrastructure/domains/integration/integration-builder.test.js
@@ -751,9 +751,10 @@ describe('IntegrationBuilder', () => {
 
             const functionKeys = Object.keys(result.functions);
 
-            // Expected order: dlqProcessor (from InternalErrorQueue), webhook, integration, queueWorker
+            // App-level functions (dlqProcessor, userActionQueueWorker) come first.
             expect(functionKeys).toEqual([
                 'dlqProcessor',
+                'userActionQueueWorker',
                 'testWebhook',
                 'test',
                 'testQueueWorker',
@@ -933,6 +934,123 @@ describe('IntegrationBuilder', () => {
             expect(result.functions.asana.package.exclude).not.toEqual(
                 expect.arrayContaining(['node_modules/@prisma/**'])
             );
+        });
+    });
+
+    describe('User-Action FIFO queue', () => {
+        const appDefinition = {
+            integrations: [{ Definition: { name: 'test' } }],
+        };
+
+        it('creates a FIFO queue without ContentBasedDeduplication', async () => {
+            const result = await integrationBuilder.build(appDefinition, {});
+
+            const q = result.resources.FriggUserActionQueue;
+            expect(q).toBeDefined();
+            expect(q.Type).toBe('AWS::SQS::Queue');
+            expect(q.Properties.FifoQueue).toBe(true);
+            expect(q.Properties.ContentBasedDeduplication).toBeUndefined();
+            expect(q.Properties.VisibilityTimeout).toBe(1800);
+            expect(q.Properties.MessageRetentionPeriod).toBe(345600);
+        });
+
+        it('redrives to the FIFO DLQ with maxReceiveCount 2', async () => {
+            const result = await integrationBuilder.build(appDefinition, {});
+
+            expect(
+                result.resources.FriggUserActionQueue.Properties.RedrivePolicy
+            ).toEqual({
+                maxReceiveCount: 2,
+                deadLetterTargetArn: {
+                    'Fn::GetAtt': ['FriggUserActionDLQ', 'Arn'],
+                },
+            });
+        });
+
+        it('creates a FIFO DLQ with 14-day retention', async () => {
+            const result = await integrationBuilder.build(appDefinition, {});
+
+            const dlq = result.resources.FriggUserActionDLQ;
+            expect(dlq).toBeDefined();
+            expect(dlq.Properties.FifoQueue).toBe(true);
+            expect(dlq.Properties.MessageRetentionPeriod).toBe(1209600);
+        });
+
+        it('creates the worker bound to the FIFO queue ARN with no reservedConcurrency', async () => {
+            const result = await integrationBuilder.build(appDefinition, {});
+
+            const worker = result.functions.userActionQueueWorker;
+            expect(worker).toBeDefined();
+            expect(worker.handler).toBe(
+                'node_modules/@friggframework/core/handlers/workers/user-action-worker.userActionQueueWorker'
+            );
+            expect(worker.timeout).toBe(900);
+            expect(worker.reservedConcurrency).toBeUndefined();
+            expect(worker.events).toEqual([
+                {
+                    sqs: {
+                        arn: { 'Fn::GetAtt': ['FriggUserActionQueue', 'Arn'] },
+                        batchSize: 1,
+                        functionResponseType: 'ReportBatchItemFailures',
+                    },
+                },
+            ]);
+        });
+
+        it('exposes USER_ACTION_QUEUE_URL to all Lambdas', async () => {
+            const result = await integrationBuilder.build(appDefinition, {});
+
+            expect(result.environment.USER_ACTION_QUEUE_URL).toEqual({
+                Ref: 'FriggUserActionQueue',
+            });
+        });
+
+        it('alarms on the FIFO DLQ via the InternalErrorBridgeTopic', async () => {
+            const result = await integrationBuilder.build(appDefinition, {});
+
+            const alarm = result.resources.FriggUserActionDLQAlarm;
+            expect(alarm).toBeDefined();
+            expect(alarm.Properties.AlarmActions).toEqual([
+                { Ref: 'InternalErrorBridgeTopic' },
+            ]);
+        });
+
+        it('creates exactly one FIFO queue + worker regardless of integration count', async () => {
+            const result = await integrationBuilder.build(
+                {
+                    integrations: [
+                        { Definition: { name: 'hubspot' } },
+                        { Definition: { name: 'salesforce' } },
+                        { Definition: { name: 'slack' } },
+                    ],
+                },
+                {}
+            );
+
+            const fifoQueues = Object.keys(result.resources).filter(
+                (k) => k === 'FriggUserActionQueue'
+            );
+            expect(fifoQueues).toHaveLength(1);
+            expect(result.functions.userActionQueueWorker).toBeDefined();
+        });
+
+        it('does not make per-integration queues FIFO', async () => {
+            const result = await integrationBuilder.build(appDefinition, {});
+
+            expect(
+                result.resources.TestQueue.Properties.FifoQueue
+            ).toBeUndefined();
+        });
+
+        it('omits the Prisma layer on the worker when usePrismaLambdaLayer=false', async () => {
+            const result = await integrationBuilder.build(
+                { usePrismaLambdaLayer: false, integrations: [{ Definition: { name: 'test' } }] },
+                {}
+            );
+
+            expect(
+                result.functions.userActionQueueWorker.layers
+            ).toBeUndefined();
         });
     });
 });

--- a/packages/devtools/infrastructure/domains/security/iam-generator.js
+++ b/packages/devtools/infrastructure/domains/security/iam-generator.js
@@ -426,6 +426,8 @@ function generateIAMCloudFormation(options = {}) {
             ],
             Resource: [
                 { 'Fn::Sub': 'arn:aws:sqs:*:${AWS::AccountId}:*frigg*' },
+                // Case-sensitive: lowercase "*frigg*" won't match "FriggUserActionQueue.fifo".
+                { 'Fn::Sub': 'arn:aws:sqs:*:${AWS::AccountId}:*Frigg*' },
                 {
                     'Fn::Sub':
                         'arn:aws:sqs:*:${AWS::AccountId}:internal-error-queue-*',

--- a/packages/devtools/infrastructure/domains/security/iam-generator.test.js
+++ b/packages/devtools/infrastructure/domains/security/iam-generator.test.js
@@ -182,6 +182,22 @@ describe('IAM Generator', () => {
             expect(yaml).toContain('internal-error-queue-*');
         });
 
+        it('should include a case-sensitive *Frigg* SQS resource for the FIFO queue', () => {
+            const appDefinition = {
+                name: 'test-app',
+                integrations: [],
+            };
+
+            const summary = getFeatureSummary(appDefinition);
+            const yaml = generateIAMCloudFormation({
+                appName: summary.appName,
+                features: summary.features,
+            });
+
+            // The lowercase "*frigg*" glob would not match "...-FriggUserActionQueue.fifo".
+            expect(yaml).toContain(':*Frigg*');
+        });
+
         it('should generate outputs section', () => {
             const appDefinition = {
                 name: 'test-app',

--- a/packages/devtools/infrastructure/domains/security/templates/frigg-deployment-iam-stack.yaml
+++ b/packages/devtools/infrastructure/domains/security/templates/frigg-deployment-iam-stack.yaml
@@ -205,6 +205,8 @@ Resources:
               - 'sqs:UntagQueue'
             Resource:
               - !Sub 'arn:aws:sqs:*:${AWS::AccountId}:*frigg*'
+              # Case-sensitive: lowercase "*frigg*" won't match "FriggUserActionQueue.fifo".
+              - !Sub 'arn:aws:sqs:*:${AWS::AccountId}:*Frigg*'
               - !Sub 'arn:aws:sqs:*:${AWS::AccountId}:internal-error-queue-*'
           
           # SNS permissions

--- a/packages/devtools/infrastructure/domains/shared/utilities/base-definition-factory.js
+++ b/packages/devtools/infrastructure/domains/shared/utilities/base-definition-factory.js
@@ -196,6 +196,8 @@ function createBaseDefinition(
                     ],
                     Resource: [
                         { 'Fn::GetAtt': ['InternalErrorQueue', 'Arn'] },
+                        // Explicit: the "-*Queue" glob below doesn't match ".fifo".
+                        { 'Fn::GetAtt': ['FriggUserActionQueue', 'Arn'] },
                         {
                             'Fn::Join': [
                                 ':',

--- a/packages/devtools/infrastructure/domains/shared/utilities/base-definition-factory.test.js
+++ b/packages/devtools/infrastructure/domains/shared/utilities/base-definition-factory.test.js
@@ -133,6 +133,11 @@ describe('Base Definition Factory', () => {
                 stmt => stmt.Action.includes('sqs:SendMessage')
             );
             expect(sqsPermission).toBeDefined();
+
+            // The "-*Queue" glob doesn't match ".fifo", so the ARN is explicit.
+            expect(sqsPermission.Resource).toContainEqual({
+                'Fn::GetAtt': ['FriggUserActionQueue', 'Arn'],
+            });
         });
 
         it('should include required plugins', () => {


### PR DESCRIPTION
## Summary

Adds a first-class, per-event **`dispatch`** axis on Frigg integration events:

- **`dispatch: 'sync'`** (default) — today's behavior: run the handler in-process, return its result.
- **`dispatch: 'queue'`** — route the event through a **framework-owned** app-level FIFO SQS queue, serialized by `MessageGroupId = integrationId`, returning a `202` ack. Async failures surface via the integration's `status`/`messages`.

This fixes the **LEF-18** class of concurrency bug: concurrent config `PATCH`es each ran `onUpdate` synchronously in the API Lambda with no serialization, racing a lock-free webhook reconcile → duplicate registrations. Serializing per-integration (one in-flight message per group) removes the race; the convergent reconcile then reaches exactly one registration/type.

The framework owns 100% of the queue infrastructure; integrations declare only intent (`dispatch` inline on an event, or a `Definition.eventDispatch` map). Fully backward-compatible — every existing event stays `sync` unless it opts in.

## Changes

**Core (`@friggframework/core`)**
- `dispatch: { SYNC, QUEUE }` constant; `Definition.eventDispatch` applied in `registerEventHandlers`, inline `dispatch` preserved through `_mergeExtensions` (inline > map > default).
- **new** `dispatchIntegrationEvent` producer helper — enqueue when `queue` + mutating + queue configured; graceful in-process fallback + warn when unconfigured; reads stay sync.
- **new** `userActionQueueWorker` (single app-level Lambda) — re-hydrates via `GetIntegrationInstance.execute(integrationId, userId)`, asserts identity, runs `send(event, data)` byte-identical to the sync path; discards only **terminal** failures (gone / not-owned / unknown-class), **retries transient** ones → FIFO DLQ; does not discard DISABLED/ERROR.
- `QueuerUtil.send` gains optional FIFO `{ messageGroupId, messageDeduplicationId }` (defaults a unique dedup id; standard sends unchanged).
- Producer call sites (`update-integration`, `create-integration`, user-action route) return `202 {queued, integrationId, messageId, requestId}` when queued, else the existing DTO/body.

**Devtools (`@friggframework/devtools`)**
- Always-created app-level `FriggUserActionQueue.fifo` + FIFO DLQ + CloudWatch alarm + worker (no `ContentBasedDeduplication`; `reservedConcurrency` unset so FIFO serializes per group while integrations run in parallel); `USER_ACTION_QUEUE_URL` injected on all Lambdas.
- IAM: explicit FIFO queue ARN for the runtime `sqs:SendMessage` policy (the `-*Queue` glob doesn't match `.fifo`); case-sensitive `*Frigg*` deploy-time glob.

## Notes
- **Consumer fix lands separately** (Quo Pipedrive `ON_UPDATE` → `queue`) and bumps `@friggframework/core` to the canary this PR publishes.
- FIFO dedup uses a unique per-message `MessageDeduplicationId` (not content-based) so two distinct PATCHes with identical bodies both run.

## Test plan
- [x] Core unit (TDD): dispatch flag resolution/precedence/extension-preservation; helper enqueue-vs-sync + graceful fallback + read-ignored; worker resolve/assert/send byte-identical, terminal-discard vs transient-retry, status/messages on failure; QueuerUtil FIFO fields present/absent; producer 202-branch return shape.
- [x] Devtools unit: FIFO queue/DLQ/alarm/worker/env emitted, no ContentBasedDeduplication, reservedConcurrency unset, per-integration templates unchanged, IAM FIFO ARN + `*Frigg*`.
- [x] `npm run lint:fix` clean (0 errors).
- [ ] Behavioral LEF-18 proof on the `next.N` canary (frigg-canary-test): N concurrent PATCHes → exactly 1 registration/type; confirm the worker drains the FIFO queue (validates consume IAM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.608.e6b65ff.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.608.e6b65ff.0
  npm install @friggframework/devtools@2.0.0--canary.608.e6b65ff.0
  npm install @friggframework/eslint-config@2.0.0--canary.608.e6b65ff.0
  npm install @friggframework/prettier-config@2.0.0--canary.608.e6b65ff.0
  npm install @friggframework/schemas@2.0.0--canary.608.e6b65ff.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.608.e6b65ff.0
  npm install @friggframework/test@2.0.0--canary.608.e6b65ff.0
  npm install @friggframework/ui@2.0.0--canary.608.e6b65ff.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.608.e6b65ff.0
  yarn add @friggframework/devtools@2.0.0--canary.608.e6b65ff.0
  yarn add @friggframework/eslint-config@2.0.0--canary.608.e6b65ff.0
  yarn add @friggframework/prettier-config@2.0.0--canary.608.e6b65ff.0
  yarn add @friggframework/schemas@2.0.0--canary.608.e6b65ff.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.608.e6b65ff.0
  yarn add @friggframework/test@2.0.0--canary.608.e6b65ff.0
  yarn add @friggframework/ui@2.0.0--canary.608.e6b65ff.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
