### PR TITLE
feat(core): add findIndividualUsersByOrganizationId user lookup

### DIFF
--- a/packages/core/application/commands/__tests__/user-commands.test.js
+++ b/packages/core/application/commands/__tests__/user-commands.test.js
@@ -1,0 +1,92 @@
+// Mock the repository factory BEFORE importing the commands
+jest.mock('../../../user/repositories/user-repository-factory', () => ({
+    createUserRepository: jest.fn(),
+}));
+
+const {
+    createUserRepository,
+} = require('../../../user/repositories/user-repository-factory');
+const { createUserCommands } = require('../user-commands');
+
+describe('user-commands findIndividualUsersByOrganizationId', () => {
+    let repository;
+
+    beforeEach(() => {
+        repository = {
+            findIndividualUsersByOrganizationId: jest.fn(),
+        };
+        createUserRepository.mockReturnValue(repository);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('projects individual users and includes appUserId (the field the org finder drops)', async () => {
+        repository.findIndividualUsersByOrganizationId.mockResolvedValue([
+            {
+                id: '2018',
+                username: 'app-user-USx4fhpNuR',
+                email: 'USx4fhpNuR@app.local',
+                appUserId: 'USx4fhpNuR',
+                hashword: 'should-not-leak',
+            },
+        ]);
+
+        const commands = createUserCommands();
+        const result =
+            await commands.findIndividualUsersByOrganizationId('2019');
+
+        expect(
+            repository.findIndividualUsersByOrganizationId
+        ).toHaveBeenCalledWith('2019');
+        expect(result).toEqual([
+            {
+                id: '2018',
+                username: 'app-user-USx4fhpNuR',
+                email: 'USx4fhpNuR@app.local',
+                appUserId: 'USx4fhpNuR',
+            },
+        ]);
+        // The whole point of this lookup: appUserId is exposed, hashword is not.
+        expect(result[0].appUserId).toBe('USx4fhpNuR');
+        expect(result[0]).not.toHaveProperty('hashword');
+    });
+
+    it('returns an empty array when the organization has no individual users', async () => {
+        repository.findIndividualUsersByOrganizationId.mockResolvedValue([]);
+
+        const commands = createUserCommands();
+
+        expect(
+            await commands.findIndividualUsersByOrganizationId('2019')
+        ).toEqual([]);
+    });
+
+    it('returns a 400 error response when organizationUserId is missing', async () => {
+        const commands = createUserCommands();
+
+        const result = await commands.findIndividualUsersByOrganizationId();
+
+        expect(result).toEqual({
+            error: 400,
+            reason: 'organizationUserId is required',
+            code: 'INVALID_USER_DATA',
+        });
+        expect(
+            repository.findIndividualUsersByOrganizationId
+        ).not.toHaveBeenCalled();
+    });
+
+    it('maps repository errors to an error response', async () => {
+        repository.findIndividualUsersByOrganizationId.mockRejectedValue(
+            new Error('db down')
+        );
+
+        const commands = createUserCommands();
+        const result =
+            await commands.findIndividualUsersByOrganizationId('2019');
+
+        expect(result).toEqual({ error: 500, reason: 'db down' });
+    });
+});

--- a/packages/core/application/commands/user-commands.js
+++ b/packages/core/application/commands/user-commands.js
@@ -170,14 +170,9 @@ function createUserCommands() {
         },
 
         /**
-         * Find all individual users linked to an organization user.
-         *
-         * Resolves the external appUserId (e.g. ^US...) from an organization
-         * user id — appUserId lives only on individual users, so reading it off
-         * an organization user yields null. An organization may have more than
-         * one individual user, so this returns an array; callers pick.
-         * @param {string} organizationUserId - Organization user ID
-         * @returns {Promise<Object[]|Object>} Array of { id, username, email, appUserId } (empty if none), or an error response
+         * Find all individual users linked to an organization user
+         * @param {string} organizationUserId - Organization user ID to search for
+         * @returns {Promise<Object[]>} Array of individual user objects (empty if none)
          */
         async findIndividualUsersByOrganizationId(organizationUserId) {
             try {

--- a/packages/core/application/commands/user-commands.js
+++ b/packages/core/application/commands/user-commands.js
@@ -170,6 +170,40 @@ function createUserCommands() {
         },
 
         /**
+         * Find all individual users linked to an organization user.
+         *
+         * Resolves the external appUserId (e.g. ^US...) from an organization
+         * user id — appUserId lives only on individual users, so reading it off
+         * an organization user yields null. An organization may have more than
+         * one individual user, so this returns an array; callers pick.
+         * @param {string} organizationUserId - Organization user ID
+         * @returns {Promise<Object[]|Object>} Array of { id, username, email, appUserId } (empty if none), or an error response
+         */
+        async findIndividualUsersByOrganizationId(organizationUserId) {
+            try {
+                if (!organizationUserId) {
+                    const error = new Error('organizationUserId is required');
+                    error.code = 'INVALID_USER_DATA';
+                    throw error;
+                }
+
+                const users =
+                    await userRepository.findIndividualUsersByOrganizationId(
+                        organizationUserId
+                    );
+
+                return (users || []).map((user) => ({
+                    id: user._id?.toString() || user.id,
+                    username: user.username,
+                    email: user.email,
+                    appUserId: user.appUserId,
+                }));
+            } catch (error) {
+                return mapErrorToResponse(error);
+            }
+        },
+
+        /**
          * Find an organization user by their ID
          * @param {string} userId - Organization user ID to search for
          * @returns {Promise<Object|null>} Organization user object or null if not found

--- a/packages/core/prisma-mongodb/schema.prisma
+++ b/packages/core/prisma-mongodb/schema.prisma
@@ -59,6 +59,7 @@ model User {
   @@unique([username, appUserId])
   @@index([type])
   @@index([appUserId])
+  @@index([organizationId])
   @@map("User")
 }
 

--- a/packages/core/prisma-postgresql/migrations/20260625000000_add_user_organization_id_index/migration.sql
+++ b/packages/core/prisma-postgresql/migrations/20260625000000_add_user_organization_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "User_organizationId_idx" ON "User"("organizationId");

--- a/packages/core/prisma-postgresql/schema.prisma
+++ b/packages/core/prisma-postgresql/schema.prisma
@@ -59,6 +59,7 @@ model User {
   @@unique([username, appUserId])
   @@index([type])
   @@index([appUserId])
+  @@index([organizationId])
 }
 
 enum UserType {

--- a/packages/core/user/repositories/__tests__/user-repository-postgres.test.js
+++ b/packages/core/user/repositories/__tests__/user-repository-postgres.test.js
@@ -1,0 +1,63 @@
+// Mock prisma + token repo BEFORE importing the repository
+jest.mock('../../../database/prisma', () => ({
+    prisma: {
+        user: {
+            findMany: jest.fn(),
+        },
+    },
+}));
+jest.mock('../../../token/repositories/token-repository-factory', () => ({
+    createTokenRepository: jest.fn(() => ({})),
+}));
+
+const { prisma } = require('../../../database/prisma');
+const { UserRepositoryPostgres } = require('../user-repository-postgres');
+
+describe('UserRepositoryPostgres.findIndividualUsersByOrganizationId', () => {
+    let repository;
+
+    beforeEach(() => {
+        repository = new UserRepositoryPostgres();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('queries INDIVIDUAL users by integer organizationId and stringifies returned ids', async () => {
+        prisma.user.findMany.mockResolvedValue([
+            {
+                id: 2018,
+                type: 'INDIVIDUAL',
+                organizationId: 2019,
+                appUserId: 'USx4fhpNuR',
+            },
+        ]);
+
+        const result =
+            await repository.findIndividualUsersByOrganizationId('2019');
+
+        expect(prisma.user.findMany).toHaveBeenCalledWith({
+            where: {
+                organizationId: 2019,
+                type: 'INDIVIDUAL',
+            },
+        });
+        expect(result).toEqual([
+            {
+                id: '2018',
+                type: 'INDIVIDUAL',
+                organizationId: '2019',
+                appUserId: 'USx4fhpNuR',
+            },
+        ]);
+    });
+
+    it('returns an empty array when no individual users are linked', async () => {
+        prisma.user.findMany.mockResolvedValue([]);
+
+        expect(
+            await repository.findIndividualUsersByOrganizationId('2019')
+        ).toEqual([]);
+    });
+});

--- a/packages/core/user/repositories/user-repository-documentdb.js
+++ b/packages/core/user/repositories/user-repository-documentdb.js
@@ -4,6 +4,7 @@ const {
     toObjectId,
     fromObjectId,
     findOne,
+    findMany,
     insertOne,
     updateOne,
     deleteOne,
@@ -65,6 +66,22 @@ class UserRepositoryDocumentDB extends UserRepositoryInterface {
             doc
         );
         return this._mapUser(decrypted);
+    }
+
+    async findIndividualUsersByOrganizationId(organizationUserId) {
+        const docs = await findMany(this.prisma, 'User', {
+            organizationId: toObjectId(organizationUserId),
+            type: 'INDIVIDUAL',
+        });
+        return Promise.all(
+            docs.map(async (doc) => {
+                const decrypted = await this.encryptionService.decryptFields(
+                    'User',
+                    doc
+                );
+                return this._mapUser(decrypted);
+            })
+        );
     }
 
     async createToken(userId, rawToken, minutes = 120) {

--- a/packages/core/user/repositories/user-repository-interface.js
+++ b/packages/core/user/repositories/user-repository-interface.js
@@ -54,10 +54,7 @@ class UserRepositoryInterface {
     }
 
     /**
-     * Find all individual users linked to an organization user.
-     *
-     * appUserId (the external app's user id) lives only on individual users,
-     * so this is the path to resolve it from an organization user id.
+     * Find all individual users linked to an organization user
      *
      * @param {string|number} organizationUserId - Organization user ID
      * @returns {Promise<Object[]>} Array of individual user objects (empty if none)

--- a/packages/core/user/repositories/user-repository-interface.js
+++ b/packages/core/user/repositories/user-repository-interface.js
@@ -54,6 +54,22 @@ class UserRepositoryInterface {
     }
 
     /**
+     * Find all individual users linked to an organization user.
+     *
+     * appUserId (the external app's user id) lives only on individual users,
+     * so this is the path to resolve it from an organization user id.
+     *
+     * @param {string|number} organizationUserId - Organization user ID
+     * @returns {Promise<Object[]>} Array of individual user objects (empty if none)
+     * @abstract
+     */
+    async findIndividualUsersByOrganizationId(organizationUserId) {
+        throw new Error(
+            'Method findIndividualUsersByOrganizationId must be implemented by subclass'
+        );
+    }
+
+    /**
      * Create token with expiration
      *
      * @param {string|number} userId - User ID

--- a/packages/core/user/repositories/user-repository-mongo.js
+++ b/packages/core/user/repositories/user-repository-mongo.js
@@ -71,6 +71,21 @@ class UserRepositoryMongo extends UserRepositoryInterface {
     }
 
     /**
+     * Find all individual users linked to an organization user
+     *
+     * @param {string} organizationUserId - Organization user ID
+     * @returns {Promise<Object[]>} Array of individual user records (empty if none)
+     */
+    async findIndividualUsersByOrganizationId(organizationUserId) {
+        return await this.prisma.user.findMany({
+            where: {
+                organizationId: organizationUserId,
+                type: 'INDIVIDUAL',
+            },
+        });
+    }
+
+    /**
      * Create token with expiration
      * Delegates to TokenRepository
      *

--- a/packages/core/user/repositories/user-repository-postgres.js
+++ b/packages/core/user/repositories/user-repository-postgres.js
@@ -106,6 +106,23 @@ class UserRepositoryPostgres extends UserRepositoryInterface {
     }
 
     /**
+     * Find all individual users linked to an organization user
+     *
+     * @param {string} organizationUserId - Organization user ID (string from application layer)
+     * @returns {Promise<Object[]>} Array of individual user objects with string IDs (empty if none)
+     */
+    async findIndividualUsersByOrganizationId(organizationUserId) {
+        const intId = this._convertId(organizationUserId);
+        const users = await this.prisma.user.findMany({
+            where: {
+                organizationId: intId,
+                type: 'INDIVIDUAL',
+            },
+        });
+        return users.map((user) => this._convertUserIds(user));
+    }
+
+    /**
      * Create token with expiration
      * Delegates to TokenRepository
      *


### PR DESCRIPTION
## Why

Frigg can model a user as an organization user plus one or more linked individual users (`primary: 'organization'`). `appUserId` — the adopter's external user id — is stored only on **individual** users; `appOrgId` only on the **organization** user.

There was no way to resolve the linked individual user(s) from an organization user id. The individual-user lookups key off `id`, `appUserId`, `username`, or `email` — none off `organizationId`. So an adopter holding only the organization user id (e.g. when the primary user is the organization user) could not retrieve the `appUserId`, even though the link exists (`individualUser.organizationId`).

## What

Add `findIndividualUsersByOrganizationId(organizationUserId)`:

- **Repository** — across all four backends: `interface` (abstract), `mongo` (`findMany`), `postgres` (`findMany` + string/int id conversion), `documentdb` (`findMany` + field decryption + `_mapUser`).
- **Command** — exposed via `createUserCommands()` (and therefore `createFriggCommands()`), projecting `{ id, username, email, appUserId }`. Returns an **array** since an organization may have more than one linked individual user.

## Tests (TDD)

- `application/commands/__tests__/user-commands.test.js` — projection includes `appUserId` and excludes `hashword`; empty-array, missing-arg (400), and repo-error mapping.
- `user/repositories/__tests__/user-repository-postgres.test.js` — query shape (`type: 'INDIVIDUAL'` + integer `organizationId`) and string id conversion.

Existing `user-repository-documentdb-encryption.test.js` still passes (32/32). ESLint: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)