### PR TITLE
fix(core): centralize INVALID_AUTH notification in requester 401 handling

### DIFF
--- a/packages/core/modules/requester/oauth-2.js
+++ b/packages/core/modules/requester/oauth-2.js
@@ -315,13 +315,13 @@ class OAuth2Requester extends Requester {
             console.log('[Frigg] Token refresh succeeded');
             return true;
         } catch (error) {
-            console.error('[Frigg] Token refresh failed', {
+            const moduleName = this.delegate?.name ?? 'unknown module';
+            console.error(`[Frigg] Token refresh failed for ${moduleName}`, {
                 error_message: error?.message,
                 error_name: error?.name,
                 response_status: error?.response?.status,
                 response_data: error?.response?.data,
             });
-            await this.notify(this.DLGT_INVALID_AUTH);
             return false;
         }
     }

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -119,9 +119,7 @@ class Requester extends Delegate {
                 if (e?.code === 'ECONNRESET' && i < this.backOff.length) {
                     clearRequestTimer();
                     const delay = this.backOff[i] * 1000;
-                    await new Promise((resolve) =>
-                        setTimeout(resolve, delay)
-                    );
+                    await new Promise((resolve) => setTimeout(resolve, delay));
                     return this._request(url, options, i + 1);
                 }
                 const fetchError = await FetchError.create({
@@ -150,16 +148,24 @@ class Requester extends Delegate {
                 const delay = this.backOff[i] * 1000;
                 await new Promise((resolve) => setTimeout(resolve, delay));
                 return this._request(url, options, i + 1);
-            } else if (status === 401) {
+            }
+
+            if (status === 401) {
                 if (!this.isRefreshable) {
                     await this.notify(this.DLGT_INVALID_AUTH);
-                } else if (this.refreshCount === 0) {
+                    return;
+                }
+
+                if (this.refreshCount === 0) {
                     this.refreshCount++;
                     const refreshSucceeded = await this.refreshAuth();
                     if (refreshSucceeded) {
                         clearRequestTimer();
                         return this._request(url, options, i + 1);
                     }
+
+                    await this.notify(this.DLGT_INVALID_AUTH);
+                    return;
                 }
             }
 
@@ -201,8 +207,7 @@ class Requester extends Delegate {
     _maybeFlagTimeoutDuringBodyRead(err, timeoutMs) {
         if (!err || typeof err !== 'object') return err;
         if (err.isTimeout) return err;
-        const isAbort =
-            err.name === 'AbortError' || err.type === 'aborted';
+        const isAbort = err.name === 'AbortError' || err.type === 'aborted';
         if (!isAbort) return err;
         err.isTimeout = true;
         err.timeoutMs = timeoutMs;


### PR DESCRIPTION
## Summary
- Move the `DLGT_INVALID_AUTH` notification out of `OAuth2Requester.refreshAuth` and into `Requester._request`'s 401 branch.
- `_request` now fires `INVALID_AUTH` in both 401 cases — non-refreshable credentials, and after a failed refresh attempt — and each path `return`s instead of falling through.
- `refreshAuth` now only logs and returns `false`. The failure log names the module via `this.delegate?.name` (falls back to `unknown module`), e.g. `[Frigg] Token refresh failed for hubspot`.

## Behavior change
A 401 that ends in invalid auth now **resolves to `undefined`** instead of throwing a `FetchError`. Previously these paths fell through to `if (status >= 400) throw fetchError`. Callers that relied on a thrown error for a terminal 401 should be aware.

The credential-invalidation chain (`INVALID_AUTH` → `markCredentialsInvalid` → `CREDENTIAL_INVALIDATED` → integration `ERROR`) is unchanged — only the layer that emits the signal moved.

## Test plan
- [ ] `npm run test:all`
- [ ] `npm run lint:fix`
- [ ] Verify a failed refresh logs the module name and flips the integration to `ERROR`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.610.ca077d5.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/core@2.0.0--canary.610.ca077d5.0
  npm install @friggframework/devtools@2.0.0--canary.610.ca077d5.0
  npm install @friggframework/eslint-config@2.0.0--canary.610.ca077d5.0
  npm install @friggframework/prettier-config@2.0.0--canary.610.ca077d5.0
  npm install @friggframework/schemas@2.0.0--canary.610.ca077d5.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.610.ca077d5.0
  npm install @friggframework/test@2.0.0--canary.610.ca077d5.0
  npm install @friggframework/ui@2.0.0--canary.610.ca077d5.0
  # or 
  yarn add @friggframework/core@2.0.0--canary.610.ca077d5.0
  yarn add @friggframework/devtools@2.0.0--canary.610.ca077d5.0
  yarn add @friggframework/eslint-config@2.0.0--canary.610.ca077d5.0
  yarn add @friggframework/prettier-config@2.0.0--canary.610.ca077d5.0
  yarn add @friggframework/schemas@2.0.0--canary.610.ca077d5.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.610.ca077d5.0
  yarn add @friggframework/test@2.0.0--canary.610.ca077d5.0
  yarn add @friggframework/ui@2.0.0--canary.610.ca077d5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
