### PR TITLE
feat(core): add human-readable labels to integrations report

### DIFF
--- a/docs/frigg-management-api.yml
+++ b/docs/frigg-management-api.yml
@@ -906,7 +906,9 @@ components:
                                 Map of `type` slug to human-readable label, for
                                 resolving labels on `integrations[].type` rows.
                                 Contains only types whose registered integration
-                                class supplies a `display.label`.
+                                class supplies a non-default `display.label`
+                                (classes still carrying the IntegrationBase
+                                default `Integration Name` are excluded).
                             additionalProperties:
                                 type: string
                             example:

--- a/docs/frigg-management-api.yml
+++ b/docs/frigg-management-api.yml
@@ -885,12 +885,32 @@ components:
                                     type:
                                         type: string
                                         example: hubspot
+                                    label:
+                                        type: string
+                                        description: >-
+                                            Human-readable name from the
+                                            integration class's
+                                            `Definition.display.label`; falls back
+                                            to the `type` slug when no registered
+                                            class provides one.
+                                        example: HubSpot CRM
                                     total:
                                         type: integer
                                     byStatus:
                                         type: object
                                         additionalProperties:
                                             type: integer
+                        typeLabels:
+                            type: object
+                            description: >-
+                                Map of `type` slug to human-readable label, for
+                                resolving labels on `integrations[].type` rows.
+                                Contains only types whose registered integration
+                                class supplies a `display.label`.
+                            additionalProperties:
+                                type: string
+                            example:
+                                hubspot: HubSpot CRM
                         integrations:
                             type: array
                             items:

--- a/packages/core/reporting/README.md
+++ b/packages/core/reporting/README.md
@@ -1,0 +1,85 @@
+# Reporting
+
+Read-only, deployment-wide reporting endpoints for `@friggframework/core`.
+Gated by a dedicated reporting API key — **not** the per-user auth used by the
+rest of the Management API.
+
+## Auth
+
+Send the reporting key in the `x-frigg-reporting-api-key` header. It is validated
+against the `REPORTING_API_KEY` environment variable. Missing or wrong key → `401`.
+
+## Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/v2/reports` | Index of available reports. |
+| `GET` | `/api/v2/reports/integrations` | Integrations report (see below). |
+
+### `GET /api/v2/reports/integrations`
+
+Optional query params (all strings): `status` (an `IntegrationStatus`), `type`
+(`config.type` slug), `userId`.
+
+## Response shape
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "service": "frigg-core-api",
+  "generatedAt": "2026-06-29T20:45:05.142Z",
+  "filters": { "status": null, "type": null, "userId": null },
+  "metrics": {
+    "total": 12,
+    "byStatus": { "ENABLED": 9, "ERROR": 2, "NEEDS_CONFIG": 1, "PROCESSING": 0, "DISABLED": 0 },
+    "byType": [
+      {
+        "type": "hubspot",
+        "label": "HubSpot CRM",
+        "total": 5,
+        "byStatus": { "ENABLED": 4, "ERROR": 1, "NEEDS_CONFIG": 0, "PROCESSING": 0, "DISABLED": 0 }
+      }
+    ],
+    "typeLabels": { "hubspot": "HubSpot CRM" },
+    "integrations": [ /* lightweight per-integration rows */ ]
+  }
+}
+```
+
+## Field reference
+
+- `schemaVersion` — contract version; branch on it. Additive changes do **not** bump it.
+- `filters` — echoes the applied filters (nulls when omitted).
+- `metrics.total` — count of integrations matching the filters.
+- `metrics.byStatus` — counts keyed by `IntegrationStatus` value.
+- `metrics.byType[]` — per `type` breakdown: `{ type, label, total, byStatus }`.
+  - `type` — the `config.type` slug. Integrations with no type bucket as `"unknown"`.
+  - `label` — human-readable name from the integration class's
+    `Definition.display.label`. Falls back to the `type` slug when no registered
+    class supplies a label (e.g. an integration that was removed, or run on an
+    older app that doesn't register it). Additive — `type` is unchanged.
+- `metrics.typeLabels` — map of `type` slug → human-readable label, so callers can
+  label `integrations[].type` rows without bloating each row. Contains only types
+  whose registered class supplies a `display.label`.
+- `metrics.integrations[]` — lightweight per-integration rows (`id`, `type`,
+  `status`, `userId`, `version`, `moduleCount`, `errorCount`, `mappedRecordCount`,
+  `createdAt`, `updatedAt`). These rows carry `type` only — resolve display names
+  via `metrics.typeLabels`.
+
+## How labels are sourced
+
+`createReportingRouter()` loads the app's registered integration classes via
+`loadAppDefinition()` and builds a `{ slug → label }` map from each class's
+`Definition.display.label`. Loading is wrapped in try/catch, so reporting still
+works (labels fall back to slugs) if the app definition can't be loaded. The
+`ListIntegrationsReport` use case stays storage-agnostic — it just reads the
+injected `typeLabels` map, so all database adapters (PostgreSQL, MongoDB,
+DocumentDB) get labels with zero adapter changes.
+
+## Caveats
+
+- The response is sensitive (exposes integration types, counts, user IDs, versions).
+  Treat the reporting key as an admin secret.
+- Read-only — no mutation endpoints.
+- Labels only appear once the deployment runs a `@friggframework/core` version that
+  includes this field and the app registers the integration classes.

--- a/packages/core/reporting/README.md
+++ b/packages/core/reporting/README.md
@@ -60,7 +60,8 @@ Optional query params (all strings): `status` (an `IntegrationStatus`), `type`
     older app that doesn't register it). Additive — `type` is unchanged.
 - `metrics.typeLabels` — map of `type` slug → human-readable label, so callers can
   label `integrations[].type` rows without bloating each row. Contains only types
-  whose registered class supplies a `display.label`.
+  whose registered class supplies a non-default `display.label` (classes still
+  carrying the IntegrationBase default `'Integration Name'` are excluded).
 - `metrics.integrations[]` — lightweight per-integration rows (`id`, `type`,
   `status`, `userId`, `version`, `moduleCount`, `errorCount`, `mappedRecordCount`,
   `createdAt`, `updatedAt`). These rows carry `type` only — resolve display names

--- a/packages/core/reporting/reporting-router.js
+++ b/packages/core/reporting/reporting-router.js
@@ -4,11 +4,40 @@ const {
     createReportingRepository,
 } = require('./repositories/reporting-repository-factory');
 const { ListIntegrationsReport } = require('./use-cases/list-integrations-report');
+const { loadAppDefinition } = require('../handlers/app-definition-loader');
+
+// IntegrationBase.Definition default — skip it so the slug is used instead.
+const PLACEHOLDER_DISPLAY_NAME = 'Integration Name';
+
+// Map each integration's config.type slug to its human-readable display label.
+// Wrapped so reporting still works if the app definition fails to load.
+function buildTypeLabels() {
+    try {
+        const { integrations = [] } = loadAppDefinition();
+        const labels = {};
+        for (const IntegrationClass of integrations) {
+            const def = IntegrationClass?.Definition;
+            if (!def?.name) continue;
+            const label = def.display?.label;
+            if (label && label !== PLACEHOLDER_DISPLAY_NAME) {
+                labels[def.name] = label;
+            }
+        }
+        return labels;
+    } catch (error) {
+        console.error(
+            'Reporting: failed to load integration labels:',
+            error.message
+        );
+        return {};
+    }
+}
 
 function createReportingRouter() {
     const reportingRepository = createReportingRepository();
     const listIntegrationsReport = new ListIntegrationsReport({
         reportingRepository,
+        typeLabels: buildTypeLabels(),
     });
 
     const router = express.Router();

--- a/packages/core/reporting/reporting-router.test.js
+++ b/packages/core/reporting/reporting-router.test.js
@@ -21,6 +21,15 @@ jest.mock('./repositories/reporting-repository-factory', () => ({
     })),
 }));
 
+jest.mock('../handlers/app-definition-loader', () => ({
+    loadAppDefinition: jest.fn(() => ({
+        integrations: [
+            { Definition: { name: 'hubspot', display: { label: 'HubSpot CRM' } } },
+            { Definition: { name: 'salesforce', display: { label: 'Salesforce' } } },
+        ],
+    })),
+}));
+
 const { createReportingRouter, validateApiKey } = require('./reporting-router');
 
 const mockRes = () => {
@@ -119,6 +128,18 @@ describe('reporting-router', () => {
                 status: 'ENABLED',
                 type: null,
                 userId: '7',
+            });
+        });
+
+        it('labels byType entries from the loaded integration definitions', async () => {
+            const res = mockRes();
+            await integrationsHandler()({ query: {} }, res, jest.fn());
+            const body = res.json.mock.calls[0][0];
+            const hub = body.metrics.byType.find((t) => t.type === 'hubspot');
+            expect(hub.label).toBe('HubSpot CRM');
+            expect(body.metrics.typeLabels).toEqual({
+                hubspot: 'HubSpot CRM',
+                salesforce: 'Salesforce',
             });
         });
     });

--- a/packages/core/reporting/use-cases/list-integrations-report.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.js
@@ -88,7 +88,7 @@ class ListIntegrationsReport {
                 total: integrations.length,
                 byStatus,
                 byType: Array.from(byTypeMap.values()),
-                typeLabels: this.typeLabels,
+                typeLabels: { ...this.typeLabels },
                 integrations,
             },
         };

--- a/packages/core/reporting/use-cases/list-integrations-report.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.js
@@ -14,11 +14,12 @@ const KNOWN_STATUSES = [
 ];
 
 class ListIntegrationsReport {
-    constructor({ reportingRepository } = {}) {
+    constructor({ reportingRepository, typeLabels = {} } = {}) {
         if (!reportingRepository) {
             throw new Error('reportingRepository is required');
         }
         this.reportingRepository = reportingRepository;
+        this.typeLabels = typeLabels;
     }
 
     async execute(query = {}) {
@@ -64,6 +65,7 @@ class ListIntegrationsReport {
             if (!byTypeMap.has(integration.type)) {
                 byTypeMap.set(integration.type, {
                     type: integration.type,
+                    label: this.typeLabels[integration.type] || integration.type,
                     total: 0,
                     byStatus: emptyStatusCounts(),
                 });
@@ -86,6 +88,7 @@ class ListIntegrationsReport {
                 total: integrations.length,
                 byStatus,
                 byType: Array.from(byTypeMap.values()),
+                typeLabels: this.typeLabels,
                 integrations,
             },
         };

--- a/packages/core/reporting/use-cases/list-integrations-report.test.js
+++ b/packages/core/reporting/use-cases/list-integrations-report.test.js
@@ -217,4 +217,42 @@ describe('ListIntegrationsReport', () => {
         expect(r2.createdAt).toBe('2026-03-04T05:06:07.000Z');
         expect(r2.updatedAt).toBeNull();
     });
+
+    it('labels byType buckets from the typeLabels map and exposes the map', async () => {
+        const rows = [
+            { id: '1', type: 'hubspot', status: 'ENABLED', moduleCount: 1, errorCount: 0 },
+            { id: '2', type: 'salesforce', status: 'ENABLED', moduleCount: 1, errorCount: 0 },
+        ];
+        const typeLabels = { hubspot: 'HubSpot CRM', salesforce: 'Salesforce' };
+        const useCase = new ListIntegrationsReport({
+            reportingRepository: makeRepo(rows),
+            typeLabels,
+        });
+
+        const out = await useCase.execute({});
+
+        const hub = out.metrics.byType.find((t) => t.type === 'hubspot');
+        expect(hub.label).toBe('HubSpot CRM');
+        const sf = out.metrics.byType.find((t) => t.type === 'salesforce');
+        expect(sf.label).toBe('Salesforce');
+        expect(out.metrics.typeLabels).toEqual(typeLabels);
+    });
+
+    it('falls back to the slug when a type has no label, and defaults typeLabels to {}', async () => {
+        const rows = [
+            { id: '1', type: 'hubspot', status: 'ENABLED', moduleCount: 1, errorCount: 0 },
+            { id: '2', type: null, status: 'ENABLED', moduleCount: 0, errorCount: 0 },
+        ];
+        const useCase = new ListIntegrationsReport({
+            reportingRepository: makeRepo(rows),
+        });
+
+        const out = await useCase.execute({});
+
+        const hub = out.metrics.byType.find((t) => t.type === 'hubspot');
+        expect(hub.label).toBe('hubspot');
+        const unknown = out.metrics.byType.find((t) => t.type === 'unknown');
+        expect(unknown.label).toBe('unknown');
+        expect(out.metrics.typeLabels).toEqual({});
+    });
 });


### PR DESCRIPTION
## Summary

Adds **human-readable integration labels** to the read-only integrations report (`GET /api/v2/reports/integrations`). The endpoint previously identified each integration only by its `config.type` slug (`"zoho"`, `"attio"`, ...). A downstream consumer (a client-facing "Integration Health" dashboard) needs friendly names ("Zoho CRM", "Pipedrive"). That name already lives on each integration class — this surfaces it.

Two **additive** fields:
- `metrics.byType[].label` — human-readable name per type bucket
- `metrics.typeLabels` — top-level `{ slug → label }` map, so callers can label `integrations[].type` rows without bloating each row

Sourced from each registered integration class's `Definition.display.label`, with a **slug fallback** when no registered class supplies one.

### Note on the field source
The original spec assumed the name lived at `Definition.display.name`. In practice that's a vestigial placeholder (`'Integration Name'`) — real integration classes populate `Definition.display.**label**`, and the framework's own DTO (`integrations/options.js:20`) reads `label`. Reading `display.name` would have made the feature a silent no-op, so this reads `display.label`.

## Design
- **Use case** (`list-integrations-report.js`): accepts an optional injected `typeLabels` map; adds `label: typeLabels[type] || type` to each `byType` bucket and exposes `metrics.typeLabels`. Stays storage-agnostic — all DB adapters (Postgres/Mongo/DocumentDB) benefit with zero adapter changes.
- **Router** (`reporting-router.js`): `buildTypeLabels()` loads registered classes via `loadAppDefinition()` (mirrors `handlers/routers/health.js`), reading `display.label` and filtering the base placeholder. Wrapped in try/catch so reporting never throws if the app definition can't load (→ labels fall back to slugs).

## Compatibility
- `type` unchanged; `label`/`typeLabels` are purely additive.
- `schemaVersion` stays `1` (additive contract).
- No new auth, routes, env vars, or infrastructure. Read-only. No change to `integrations[]` row shape.

## Test plan
- [x] `npx jest reporting` → 6 suites / 35 tests green (use-case label-from-map + slug fallback + `typeLabels` echo; router mocks `loadAppDefinition` and asserts `byType` labels)
- [x] ESLint: 0 errors on touched files
- [x] OpenAPI spec (`docs/frigg-management-api.yml`) updated for `label` + `typeLabels` (YAML validated)
- [x] No consumers of `byType`/`ListIntegrationsReport` outside the reporting module

## Notes
- A reporting `README.md` did not exist on `next`; it's created here.
- Each client Frigg instance must bump `@friggframework/core` + redeploy for labels to appear; the dashboard will render `label || type` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
