### PR TITLE
docs(adr): ADR-010 Reporting as an Admin Operation + ADR-011 Telemetry &amp; Usage Tracking

### DIFF
--- a/docs/architecture-decisions/010-reporting-as-admin-operation.md
+++ b/docs/architecture-decisions/010-reporting-as-admin-operation.md
@@ -82,6 +82,97 @@ must never surface in an end-user-scoped query.
 - **Adopter, operations:** a scheduled per-tenant operational export pushed to an external admin
   dashboard, gated by the admin key — no direct database access to each instance.
 
+## Run Modes & Persistence
+
+A report definition is *standing* (registered, runnable on demand). Each invocation picks a **run
+mode**, and persistence follows from the mode:
+
+| Mode | Persists | Use it for |
+|---|---|---|
+| **live** | nothing — compute and return inline | cheap, always-fresh queries (what #607 does today) |
+| **recorded** | an execution record (input + results + logs) in the admin store | audit trail, async polling, expensive/large reports |
+| **snapshot** | a recorded run retained as a point-in-time data point in a series | trends over time (30/60/90-day actives, growth) |
+
+`live` keeps #607's behavior as a first-class mode; `recorded` and `snapshot` are what unlock
+history and time-windowed metrics. A snapshot is just a recorded run tagged with a series name +
+`capturedAt`; listing a series returns the trend. All three run through the **one** runner and the
+isolated admin execution store from Decision 3.
+
+**Definition** (mirrors `AdminScriptBase`; illustrative):
+
+```js
+class ConnectedAccountsActivity extends ReportBase {
+  static Definition = {
+    name: 'connected-accounts-activity',
+    version: '1.0.0',
+    description: 'Connected accounts active in the last N days, by integration type',
+    runModes: ['snapshot', 'recorded', 'live'],     // allowed modes; first is the default
+    inputSchema: { type: 'object', properties: {
+      windowDays: { type: 'integer', enum: [30, 60, 90], default: 30 } } },
+    output: { format: 'json' },                      // 'csv' | 'pdf' | 'zip' → artifact storage
+    schedule: { enabled: true, cron: 'cron(0 6 * * ? *)', mode: 'snapshot' },
+  };
+
+  async execute(frigg, params) {
+    const since = daysAgo(params.windowDays ?? 30);
+    const byType = await frigg.report.activeIntegrationsSince(since); // generic counters (Decision 5)
+    return { windowDays: params.windowDays ?? 30, byType };
+  }
+}
+```
+
+**Invocation** — one runner; the mode selects the persistence path:
+
+```
+POST /api/v2/reports/:name/run  { "mode":"live",     "params":{...} } → 200 inline result, nothing stored
+POST /api/v2/reports/:name/run  { "mode":"recorded", "params":{...} } → 202 { executionId }; poll GET /reports/executions/:id
+GET  /api/v2/reports/:name/snapshots?from=&to=                        → [ { capturedAt, summary, artifactUrl? } ]  // trend series
+```
+
+**Artifact storage** for non-JSON / large output (object storage + signed URL, never public):
+
+```js
+const exec = await adminExecutions.create({ scope: 'admin', kind: 'report', name, params, state: 'RUNNING' });
+const result = await reportRunner.execute(definition, params);
+
+if (definition.output.format === 'json') {
+  await adminExecutions.complete(exec.id, { results: result });           // small payload inline in the record
+} else {
+  const ref = await artifactStore.put(                                     // large/binary → object storage
+    `reports/${exec.id}/${name}-${stamp}.${ext}`, result.file, contentType);
+  await adminExecutions.complete(exec.id, { summary: result.summary, artifact: ref });
+}
+// download later, time-limited, no public exposure:
+const url = await artifactStore.signedUrl(exec.artifact, { expiresIn: 3600 });
+```
+
+### Derived from FreshBooks-frigg
+
+The FreshBooks-frigg repo already runs this pattern (its `ReportRunner` + `AdminProcess` + S3).
+Worth lifting, but adapt to ADR-005's hexagonal layering rather than copying its Mongoose /
+direct-`aws-sdk` form:
+
+- **Lambda-timeout-aware long runs.** Its runner checks `context.getRemainingTimeInMillis()` against
+  a per-step `timeoutLimit` and **re-queues itself to resume at the next step**, chunking a job that
+  exceeds the Lambda ceiling across invocations. This is the answer to "a deployment-wide scan is too
+  expensive per request" — the scan runs as a `recorded`/`snapshot` job, not in the request path.
+  ```js
+  if (context.getRemainingTimeInMillis() < nextStep.timeoutLimit) {
+    await queue.requeue({ executionId: exec.id, resumeAt: nextStep.name }); // same SQS worker resumes
+    return;
+  }
+  ```
+- **Artifact lifecycle.** `storeReportFile` (key `reports/{id}/{name}-{ts}.{ext}`, content-type per a
+  `fileType` of csv/json/pdf/zip) + `generateSignedUrl` (1-hour expiry) + `getPreviousReports`
+  (prior runs, newest first). That last one *is* the snapshot-series listing.
+- **Parameterization for a generated UI.** Each definition carries `options: { jsonSchema, uiSchema,
+  data }` and an admin UI renders the form from it. Reuse ADR-005's `inputSchema` for the same effect.
+- **Multi-step / fan-out.** Handlers emit `actions.sendMessage` to a parent/child process — useful
+  when a report aggregates sub-reports. Optional; only where composition is needed.
+
+**Do not copy:** FreshBooks stores admin processes in the same datastore space as app data. Per
+Decision 3, keep the admin execution store isolated from the user/integration-scoped `Process`.
+
 ## Consequences
 
 ### Positive

--- a/docs/architecture-decisions/010-reporting-as-admin-operation.md
+++ b/docs/architecture-decisions/010-reporting-as-admin-operation.md
@@ -62,12 +62,15 @@ must never surface in an end-user-scoped query.
    are adopter-registered definitions, an adopter ships a report from *their* repository against a
    published `@friggframework/core` — no fork, no core release per report.
 
-5. **Cross-integration metrics need a generic contract.** The built-in usage-comparison report is
-   only apples-to-apples if core defines a standard way for each integration type to surface
-   comparable counts (e.g. records synced, webhooks received, workflows invoked) rather than
-   per-adopter bespoke fields. Built-in reports read these generic counters; adopter reports may
-   extend them. This generalized metric contract is a prerequisite for the comparison report and is
-   tracked as follow-up scope, not assumed to exist today.
+5. **Structural generics exist today; feature-based usage tracking is the gap.** Core already
+   exposes cross-integration generics every report can read now: status, type, version,
+   module/entity count, error count, mapped-record count, created/updated timestamps, and
+   credential-refresh timestamps (a usable "active" proxy). What core does **not** yet have is
+   **feature-level usage tracking** — comparable counters such as records synced, webhooks received,
+   or workflows invoked, accumulated per integration over time. So the comparison report's
+   *structural* columns work on existing generics immediately; its *usage* columns require a generic
+   usage-counter contract (emit + persist per-feature counts) and are follow-up scope. This is the
+   "can do with data today vs. needs more data" split.
 
 ### Conceivable use cases
 
@@ -75,7 +78,9 @@ must never surface in an end-user-scoped query.
   **cross-integration usage comparison** — apples-to-apples counts (records synced, webhooks
   received, workflows invoked) per integration type, so any adopter can see how each of their
   integrations performs relative to the others. This is generically valuable to every adopter and
-  therefore ships in core, not as an adopter definition.
+  therefore ships in core, not as an adopter definition. Its structural columns (status, counts,
+  timestamps) run on today's generics; the usage columns depend on the feature-usage tracking in
+  Decision 5.
 - **Adopter, "data we have today":** connected accounts active in the last 30/60/90 days, derived
   from integration `createdAt` + credential-refresh timestamps — a few lines in one report
   definition, run async so a deployment-wide scan never blocks a request.

--- a/docs/architecture-decisions/010-reporting-as-admin-operation.md
+++ b/docs/architecture-decisions/010-reporting-as-admin-operation.md
@@ -62,15 +62,23 @@ must never surface in an end-user-scoped query.
    are adopter-registered definitions, an adopter ships a report from *their* repository against a
    published `@friggframework/core` — no fork, no core release per report.
 
+5. **Cross-integration metrics need a generic contract.** The built-in usage-comparison report is
+   only apples-to-apples if core defines a standard way for each integration type to surface
+   comparable counts (e.g. records synced, webhooks received, workflows invoked) rather than
+   per-adopter bespoke fields. Built-in reports read these generic counters; adopter reports may
+   extend them. This generalized metric contract is a prerequisite for the comparison report and is
+   tracked as follow-up scope, not assumed to exist today.
+
 ### Conceivable use cases
 
-- **Core built-in:** integrations by status/type (#607); OAuth token-health; per-type error rates.
+- **Core built-in:** integrations by status/type (#607); OAuth token-health; per-type error rates;
+  **cross-integration usage comparison** — apples-to-apples counts (records synced, webhooks
+  received, workflows invoked) per integration type, so any adopter can see how each of their
+  integrations performs relative to the others. This is generically valuable to every adopter and
+  therefore ships in core, not as an adopter definition.
 - **Adopter, "data we have today":** connected accounts active in the last 30/60/90 days, derived
   from integration `createdAt` + credential-refresh timestamps — a few lines in one report
   definition, run async so a deployment-wide scan never blocks a request.
-- **Adopter, product analytics:** apples-to-apples usage across integration types (records synced,
-  webhooks received, workflows invoked) so a Frigg adopter can compare how each of their
-  integrations is performing.
 - **Adopter, operations:** a scheduled per-tenant operational export pushed to an external admin
   dashboard, gated by the admin key — no direct database access to each instance.
 

--- a/docs/architecture-decisions/010-reporting-as-admin-operation.md
+++ b/docs/architecture-decisions/010-reporting-as-admin-operation.md
@@ -1,0 +1,111 @@
+# ADR-010: Reporting as an Admin Operation
+
+**Status**: Proposed
+**Date**: 2026-06-30
+**Deciders**: Daniel Klotz, Sean Matthews
+
+## Context
+
+Two adjacent capabilities have been built independently:
+
+- **Admin Script Runner** (ADR-005, accepted): adopters and core register operations via
+  `adminScripts: []` in the app definition; each extends `AdminScriptBase` (mirroring
+  `IntegrationBase`); a `ScriptRunner` executes them sync or async over SQS, with a dedicated
+  admin API key, a separate `ScriptExecutionRepository`, and EventBridge scheduling.
+- **Reporting API** (PR #607, on `next`): a read-only `/api/v2/reports/integrations` endpoint.
+  It is a self-contained silo — its own router, its own repository triad, its own API key — that
+  reuses **none** of the script-runner primitives. It exposes exactly one hardcoded report;
+  adding another requires editing and republishing `@friggframework/core`.
+
+These are the same shape of problem — *a deployment-wide admin operation that reads/derives data,
+runs sync or scheduled, and is gated by an admin key* — solved twice. A report is just a script
+whose output is the payload. Left as-is, every new report is a core release, and adopters cannot
+ship their own reports against an off-the-shelf core.
+
+Separately, the `Process` model (`packages/core/integrations/repositories/`) is **user- and
+integration-scoped**. Admin operations are **cross-integration and deployment-wide**; their records
+must never surface in an end-user-scoped query.
+
+### Scope boundary (what this ADR is *not* about)
+
+"Migration" names three unrelated things; none are admin operations under this ADR:
+
+1. **Project-scaffold migration** — `create-frigg-app` → `frigg init` (ADR-004, CLI, build-time).
+2. **Prisma/db schema migration** — `handlers/workers/db-migration.js` (deploy-time infra).
+3. **Integration *data* version migration** — `devtools` `Migrator` (per-integration record
+   upgrades). This *could* later run as an admin operation, but is out of scope here.
+
+## Decision
+
+**Treat reporting as an admin operation — a sibling of admin scripts — on shared primitives.**
+
+1. **One registry, two sources.** Reports register via `reports: []` in the app definition,
+   exactly like `adminScripts`. **Core ships built-in reports; adopters define their own.** Both
+   are discovered, listed, and executed through the same runner. PR #607's integrations report
+   becomes the first built-in report definition, not a bespoke endpoint.
+
+2. **`ReportBase` mirrors `AdminScriptBase`.** A report is a definition (`name`, `version`,
+   `description`, optional `inputSchema`/`outputSchema`, optional `schedule`) with an `execute`
+   method receiving the same admin helper (`AdminFriggCommands`) and returning a structured
+   payload. Reports reuse the runner, admin API key, sync/async execution, and scheduling defined
+   in ADR-005 rather than reintroducing them.
+
+3. **Shared admin execution store, isolated from end users.** Admin operation records (script and
+   report executions) persist in their **own table/namespace** — extending ADR-005's
+   `ScriptExecutionRepository` rather than the integration-scoped `Process` model. Admin records
+   are a distinct type, not a row in a user's process list. Whether implemented as a separate table
+   or a discriminated (`scope: 'admin'`) partition, the repository layer **must guarantee that a
+   user-context query can never return an admin record**, and vice versa. This isolation is the
+   reason admin operations are not folded into `Process`.
+
+4. **Adopter reports run on stock core.** Because the runner and registry live in core and reports
+   are adopter-registered definitions, an adopter ships a report from *their* repository against a
+   published `@friggframework/core` — no fork, no core release per report.
+
+### Conceivable use cases
+
+- **Core built-in:** integrations by status/type (#607); OAuth token-health; per-type error rates.
+- **Adopter, "data we have today":** connected accounts active in the last 30/60/90 days, derived
+  from integration `createdAt` + credential-refresh timestamps — a few lines in one report
+  definition, run async so a deployment-wide scan never blocks a request.
+- **Adopter, product analytics:** apples-to-apples usage across integration types (records synced,
+  webhooks received, workflows invoked) so a Frigg adopter can compare how each of their
+  integrations is performing.
+- **Adopter, operations:** a scheduled per-tenant operational export pushed to an external admin
+  dashboard, gated by the admin key — no direct database access to each instance.
+
+## Consequences
+
+### Positive
+- One mental model and one set of primitives for all admin operations; new reports are config, not
+  a core release.
+- Adopters extend reporting without forking core; ad-hoc admin queries become durable, versioned
+  report definitions instead of throwaway scripts.
+- Async + scheduling come for free, addressing the cost of deployment-wide scans.
+- Admin/user isolation is explicit and enforced at the repository boundary.
+
+### Negative
+- #607's standalone reporting router/repository must be refactored onto the runner (one-time cost;
+  its repository logic is largely reusable as the first report definition).
+- A second persistence concern (admin execution store vs. integration `Process`) to keep distinct.
+
+### Neutral
+- The dedicated reporting API key collapses into the admin API key (ADR-005); one admin auth model.
+- Reporting moves from "a feature in core" to "a capability adopters populate."
+
+## Alternatives Considered
+
+- **Keep reporting as its own subsystem (status quo).** Rejected: duplicates the runner, auth, and
+  (eventually) job/scheduling machinery already accepted in ADR-005, and locks every report behind
+  a core release.
+- **Fold reporting into the per-user integration router.** Rejected: mixes a user-scoped auth model
+  with deployment-wide admin reads and reintroduces the bleed-over risk decision #3 prevents.
+- **Reuse the integration `Process` model for admin records.** Rejected for isolation: that model is
+  user/integration-scoped; admin operations are cross-integration and must not be reachable from
+  user context.
+
+## Related
+- [ADR-005: Admin Script Runner Service](./005-admin-script-runner.md)
+- [ADR-004: Migration Tool Design](./004-migration-tool-design.md)
+- Reporting API (PR #607): `packages/core/reporting/`
+- Integration `Process` model: `packages/core/integrations/repositories/`

--- a/docs/architecture-decisions/010-reporting-as-admin-operation.md
+++ b/docs/architecture-decisions/010-reporting-as-admin-operation.md
@@ -44,6 +44,16 @@ must never surface in an end-user-scoped query.
    are discovered, listed, and executed through the same runner. PR #607's integrations report
    becomes the first built-in report definition, not a bespoke endpoint.
 
+   ```js
+   // app definition — same shape as adminScripts
+   const Definition = {
+     name: 'my-app',
+     integrations: [HubSpotIntegration, SalesforceIntegration],
+     reports: [ConnectedAccountsActivity, RevenueByType],  // adopter-defined
+     admin: { includeBuiltinReports: true },               // + core built-ins (integrations, usage-comparison, ...)
+   };
+   ```
+
 2. **`ReportBase` mirrors `AdminScriptBase`.** A report is a definition (`name`, `version`,
    `description`, optional `inputSchema`/`outputSchema`, optional `schedule`) with an `execute`
    method receiving the same admin helper (`AdminFriggCommands`) and returning a structured
@@ -57,6 +67,19 @@ must never surface in an end-user-scoped query.
    or a discriminated (`scope: 'admin'`) partition, the repository layer **must guarantee that a
    user-context query can never return an admin record**, and vice versa. This isolation is the
    reason admin operations are not folded into `Process`.
+
+   ```js
+   // admin execution store — separate from the integration-scoped Process repo
+   class AdminExecutionRepository {                 // every row is scope:'admin'
+     async create({ kind, name, params }) { /* writes scope:'admin' only */ }
+     async findById(id) { /* ... */ }
+     async listByName(name, { from, to }) { /* snapshot series */ }
+   }
+   // hard guard, enforced at the repository boundary:
+   //   ProcessRepository.find({ userId })  → scope:'user' rows only
+   //   AdminExecutionRepository.*          → scope:'admin' rows only
+   // neither can ever return the other's rows.
+   ```
 
 4. **Adopter reports run on stock core.** Because the runner and registry live in core and reports
    are adopter-registered definitions, an adopter ships a report from *their* repository against a

--- a/docs/architecture-decisions/011-integration-telemetry-and-usage-tracking.md
+++ b/docs/architecture-decisions/011-integration-telemetry-and-usage-tracking.md
@@ -36,6 +36,15 @@ feeds a durable usage store for reporting.
    definition (OTLP → the adopter's backend: Honeycomb / Datadog / CloudWatch / etc.); the default
    is no-op/console so telemetry rides for free in dev and adds nothing mandatory.
 
+   ```js
+   // core wraps the OTel SDK; integrations use this, never a vendor SDK
+   const telemetry = createTelemetry({
+     exporter: appDefinition.telemetry?.exporter ?? { type: 'none' }, // no-op default
+     resource: { service: appName, stage },
+   });
+   // injected onto each integration instance as this.telemetry
+   ```
+
 2. **Auto-instrumentation that rides for free.** Framework seams emit spans + low-cardinality
    counters with no developer effort:
    - **Instantiation** — every integration instance opens a context carrying standard identifiers
@@ -48,6 +57,18 @@ feeds a durable usage store for reporting.
      the `Worker`/queue and webhook seams.
    These yield ADR-010's usage counters as a byproduct of normal execution — zero per-integration
    code.
+
+   ```js
+   // framework wraps every handler dispatch — devs write no telemetry for this
+   async function dispatch(event, handler, ctx) {
+     return telemetry.span(`handler.${event.type}`, async (span) => {
+       span.setAttributes(ctx.identifiers);              // integrationId, integrationType, userId, version
+       telemetry.count('frigg.handler.invocations', 1, {
+         integration_type: ctx.integrationType, event: event.type });
+       return handler(event);
+     });
+   }
+   ```
 
 3. **Standard context / baggage.** The identifier set from instantiation rides every emission as
    resource attributes / baggage, so all telemetry is sliceable by integration, type, and tenant.
@@ -92,6 +113,15 @@ feeds a durable usage store for reporting.
    comparison report and snapshot series read. This is deliberately distinct from OTel export: OTel
    feeds observability backends; the rollup owns durable, queryable usage history for reports.
    **Reports never query an external APM.**
+
+   ```js
+   // built-in subscriber: fold selected signals into the durable usage store reports read
+   telemetry.on('metric', ({ name, value, attrs }) => {
+     if (!usageRollup.tracks(name)) return;              // only rolled-up metrics + north star
+     usageRollup.increment({ integrationType: attrs.integration_type, metric: name, value });
+   });
+   // ADR-010 `snapshot` mode periodically persists usageRollup values → trend series
+   ```
 
 ### Relationship to ADR-010
 

--- a/docs/architecture-decisions/011-integration-telemetry-and-usage-tracking.md
+++ b/docs/architecture-decisions/011-integration-telemetry-and-usage-tracking.md
@@ -136,6 +136,81 @@ Per-user / per-integration labels explode metric cardinality. Rule: high-cardina
 (integrationType, event, endpoint, status). The usage rollup derives per-integration counts from
 spans, not from unbounded metric labels.
 
+## Usage-Counter Contract
+
+The concrete contract behind ADR-010 Decision 5 — how integrations declare comparable counters, and
+how those are emitted, persisted, and read by reports. It is a thin convention on the ADR-011
+metrics primitive, **not** a parallel API.
+
+**1. Canonical vocabulary (core-owned, versioned).** A registry of well-known counter keys is what
+makes cross-integration comparison apples-to-apples. Canonical keys are the only metrics guaranteed
+comparable *across* integration types.
+
+```js
+const CANONICAL_COUNTERS = {
+  'records.synced':    { unit: 'count', label: 'Records synced',    dims: ['entity'] },
+  'webhooks.received': { unit: 'count', label: 'Webhooks received', dims: ['event'] },
+  'workflows.invoked': { unit: 'count', label: 'Workflows invoked', dims: ['workflow'] },
+  'api.requests':      { unit: 'count', label: 'API requests',      dims: ['endpoint', 'status'] },
+  'user_actions':      { unit: 'count', label: 'User actions',      dims: ['action'] },
+};
+```
+
+**2. Declaration (opt-in per integration).** An integration declares which counters it reports.
+Declaring a canonical key opts it into the comparison report and the rollup; custom keys are
+surfaced but comparable only *within* that integration type.
+
+```js
+class HubSpotIntegration extends IntegrationBase {
+  static Definition = {
+    name: 'hubspot',
+    usage: {
+      canonical: ['records.synced', 'webhooks.received', 'api.requests'],
+      custom: { 'deals.enriched': { unit: 'count', label: 'Deals enriched' } },
+    },
+  };
+}
+```
+
+**3. Emission (one path, two sources).** A usage counter is an ordinary ADR-011 metric whose key is
+canonical or declared in `usage`. Populated either by auto-instrumentation (Decision 2 maps
+framework signals: api-module request → `api.requests`, webhook seam → `webhooks.received`,
+`USER_ACTION` handler → `user_actions`) or explicitly:
+
+```js
+this.telemetry.count('records.synced', batch.length, { entity: 'contact' });
+```
+
+**4. Persistence (rollup store, isolated).** The Decision-7 subscriber folds declared counters into
+a Frigg-owned usage store with its own repository triad (postgres/mongo/documentdb), isolated per
+ADR-010 Decision 3. Dimensions must be bounded (Cardinality note); high-cardinality ids stay on
+traces.
+
+```js
+class UsageRepositoryInterface {                 // port; adapters mirror reporting/process
+  async increment({ integrationId, integrationType, metric, value, window }) {}
+  async totals({ metric, groupBy, since }) {}                     // comparison
+  async series({ metric, integrationType, from, to, bucket }) {}  // trend
+}
+// fact row: { integrationId, integrationType, metric, window, value, updatedAt }
+```
+
+**5. Read contract (what reports call).**
+
+```js
+frigg.usage.totals({ metric: 'records.synced', groupBy: 'integrationType', since })
+  // → [{ integrationType, value }]                    powers the apples-to-apples comparison
+frigg.usage.series({ metric: 'records.synced', integrationType: 'hubspot', from, to, bucket: 'day' })
+  // → [{ bucket, value }]                             powers snapshot / trend
+```
+
+**6. North Star** references a counter key (canonical or custom); Decision 5's config maps it to a
+derived-from-trace signal or a direct emission — no separate mechanism.
+
+**Rules:** canonical keys compare across types; custom keys compare within a type; the registry is
+versioned and additive (new keys never break existing reports); declaration in `Definition.usage` is
+the single opt-in for rollup + report inclusion.
+
 ## Consequences
 
 ### Positive

--- a/docs/architecture-decisions/011-integration-telemetry-and-usage-tracking.md
+++ b/docs/architecture-decisions/011-integration-telemetry-and-usage-tracking.md
@@ -1,0 +1,143 @@
+# ADR-011: Integration Telemetry, Eventing & Feature-Usage Tracking
+
+**Status**: Proposed
+**Date**: 2026-06-30
+**Deciders**: Sean Matthews, Daniel Klotz
+
+## Context
+
+ADR-010 (Reporting as an Admin Operation) found that core exposes only *structural*
+cross-integration generics — status, type, version, module/error/mapping counts, timestamps,
+credential-refresh. It has **no feature-level usage tracking**: records synced, webhooks received,
+workflows invoked, messages used, user actions taken. More broadly, Frigg has no first-class
+observability layer — an operator running a fleet of per-tenant instances cannot see what
+integrations are doing without bespoke logging, and there is no standard, vendor-neutral way to
+emit traces/metrics/events or to tap into them.
+
+Two needs converge on one substrate:
+
+1. **Observability** — traces and logs across handlers, queues, API modules, per integration, for
+   debugging and fleet health.
+2. **Product/usage analytics** — durable per-integration counters that feed ADR-010's
+   cross-integration comparison report and snapshot trends, plus an adopter-defined North Star.
+
+Both should ride on the same primitive, emit useful signal *for free*, and be extensible by the
+same plugin/extension model Frigg already uses.
+
+## Decision
+
+Adopt **OpenTelemetry (OTel)** as the vendor-neutral telemetry substrate (traces, metrics,
+logs/events), wrapped by a core telemetry/logger abstraction, with auto-instrumentation at
+framework seams, dev-defined custom metrics, an adopter North Star, and a plugin/extension tap that
+feeds a durable usage store for reporting.
+
+1. **One abstraction, vendor-neutral.** A core `TelemetryService` (working name) wraps the OTel
+   SDK; integration code never imports a backend SDK. The exporter is configured in the app
+   definition (OTLP → the adopter's backend: Honeycomb / Datadog / CloudWatch / etc.); the default
+   is no-op/console so telemetry rides for free in dev and adds nothing mandatory.
+
+2. **Auto-instrumentation that rides for free.** Framework seams emit spans + low-cardinality
+   counters with no developer effort:
+   - **Instantiation** — every integration instance opens a context carrying standard identifiers
+     (integrationId, integrationType, userId, version, stage, appName), logged once and propagated.
+   - **Handlers** — each `USER_ACTION` / `CRON` / `QUEUE` / `WEBHOOK` invocation → a span +
+     `frigg.handler.invocations{integration_type, event}`.
+   - **API modules** — each outbound request from an Api class → a span +
+     `frigg.apimodule.requests{module, endpoint, status}`.
+   - **Queue / webhook / sync** — messages processed, webhooks received, sync runs — emitted from
+     the `Worker`/queue and webhook seams.
+   These yield ADR-010's usage counters as a byproduct of normal execution — zero per-integration
+   code.
+
+3. **Standard context / baggage.** The identifier set from instantiation rides every emission as
+   resource attributes / baggage, so all telemetry is sliceable by integration, type, and tenant.
+
+4. **Dev-defined custom metrics.** Integration developers emit through the same abstraction —
+   same context, same exporters, no vendor lock-in:
+   ```js
+   this.telemetry.count('records_synced', batch.length, { entity: 'contact' });
+   this.telemetry.event('workflow_invoked', { workflow: 'lead_route' });
+   await this.telemetry.span('delta_sync', async () => { /* ... */ });
+   ```
+
+5. **Adopter North Star metric.** An adopter declares, at base or in config, a north-star metric
+   for integrations (or for a given integration type), populated either way:
+   - **(a) Derived from default traces** — config maps the north star to an auto-emitted signal:
+     "every request to endpoint X," "every use of message Y," "every `USER_ACTION` Z counts."
+     Config-only, no code.
+   - **(b) Directly emitted** in integration code via `this.telemetry.*`.
+
+   Either way it is surfaced through the telemetry/logger service as a first-class metric that
+   reports and snapshots can read.
+   ```js
+   // app definition
+   telemetry: {
+     exporter: { type: 'otlp', endpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT },
+     northStar: {
+       default: { name: 'records_synced' },
+       byType: {
+         crm: { name: 'contacts_synced',
+                deriveFrom: { apiRequest: { endpoint: '/contacts', method: 'POST' } } },
+       },
+     },
+   }
+   ```
+
+6. **Eventing + plugin/extension taps.** Telemetry also flows onto an internal event stream that
+   plugins/extensions subscribe to — forward to a custom sink, compute aggregates, persist counters.
+   This applies Frigg's existing module-plugin extension model to telemetry.
+
+7. **Durable usage rollup for reporting (the ADR-010 hand-off).** A built-in subscriber rolls
+   selected counters / north-star values into a Frigg-owned **usage store** that ADR-010's
+   comparison report and snapshot series read. This is deliberately distinct from OTel export: OTel
+   feeds observability backends; the rollup owns durable, queryable usage history for reports.
+   **Reports never query an external APM.**
+
+### Relationship to ADR-010
+
+ADR-011 **produces** the feature-usage counters; ADR-010 **reads** them. The comparison report
+renders its structural columns today and its usage columns once this lands; ADR-010's `snapshot`
+mode persists the rollup over time.
+
+### Cardinality note
+
+Per-user / per-integration labels explode metric cardinality. Rule: high-cardinality identifiers
+(userId, integrationId) belong on **traces/baggage**; **metrics** aggregate to bounded dimensions
+(integrationType, event, endpoint, status). The usage rollup derives per-integration counts from
+spans, not from unbounded metric labels.
+
+## Consequences
+
+### Positive
+- Free baseline observability across the fleet; vendor-neutral and swappable backend.
+- Feature-usage tracking unblocks ADR-010's usage columns and trend snapshots.
+- Adopters get a declarative North Star without bespoke plumbing.
+- Telemetry is tappable through the existing plugin/extension model.
+
+### Negative
+- OTel SDK adds dependency weight and some cold-start cost (mitigate: lazy init, sampling, no-op
+  default).
+- Exporter configuration and backend cost fall on the adopter.
+- The durable usage rollup + store is net-new and must stay isolated per ADR-010 Decision 3.
+
+### Neutral
+- Introduces a standard identifier / resource-attribute schema that all emissions carry.
+- Establishes OTel as the observability standard, superseding ad-hoc console logging over time.
+
+## Alternatives Considered
+
+- **Ad-hoc / bespoke logging per integration.** Rejected: not standard, not tappable, no
+  apples-to-apples, no free baseline.
+- **Require adopters to bring their own instrumentation.** Rejected: no default signal; defeats core
+  reports.
+- **Reuse the `Process` model as the telemetry/usage store.** Rejected: `Process` tracks
+  operations, not high-volume telemetry; cardinality and retention differ. The usage rollup is its
+  own store.
+- **A proprietary Frigg telemetry format.** Rejected: OTel is the interop standard; don't reinvent.
+
+## Related
+- [ADR-010: Reporting as an Admin Operation](./010-reporting-as-admin-operation.md)
+- [ADR-005: Admin Script Runner Service](./005-admin-script-runner.md)
+- Instrumentation + extension seams: integration events (`USER_ACTION`/`CRON`/`QUEUE`/`WEBHOOK`),
+  `createFriggCommands`, the `Worker` queue base, the module-plugin system.
+- OpenTelemetry: https://opentelemetry.io/

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -22,6 +22,7 @@ An ADR documents a significant architectural decision made in the project, inclu
 | [003](./003-runtime-state-only.md) | Runtime State Only for Management GUI | Accepted | 2025-01-25 |
 | [004](./004-migration-tool-design.md) | Migration Tool Design | Proposed | 2025-01-25 |
 | [005](./005-admin-script-runner.md) | Admin Script Runner Service | Accepted | 2025-12-10 |
+| [010](./010-reporting-as-admin-operation.md) | Reporting as an Admin Operation | Proposed | 2026-06-30 |
 
 ## ADR Template
 

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -22,6 +22,10 @@ An ADR documents a significant architectural decision made in the project, inclu
 | [003](./003-runtime-state-only.md) | Runtime State Only for Management GUI | Accepted | 2025-01-25 |
 | [004](./004-migration-tool-design.md) | Migration Tool Design | Proposed | 2025-01-25 |
 | [005](./005-admin-script-runner.md) | Admin Script Runner Service | Accepted | 2025-12-10 |
+| [006](./006-integration-router-v2.md) | Integration Router v2 | Accepted | 2025-12-14 |
+| [007](./007-management-ui-architecture.md) | Management UI Architecture | Accepted | 2025-12-14 |
+| [008](./008-frigg-cli-start-command.md) | Frigg CLI Start Command | Accepted | 2025-12-14 |
+| [009](./009-e2e-test-package.md) | E2E Test Package | Accepted | 2025-12-15 |
 | [010](./010-reporting-as-admin-operation.md) | Reporting as an Admin Operation | Proposed | 2026-06-30 |
 
 ## ADR Template

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -27,6 +27,7 @@ An ADR documents a significant architectural decision made in the project, inclu
 | [008](./008-frigg-cli-start-command.md) | Frigg CLI Start Command | Accepted | 2025-12-14 |
 | [009](./009-e2e-test-package.md) | E2E Test Package | Accepted | 2025-12-15 |
 | [010](./010-reporting-as-admin-operation.md) | Reporting as an Admin Operation | Proposed | 2026-06-30 |
+| [011](./011-integration-telemetry-and-usage-tracking.md) | Integration Telemetry, Eventing & Feature-Usage Tracking | Proposed | 2026-06-30 |
 
 ## ADR Template
 


### PR DESCRIPTION
## Summary

Docs-only. Two related, tightly-coupled ADRs (both **Proposed**) under `docs/architecture-decisions/`, plus index rows.

### ADR-010 — Reporting as an Admin Operation
Reporting should be a **sibling of the accepted Admin Script Runner (ADR-005)**, not a standalone subsystem. A report is an admin operation whose output is the payload, so it should register via `reports: []` in the app definition (like `adminScripts: []`), extend a `ReportBase` mirroring `AdminScriptBase`, and reuse the shared admin primitives (registry, runner, admin auth, sync/async, scheduling). **Core ships built-in reports; adopters define their own** against off-the-shelf `@friggframework/core`. PR #607's integrations report becomes the first built-in.

Key decisions:
- Unify on the ADR-005 runner/auth/scheduling primitives (one admin-operation model).
- **Isolation:** admin operation records are cross-integration/deployment-wide and live in their own admin execution store — never the user/integration-scoped `Process` model; no bleed-over in either direction.
- **Core built-in cross-integration usage comparison** (apples-to-apples per integration type). Structural columns run on today's generics; usage columns depend on ADR-011.
- **Run modes & persistence:** `live` (compute-and-return, #607 today) / `recorded` (execution record) / `snapshot` (retained point-in-time series → trends), plus object-storage artifacts + signed URLs.
- Derives concrete ideas from the FreshBooks-frigg `ReportRunner`/`AdminProcess`/S3 pattern (timeout-aware requeue for long scans, artifact lifecycle, schema-driven UI params, parent/child fan-out) — adapted to Frigg's hexagonal layering.
- Scopes out the three unrelated "migration" concepts (project-scaffold/CLI per ADR-004, Prisma schema via `db-migration.js`, integration data-version via devtools `Migrator`).

### ADR-011 — Integration Telemetry, Eventing & Feature-Usage Tracking
The feature-usage counters ADR-010 needs, delivered as part of a broader observability layer. Adopt **OpenTelemetry** behind a core telemetry/logger abstraction:
- **Free auto-instrumentation** at framework seams — instantiation identifiers, `USER_ACTION`/`CRON`/`QUEUE`/`WEBHOOK` handlers, api-module requests, queues/webhooks/sync.
- **Dev-defined custom metrics** via the same abstraction.
- **Adopter North Star** metric (per integration or type), populated either derived-from-trace (config-only) or directly emitted.
- **Plugin/extension taps** on an internal event stream; a **durable usage rollup** feeds ADR-010's usage columns and snapshots (reports never query an external APM).
- Cardinality guardrail: high-cardinality ids on traces/baggage, metrics aggregated to bounded dimensions.

**ADR-011 produces what ADR-010 Decision 5 reads.**

## Notes for reviewers

- Docs only — no code changes; nothing to release (holding `release`/`prerelease` since no package ships).
- Opened as **draft** for discussion before promoting either from Proposed.
- Branch is based on `next` so the ADRs sit beside 001–009 and reference the real `packages/core/reporting/` and `packages/core/integrations/repositories/` code.
- ADR-010 and ADR-011 are stacked in this one PR because 011 produces the data 010 consumes; happy to split 011 into its own PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)