### PR TITLE
fix(core): dedupe integration creation on re-authorize with race backstop

### DIFF
--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -341,6 +341,9 @@ class IntegrationBase {
      */
     async reconcileAuthStatus(authPassed) {
         if (!authPassed) {
+            console.log(
+                `[Frigg] Integration ${this.id} failed to authenticate`
+            );
             await this.persistStatus('ERROR');
         }
         if (authPassed && this.status === 'ERROR') {
@@ -539,6 +542,7 @@ class IntegrationBase {
     async persistStatus(status) {
         await this.updateIntegrationStatus.execute(this.id, status);
         this.status = status;
+        console.log(`[Frigg] Integration ${this.id} status changed to ${status}`);
     }
 
     isActive() {

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -300,7 +300,10 @@ class IntegrationBase {
 
         for (const module of Object.keys(this.constructor.Definition.modules)) {
             try {
-                await this[module].testAuth();
+                const authPassed = await this[module].testAuth();
+                if (!authPassed) {
+                    throw new Error(`testAuth returned false for module ${module}`);
+                }
             } catch {
                 didAuthPass = false;
                 await this.updateIntegrationMessages.execute(

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -312,7 +312,7 @@ class IntegrationBase {
                     'Authentication Error',
                     `There was an error with your ${this[
                         module
-                    ].constructor.getName()} Entity.
+                    ].getName()} Entity.
                 Please reconnect/re-authenticate, or reach out to Support for assistance.`,
                     Date.now()
                 );

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -295,6 +295,16 @@ class IntegrationBase {
         }
     }
 
+    /**
+     * Verify every module's credentials. Records a diagnostic error message
+     * per failing module and returns whether all passed. Does not directly
+     * change integration status — the caller decides the consequence (see
+     * reconcileAuthStatus), so a passive check and an active reconnect can
+     * react differently. (A module can still fire a credential-invalidated
+     * delegate that flips status via receiveNotification, independent of this
+     * return value.)
+     * @returns {Promise<boolean>} True when every module authenticated.
+     */
     async testAuth() {
         let didAuthPass = true;
 
@@ -319,11 +329,22 @@ class IntegrationBase {
             }
         }
 
-        if (!didAuthPass) {
+        return didAuthPass;
+    }
+
+    /**
+     * Reconcile the auth-health axis (ERROR ↔ ENABLED) from a testAuth result.
+     * On success it never clears DISABLED — a user pause is not an auth-health
+     * state, so it is only lifted by a deliberate reconnect. On failure the
+     * integration is marked ERROR regardless of its prior status.
+     * @param {boolean} authPassed - The result of testAuth().
+     */
+    async reconcileAuthStatus(authPassed) {
+        if (!authPassed) {
             await this.persistStatus('ERROR');
         } else if (this.status === 'ERROR') {
             console.log(
-                `[Frigg] testAuth passed for integration ${this.id} — clearing ERROR → ENABLED`
+                `[Frigg] auth confirmed for integration ${this.id} — clearing ERROR → ENABLED`
             );
             await this.persistStatus('ENABLED');
         }
@@ -674,7 +695,7 @@ class IntegrationBase {
      * Receives notifications from modules (the Delegate pattern) when
      * something integration-level needs attention. Today this catches the
      * `CREDENTIAL_INVALIDATED` event Module fires from `markCredentialsInvalid`
-     * and flips this integration's status to DISABLED so the queue worker
+     * and flips this integration's status to ERROR so the queue worker
      * stops processing further webhooks until the user re-authorizes.
      *
      * Modules are wired to this delegate in `_appendModules()`, which runs

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -320,14 +320,12 @@ class IntegrationBase {
         }
 
         if (!didAuthPass) {
-            await this.updateIntegrationStatus.execute(this.id, 'ERROR');
-            this.status = 'ERROR';
+            await this.persistStatus('ERROR');
         } else if (this.status === 'ERROR') {
             console.log(
                 `[Frigg] testAuth passed for integration ${this.id} — clearing ERROR → ENABLED`
             );
-            await this.updateIntegrationStatus.execute(this.id, 'ENABLED');
-            this.status = 'ENABLED';
+            await this.persistStatus('ENABLED');
         }
     }
 
@@ -510,6 +508,17 @@ class IntegrationBase {
         this.messages.warnings.push(warning);
     }
 
+    /**
+     * Persist a status change and keep the in-memory field in sync. The
+     * single place that couples both writes, so no caller can update the
+     * database while leaving `this.status` stale.
+     * @param {string} status - The new integration status.
+     */
+    async persistStatus(status) {
+        await this.updateIntegrationStatus.execute(this.id, status);
+        this.status = status;
+    }
+
     isActive() {
         return this.status === 'ENABLED' || this.status === 'ACTIVE';
     }
@@ -687,8 +696,7 @@ class IntegrationBase {
             console.log(
                 `[Frigg] Module ${notifier?.name || '?'} reported invalid credentials for integration ${this.id} — marking ERROR`
             );
-            await this.updateIntegrationStatus.execute(this.id, 'ERROR');
-            this.status = 'ERROR';
+            await this.persistStatus('ERROR');
             return;
         }
 
@@ -697,8 +705,7 @@ class IntegrationBase {
             console.log(
                 `[Frigg] Module ${notifier?.name || '?'} reported valid credentials for integration ${this.id} — clearing ERROR → ENABLED`
             );
-            await this.updateIntegrationStatus.execute(this.id, 'ENABLED');
-            this.status = 'ENABLED';
+            await this.persistStatus('ENABLED');
         }
     }
 }

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -342,7 +342,8 @@ class IntegrationBase {
     async reconcileAuthStatus(authPassed) {
         if (!authPassed) {
             await this.persistStatus('ERROR');
-        } else if (this.status === 'ERROR') {
+        }
+        if (authPassed && this.status === 'ERROR') {
             console.log(
                 `[Frigg] auth confirmed for integration ${this.id} — clearing ERROR → ENABLED`
             );

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -318,6 +318,13 @@ class IntegrationBase {
 
         if (!didAuthPass) {
             await this.updateIntegrationStatus.execute(this.id, 'ERROR');
+            this.status = 'ERROR';
+        } else if (this.status === 'ERROR') {
+            console.log(
+                `[Frigg] testAuth passed for integration ${this.id} — clearing ERROR → ENABLED`
+            );
+            await this.updateIntegrationStatus.execute(this.id, 'ENABLED');
+            this.status = 'ENABLED';
         }
     }
 

--- a/packages/core/integrations/integration-router.js
+++ b/packages/core/integrations/integration-router.js
@@ -468,7 +468,8 @@ function setIntegrationRoutes(router, authenticateUser, useCases) {
             }
 
             const start = Date.now();
-            await instance.testAuth();
+            const authPassed = await instance.testAuth();
+            await instance.reconcileAuthStatus(authPassed);
             const errors = instance.record.messages?.errors?.filter(
                 ({ timestamp }) => timestamp >= start
             );

--- a/packages/core/integrations/repositories/integration-repository-documentdb.js
+++ b/packages/core/integrations/repositories/integration-repository-documentdb.js
@@ -200,6 +200,7 @@ class IntegrationRepositoryDocumentDB extends IntegrationRepositoryInterface {
             version: doc?.version ?? null,
             status: doc?.status ?? null,
             messages,
+            createdAt: doc?.createdAt ?? null,
         };
     }
 

--- a/packages/core/integrations/repositories/integration-repository-mongo.js
+++ b/packages/core/integrations/repositories/integration-repository-mongo.js
@@ -48,6 +48,7 @@ class IntegrationRepositoryMongo extends IntegrationRepositoryInterface {
             version: integration.version,
             status: integration.status,
             messages: integration.messages,
+            createdAt: integration.createdAt,
         }));
     }
 

--- a/packages/core/integrations/repositories/integration-repository-postgres.js
+++ b/packages/core/integrations/repositories/integration-repository-postgres.js
@@ -84,6 +84,7 @@ class IntegrationRepositoryPostgres extends IntegrationRepositoryInterface {
                 version: converted.version,
                 status: converted.status,
                 messages: converted.messages,
+                createdAt: converted.createdAt,
             };
         });
     }

--- a/packages/core/integrations/tests/doubles/dummy-integration-class.js
+++ b/packages/core/integrations/tests/doubles/dummy-integration-class.js
@@ -32,6 +32,7 @@ class DummyIntegration extends IntegrationBase {
     constructor(params) {
         super(params);
         this.sendSpy = jest.fn();
+        this.testAuthSpy = jest.fn();
         this.eventCallHistory = [];
         this.events = {};
 
@@ -64,6 +65,10 @@ class DummyIntegration extends IntegrationBase {
 
     async initialize() {
         return;
+    }
+
+    async testAuth() {
+        this.testAuthSpy();
     }
 
     async onCreate({ integrationId }) {

--- a/packages/core/integrations/tests/doubles/test-integration-repository.js
+++ b/packages/core/integrations/tests/doubles/test-integration-repository.js
@@ -17,6 +17,7 @@ class TestIntegrationRepository {
             version: '0.0.0',
             status: 'NEW',
             messages: {},
+            createdAt: new Date(),
         };
         this.store.set(id, record);
         this.operationHistory.push({ operation: 'create', id, userId, config });

--- a/packages/core/integrations/tests/integration-base-persist-status.test.js
+++ b/packages/core/integrations/tests/integration-base-persist-status.test.js
@@ -1,0 +1,50 @@
+jest.mock('../../database/config', () => ({
+    DB_TYPE: 'mongodb',
+    getDatabaseType: jest.fn(() => 'mongodb'),
+    PRISMA_LOG_LEVEL: 'error,warn',
+    PRISMA_QUERY_LOGGING: false,
+}));
+
+const { IntegrationBase } = require('../integration-base');
+
+describe('IntegrationBase.persistStatus', () => {
+    let integration;
+    let mockUpdateIntegrationStatus;
+
+    beforeEach(() => {
+        integration = new IntegrationBase();
+        integration.id = 'int-1';
+        integration.status = 'ENABLED';
+
+        mockUpdateIntegrationStatus = {
+            execute: jest.fn().mockResolvedValue(true),
+        };
+        integration.updateIntegrationStatus = mockUpdateIntegrationStatus;
+    });
+
+    it('persists the new status through the injected command', async () => {
+        await integration.persistStatus('ERROR');
+
+        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
+            'int-1',
+            'ERROR'
+        );
+    });
+
+    it('syncs the in-memory status field', async () => {
+        await integration.persistStatus('ERROR');
+
+        expect(integration.status).toBe('ERROR');
+    });
+
+    it('leaves the in-memory status unchanged when the persist fails', async () => {
+        mockUpdateIntegrationStatus.execute.mockRejectedValue(
+            new Error('db down')
+        );
+
+        await expect(integration.persistStatus('ERROR')).rejects.toThrow(
+            'db down'
+        );
+        expect(integration.status).toBe('ENABLED');
+    });
+});

--- a/packages/core/integrations/tests/integration-base-reconcile-auth-status.test.js
+++ b/packages/core/integrations/tests/integration-base-reconcile-auth-status.test.js
@@ -1,0 +1,65 @@
+jest.mock('../../database/config', () => ({
+    DB_TYPE: 'mongodb',
+    getDatabaseType: jest.fn(() => 'mongodb'),
+    PRISMA_LOG_LEVEL: 'error,warn',
+    PRISMA_QUERY_LOGGING: false,
+}));
+
+const { IntegrationBase } = require('../integration-base');
+
+describe('IntegrationBase.reconcileAuthStatus', () => {
+    let integration;
+    let mockUpdateIntegrationStatus;
+
+    beforeEach(() => {
+        integration = new IntegrationBase();
+        integration.id = 'int-1';
+        integration.status = 'ENABLED';
+
+        mockUpdateIntegrationStatus = {
+            execute: jest.fn().mockResolvedValue(true),
+        };
+        integration.updateIntegrationStatus = mockUpdateIntegrationStatus;
+    });
+
+    it('marks ERROR when auth did not pass', async () => {
+        await integration.reconcileAuthStatus(false);
+
+        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
+            'int-1',
+            'ERROR'
+        );
+        expect(integration.status).toBe('ERROR');
+    });
+
+    it('heals ERROR to ENABLED when auth passed', async () => {
+        integration.status = 'ERROR';
+
+        await integration.reconcileAuthStatus(true);
+
+        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
+            'int-1',
+            'ENABLED'
+        );
+        expect(integration.status).toBe('ENABLED');
+    });
+
+    it('does nothing when auth passed and status is already ENABLED', async () => {
+        await integration.reconcileAuthStatus(true);
+
+        expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+        expect(integration.status).toBe('ENABLED');
+    });
+
+    it.each(['NEEDS_CONFIG', 'DISABLED', 'PROCESSING'])(
+        'leaves %s untouched when auth passed (only the ERROR axis is reconciled)',
+        async (status) => {
+            integration.status = status;
+
+            await integration.reconcileAuthStatus(true);
+
+            expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+            expect(integration.status).toBe(status);
+        }
+    );
+});

--- a/packages/core/integrations/tests/integration-base-test-auth.test.js
+++ b/packages/core/integrations/tests/integration-base-test-auth.test.js
@@ -1,0 +1,101 @@
+jest.mock('../../database/config', () => ({
+    DB_TYPE: 'mongodb',
+    getDatabaseType: jest.fn(() => 'mongodb'),
+    PRISMA_LOG_LEVEL: 'error,warn',
+    PRISMA_QUERY_LOGGING: false,
+}));
+
+const { IntegrationBase } = require('../integration-base');
+
+class TestAuthIntegration extends IntegrationBase {
+    static Definition = {
+        ...IntegrationBase.Definition,
+        modules: { testmodule: {} },
+    };
+}
+
+describe('IntegrationBase.testAuth', () => {
+    let integration;
+    let mockUpdateIntegrationStatus;
+    let mockUpdateIntegrationMessages;
+
+    beforeEach(() => {
+        integration = new TestAuthIntegration();
+        integration.id = 'int-1';
+        integration.status = 'ENABLED';
+
+        mockUpdateIntegrationStatus = {
+            execute: jest.fn().mockResolvedValue(true),
+        };
+        mockUpdateIntegrationMessages = {
+            execute: jest.fn().mockResolvedValue(true),
+        };
+        integration.updateIntegrationStatus = mockUpdateIntegrationStatus;
+        integration.updateIntegrationMessages = mockUpdateIntegrationMessages;
+
+        integration.testmodule = {
+            testAuth: jest.fn().mockResolvedValue(true),
+            constructor: { getName: () => 'testmodule' },
+        };
+    });
+
+    it("flips ERROR to ENABLED when every module's auth check passes", async () => {
+        integration.status = 'ERROR';
+
+        await integration.testAuth();
+
+        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
+            'int-1',
+            'ENABLED'
+        );
+        expect(integration.status).toBe('ENABLED');
+    });
+
+    it('does not touch status when auth passes and the integration is already ENABLED', async () => {
+        await integration.testAuth();
+
+        expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+        expect(integration.status).toBe('ENABLED');
+    });
+
+    it.each(['NEEDS_CONFIG', 'DISABLED', 'PROCESSING'])(
+        'does not heal %s when auth passes',
+        async (status) => {
+            integration.status = status;
+
+            await integration.testAuth();
+
+            expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+            expect(integration.status).toBe(status);
+        }
+    );
+
+    it('sets ERROR when a module auth check fails', async () => {
+        integration.testmodule.testAuth.mockRejectedValue(
+            new Error('bad creds')
+        );
+
+        await integration.testAuth();
+
+        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
+            'int-1',
+            'ERROR'
+        );
+        expect(integration.status).toBe('ERROR');
+    });
+
+    it('keeps ERROR when a currently-ERROR integration still fails auth', async () => {
+        integration.status = 'ERROR';
+        integration.testmodule.testAuth.mockRejectedValue(
+            new Error('bad creds')
+        );
+
+        await integration.testAuth();
+
+        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
+            'int-1',
+            'ERROR'
+        );
+        expect(integration.status).toBe('ERROR');
+    });
+});

--- a/packages/core/integrations/tests/integration-base-test-auth.test.js
+++ b/packages/core/integrations/tests/integration-base-test-auth.test.js
@@ -33,9 +33,12 @@ describe('IntegrationBase.testAuth', () => {
         integration.updateIntegrationStatus = mockUpdateIntegrationStatus;
         integration.updateIntegrationMessages = mockUpdateIntegrationMessages;
 
+        // Shaped like a real Module instance: getName() is defined on the
+        // instance itself (Module.prototype.getName() returns this.name),
+        // not on the constructor.
         integration.testmodule = {
             testAuth: jest.fn().mockResolvedValue(true),
-            constructor: { getName: () => 'testmodule' },
+            getName: () => 'testmodule',
         };
     });
 
@@ -113,6 +116,24 @@ describe('IntegrationBase.testAuth', () => {
             'ERROR'
         );
         expect(integration.status).toBe('ERROR');
+    });
+
+    it('records the failing module name in the error message without crashing', async () => {
+        // Regression: the error-message builder used to read
+        // this[module].constructor.getName(), which does not exist on a real
+        // Module instance (getName() is an instance method) — every genuine
+        // auth failure crashed here instead of recording the error.
+        integration.testmodule.testAuth.mockResolvedValue(false);
+
+        await integration.testAuth();
+
+        expect(mockUpdateIntegrationMessages.execute).toHaveBeenCalledWith(
+            'int-1',
+            'errors',
+            'Authentication Error',
+            expect.stringContaining('testmodule'),
+            expect.any(Number)
+        );
     });
 
     it('does not heal ERROR to ENABLED when a module resolves false', async () => {

--- a/packages/core/integrations/tests/integration-base-test-auth.test.js
+++ b/packages/core/integrations/tests/integration-base-test-auth.test.js
@@ -70,7 +70,7 @@ describe('IntegrationBase.testAuth', () => {
         }
     );
 
-    it('sets ERROR when a module auth check fails', async () => {
+    it('sets ERROR when a module auth check throws', async () => {
         integration.testmodule.testAuth.mockRejectedValue(
             new Error('bad creds')
         );
@@ -84,7 +84,7 @@ describe('IntegrationBase.testAuth', () => {
         expect(integration.status).toBe('ERROR');
     });
 
-    it('keeps ERROR when a currently-ERROR integration still fails auth', async () => {
+    it('keeps ERROR when a currently-ERROR integration still throws on auth', async () => {
         integration.status = 'ERROR';
         integration.testmodule.testAuth.mockRejectedValue(
             new Error('bad creds')
@@ -95,6 +95,39 @@ describe('IntegrationBase.testAuth', () => {
         expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
             'int-1',
             'ERROR'
+        );
+        expect(integration.status).toBe('ERROR');
+    });
+
+    it('sets ERROR when a module resolves false (the real Module.testAuth contract on bad credentials)', async () => {
+        // Module.testAuth() catches its own request failures and resolves
+        // false rather than rejecting — this is how real modules (Attio,
+        // AxisCare, HouseCallPro) report a 401. A resolved false must be
+        // treated the same as a thrown error.
+        integration.testmodule.testAuth.mockResolvedValue(false);
+
+        await integration.testAuth();
+
+        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
+            'int-1',
+            'ERROR'
+        );
+        expect(integration.status).toBe('ERROR');
+    });
+
+    it('does not heal ERROR to ENABLED when a module resolves false', async () => {
+        integration.status = 'ERROR';
+        integration.testmodule.testAuth.mockResolvedValue(false);
+
+        await integration.testAuth();
+
+        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
+            'int-1',
+            'ERROR'
+        );
+        expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalledWith(
+            'int-1',
+            'ENABLED'
         );
         expect(integration.status).toBe('ERROR');
     });

--- a/packages/core/integrations/tests/integration-base-test-auth.test.js
+++ b/packages/core/integrations/tests/integration-base-test-auth.test.js
@@ -42,87 +42,31 @@ describe('IntegrationBase.testAuth', () => {
         };
     });
 
-    it("flips ERROR to ENABLED when every module's auth check passes", async () => {
-        integration.status = 'ERROR';
-
-        await integration.testAuth();
-
-        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
-            'int-1',
-            'ENABLED'
-        );
-        expect(integration.status).toBe('ENABLED');
+    it('returns true when every module authenticates', async () => {
+        await expect(integration.testAuth()).resolves.toBe(true);
     });
 
-    it('does not touch status when auth passes and the integration is already ENABLED', async () => {
-        await integration.testAuth();
-
-        expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
-        expect(integration.status).toBe('ENABLED');
-    });
-
-    it.each(['NEEDS_CONFIG', 'DISABLED', 'PROCESSING'])(
-        'does not heal %s when auth passes',
-        async (status) => {
-            integration.status = status;
-
-            await integration.testAuth();
-
-            expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
-            expect(integration.status).toBe(status);
-        }
-    );
-
-    it('sets ERROR when a module auth check throws', async () => {
+    it('returns false when a module throws', async () => {
         integration.testmodule.testAuth.mockRejectedValue(
             new Error('bad creds')
         );
 
-        await integration.testAuth();
-
-        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
-            'int-1',
-            'ERROR'
-        );
-        expect(integration.status).toBe('ERROR');
+        await expect(integration.testAuth()).resolves.toBe(false);
     });
 
-    it('keeps ERROR when a currently-ERROR integration still throws on auth', async () => {
-        integration.status = 'ERROR';
-        integration.testmodule.testAuth.mockRejectedValue(
-            new Error('bad creds')
-        );
-
-        await integration.testAuth();
-
-        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
-            'int-1',
-            'ERROR'
-        );
-        expect(integration.status).toBe('ERROR');
-    });
-
-    it('sets ERROR when a module resolves false (the real Module.testAuth contract on bad credentials)', async () => {
+    it('returns false when a module resolves false (the real Module.testAuth contract on bad credentials)', async () => {
         // Module.testAuth() catches its own request failures and resolves
         // false rather than rejecting — this is how real modules (Attio,
-        // AxisCare, HouseCallPro) report a 401. A resolved false must be
-        // treated the same as a thrown error.
+        // AxisCare, HouseCallPro) report a 401.
         integration.testmodule.testAuth.mockResolvedValue(false);
 
-        await integration.testAuth();
-
-        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
-            'int-1',
-            'ERROR'
-        );
-        expect(integration.status).toBe('ERROR');
+        await expect(integration.testAuth()).resolves.toBe(false);
     });
 
-    it('records the failing module name in the error message without crashing', async () => {
-        // Regression: the error-message builder used to read
+    it('records the failing module name in an error message without crashing', async () => {
+        // Regression: the message builder used to read
         // this[module].constructor.getName(), which does not exist on a real
-        // Module instance (getName() is an instance method) — every genuine
-        // auth failure crashed here instead of recording the error.
+        // Module instance (getName() is an instance method).
         integration.testmodule.testAuth.mockResolvedValue(false);
 
         await integration.testAuth();
@@ -136,20 +80,21 @@ describe('IntegrationBase.testAuth', () => {
         );
     });
 
-    it('does not heal ERROR to ENABLED when a module resolves false', async () => {
+    it('does not change integration status on success', async () => {
         integration.status = 'ERROR';
+
+        await integration.testAuth();
+
+        expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+        expect(integration.status).toBe('ERROR');
+    });
+
+    it('does not change integration status on failure', async () => {
         integration.testmodule.testAuth.mockResolvedValue(false);
 
         await integration.testAuth();
 
-        expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
-            'int-1',
-            'ERROR'
-        );
-        expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalledWith(
-            'int-1',
-            'ENABLED'
-        );
-        expect(integration.status).toBe('ERROR');
+        expect(mockUpdateIntegrationStatus.execute).not.toHaveBeenCalled();
+        expect(integration.status).toBe('ENABLED');
     });
 });

--- a/packages/core/integrations/tests/use-cases/create-integration.test.js
+++ b/packages/core/integrations/tests/use-cases/create-integration.test.js
@@ -11,6 +11,9 @@ const { TestModuleFactory } = require('../../../modules/tests/doubles/test-modul
 const { DummyIntegration } = require('../doubles/dummy-integration-class');
 const { IntegrationBase } = require('../../integration-base');
 
+// Simulates two requests racing to create the same integration: the caller's
+// initial duplicate check misses a row that a concurrent request already
+// committed. Used by the "creation race backstop" tests below.
 function makeFirstLookupStale(repository) {
     const realFind = repository.findIntegrationsByUserId.bind(repository);
     let first = true;

--- a/packages/core/integrations/tests/use-cases/create-integration.test.js
+++ b/packages/core/integrations/tests/use-cases/create-integration.test.js
@@ -6,8 +6,12 @@ jest.mock('../../../database/config', () => ({
 }));
 
 const { CreateIntegration } = require('../../use-cases/create-integration');
-const { TestIntegrationRepository } = require('../doubles/test-integration-repository');
-const { TestModuleFactory } = require('../../../modules/tests/doubles/test-module-factory');
+const {
+    TestIntegrationRepository,
+} = require('../doubles/test-integration-repository');
+const {
+    TestModuleFactory,
+} = require('../../../modules/tests/doubles/test-module-factory');
 const { DummyIntegration } = require('../doubles/dummy-integration-class');
 const { IntegrationBase } = require('../../integration-base');
 
@@ -29,12 +33,12 @@ function makeFirstLookupStale(repository) {
 describe('CreateIntegration Use-Case', () => {
     let integrationRepository;
     let moduleFactory;
-    let useCase;
+    let createIntegration;
 
     beforeEach(() => {
         integrationRepository = new TestIntegrationRepository();
         moduleFactory = new TestModuleFactory();
-        useCase = new CreateIntegration({
+        createIntegration = new CreateIntegration({
             integrationRepository,
             integrationClasses: [DummyIntegration],
             moduleFactory,
@@ -47,7 +51,11 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-1';
             const config = { type: 'dummy', foo: 'bar' };
 
-            const dto = await useCase.execute(entities, userId, config);
+            const dto = await createIntegration.execute(
+                entities,
+                userId,
+                config
+            );
 
             expect(dto.id).toBeDefined();
             expect(dto.config).toEqual(config);
@@ -61,19 +69,16 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-1';
             const config = { type: 'dummy', foo: 'bar' };
 
-            const dto = await useCase.execute(entities, userId, config);
-
-            const record = await integrationRepository.findIntegrationById(dto.id);
-            expect(record).toBeTruthy();
-
-            const history = integrationRepository.getOperationHistory();
-            const createOperation = history.find(op => op.operation === 'create');
-            expect(createOperation).toEqual({
-                operation: 'create',
-                id: dto.id,
+            const dto = await createIntegration.execute(
+                entities,
                 userId,
                 config
-            });
+            );
+
+            const record = await integrationRepository.findIntegrationById(
+                dto.id
+            );
+            expect(record).toMatchObject({ userId, config });
         });
 
         it('loads modules for each entity', async () => {
@@ -81,7 +86,11 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-1';
             const config = { type: 'dummy' };
 
-            const dto = await useCase.execute(entities, userId, config);
+            const dto = await createIntegration.execute(
+                entities,
+                userId,
+                config
+            );
 
             expect(dto.entities).toEqual(entities);
         });
@@ -93,13 +102,15 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-1';
             const config = { type: 'unknown-type' };
 
-            await expect(useCase.execute(entities, userId, config))
-                .rejects
-                .toThrow('No integration class found for type: unknown-type');
+            await expect(
+                createIntegration.execute(entities, userId, config)
+            ).rejects.toThrow(
+                'No integration class found for type: unknown-type'
+            );
         });
 
         it('throws error when no integration classes provided', async () => {
-            const useCaseWithoutClasses = new CreateIntegration({
+            const createIntegrationWithoutClasses = new CreateIntegration({
                 integrationRepository,
                 integrationClasses: [],
                 moduleFactory,
@@ -109,9 +120,13 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-1';
             const config = { type: 'dummy' };
 
-            await expect(useCaseWithoutClasses.execute(entities, userId, config))
-                .rejects
-                .toThrow('No integration class found for type: dummy');
+            await expect(
+                createIntegrationWithoutClasses.execute(
+                    entities,
+                    userId,
+                    config
+                )
+            ).rejects.toThrow('No integration class found for type: dummy');
         });
     });
 
@@ -121,7 +136,11 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-1';
             const config = { type: 'dummy' };
 
-            const dto = await useCase.execute(entities, userId, config);
+            const dto = await createIntegration.execute(
+                entities,
+                userId,
+                config
+            );
 
             expect(dto.entities).toEqual([]);
             expect(dto.id).toBeDefined();
@@ -135,11 +154,15 @@ describe('CreateIntegration Use-Case', () => {
                 nested: {
                     value: 123,
                     array: [1, 2, 3],
-                    bool: true
-                }
+                    bool: true,
+                },
             };
 
-            const dto = await useCase.execute(entities, userId, config);
+            const dto = await createIntegration.execute(
+                entities,
+                userId,
+                config
+            );
 
             expect(dto.config).toEqual(config);
         });
@@ -151,38 +174,50 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-dedupe-1';
             const config = { type: 'dummy', foo: 'bar' };
 
-            const first = await useCase.execute(entities, userId, config);
-            integrationRepository.clearHistory();
-
-            const second = await useCase.execute(entities, userId, config);
+            const first = await createIntegration.execute(
+                entities,
+                userId,
+                config
+            );
+            const second = await createIntegration.execute(
+                entities,
+                userId,
+                config
+            );
 
             expect(second.id).toBe(first.id);
-            const history = integrationRepository.getOperationHistory();
-            expect(history.some((op) => op.operation === 'create')).toBe(false);
-            expect(history.find((op) => op.operation === 'findByUserId')).toMatchObject({
-                userId,
-                count: 1,
-            });
+            const stored = await integrationRepository.findIntegrationsByUserId(
+                userId
+            );
+            expect(stored).toHaveLength(1);
         });
 
         it('runs testAuth on the reused integration so stale credentials surface', async () => {
             const testAuthCalls = [];
-            class TrackingIntegration extends DummyIntegration {
+            class AuthTrackingIntegration extends DummyIntegration {
                 async testAuth() {
                     testAuthCalls.push(this.id);
                 }
             }
-            const trackingUseCase = new CreateIntegration({
+            const createIntegrationWithAuthTracking = new CreateIntegration({
                 integrationRepository,
-                integrationClasses: [TrackingIntegration],
+                integrationClasses: [AuthTrackingIntegration],
                 moduleFactory,
             });
             const entities = ['entity-1'];
             const userId = 'user-dedupe-2';
             const config = { type: 'dummy' };
 
-            await trackingUseCase.execute(entities, userId, config);
-            await trackingUseCase.execute(entities, userId, config);
+            await createIntegrationWithAuthTracking.execute(
+                entities,
+                userId,
+                config
+            );
+            await createIntegrationWithAuthTracking.execute(
+                entities,
+                userId,
+                config
+            );
 
             expect(testAuthCalls).toHaveLength(1);
         });
@@ -191,17 +226,28 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-dedupe-3';
             const config = { type: 'dummy' };
 
-            const first = await useCase.execute(['entity-1', 'entity-2'], userId, config);
-            const second = await useCase.execute(['entity-2', 'entity-1'], userId, config);
+            const first = await createIntegration.execute(
+                ['entity-1', 'entity-2'],
+                userId,
+                config
+            );
+            const second = await createIntegration.execute(
+                ['entity-2', 'entity-1'],
+                userId,
+                config
+            );
 
             expect(second.id).toBe(first.id);
         });
 
         it('creates a new integration when the type differs', async () => {
             class OtherIntegration extends DummyIntegration {
-                static Definition = { ...DummyIntegration.Definition, name: 'other-dummy' };
+                static Definition = {
+                    ...DummyIntegration.Definition,
+                    name: 'other-dummy',
+                };
             }
-            const useCaseWithBoth = new CreateIntegration({
+            const createIntegrationWithTwoTypes = new CreateIntegration({
                 integrationRepository,
                 integrationClasses: [DummyIntegration, OtherIntegration],
                 moduleFactory,
@@ -209,8 +255,16 @@ describe('CreateIntegration Use-Case', () => {
             const entities = ['entity-1'];
             const userId = 'user-dedupe-4';
 
-            const first = await useCaseWithBoth.execute(entities, userId, { type: 'dummy' });
-            const second = await useCaseWithBoth.execute(entities, userId, { type: 'other-dummy' });
+            const first = await createIntegrationWithTwoTypes.execute(
+                entities,
+                userId,
+                { type: 'dummy' }
+            );
+            const second = await createIntegrationWithTwoTypes.execute(
+                entities,
+                userId,
+                { type: 'other-dummy' }
+            );
 
             expect(second.id).not.toBe(first.id);
         });
@@ -219,8 +273,16 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-dedupe-5';
             const config = { type: 'dummy' };
 
-            const first = await useCase.execute(['entity-1'], userId, config);
-            const second = await useCase.execute(['entity-1', 'entity-2'], userId, config);
+            const first = await createIntegration.execute(
+                ['entity-1'],
+                userId,
+                config
+            );
+            const second = await createIntegration.execute(
+                ['entity-1', 'entity-2'],
+                userId,
+                config
+            );
 
             expect(second.id).not.toBe(first.id);
         });
@@ -229,8 +291,16 @@ describe('CreateIntegration Use-Case', () => {
             const entities = ['entity-1'];
             const config = { type: 'dummy' };
 
-            const first = await useCase.execute(entities, 'user-dedupe-6a', config);
-            const second = await useCase.execute(entities, 'user-dedupe-6b', config);
+            const first = await createIntegration.execute(
+                entities,
+                'user-dedupe-6a',
+                config
+            );
+            const second = await createIntegration.execute(
+                entities,
+                'user-dedupe-6b',
+                config
+            );
 
             expect(second.id).not.toBe(first.id);
         });
@@ -240,17 +310,32 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-dedupe-7';
             const config = { type: 'dummy' };
 
-            const older = await integrationRepository.createIntegration(entities, userId, config);
-            const olderRecord = await integrationRepository.findIntegrationById(older.id);
+            const older = await integrationRepository.createIntegration(
+                entities,
+                userId,
+                config
+            );
+            const olderRecord = await integrationRepository.findIntegrationById(
+                older.id
+            );
             olderRecord.createdAt = new Date(Date.now() - 60_000);
-            await integrationRepository.createIntegration(entities, userId, config);
-            integrationRepository.clearHistory();
+            await integrationRepository.createIntegration(
+                entities,
+                userId,
+                config
+            );
 
-            const dto = await useCase.execute(entities, userId, config);
+            const dto = await createIntegration.execute(
+                entities,
+                userId,
+                config
+            );
 
             expect(dto.id).toBe(older.id);
-            const history = integrationRepository.getOperationHistory();
-            expect(history.some((op) => op.operation === 'create')).toBe(false);
+            const stored = await integrationRepository.findIntegrationsByUserId(
+                userId
+            );
+            expect(stored).toHaveLength(2);
         });
 
         it('heals a reused integration from ERROR to ENABLED when credentials are valid again', async () => {
@@ -270,7 +355,7 @@ describe('CreateIntegration Use-Case', () => {
                     };
                 }
             }
-            const healingUseCase = new CreateIntegration({
+            const createIntegrationWithRealAuth = new CreateIntegration({
                 integrationRepository,
                 integrationClasses: [RealAuthIntegration],
                 moduleFactory: new HealingModuleFactory(),
@@ -279,11 +364,21 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-heal-1';
             const config = { type: 'dummy' };
 
-            const created = await healingUseCase.execute(entities, userId, config);
-            const record = await integrationRepository.findIntegrationById(created.id);
+            const created = await createIntegrationWithRealAuth.execute(
+                entities,
+                userId,
+                config
+            );
+            const record = await integrationRepository.findIntegrationById(
+                created.id
+            );
             record.status = 'ERROR';
 
-            const reused = await healingUseCase.execute(entities, userId, config);
+            const reused = await createIntegrationWithRealAuth.execute(
+                entities,
+                userId,
+                config
+            );
 
             expect(reused.id).toBe(created.id);
             expect(reused.status).toBe('ENABLED');
@@ -296,75 +391,102 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-race-1';
             const config = { type: 'dummy' };
 
-            const first = await useCase.execute(entities, userId, config);
-            const firstRecord = await integrationRepository.findIntegrationById(first.id);
+            const first = await createIntegration.execute(
+                entities,
+                userId,
+                config
+            );
+            const firstRecord = await integrationRepository.findIntegrationById(
+                first.id
+            );
             firstRecord.createdAt = new Date(Date.now() - 60_000);
-            integrationRepository.clearHistory();
             makeFirstLookupStale(integrationRepository);
 
-            const second = await useCase.execute(entities, userId, config);
+            const second = await createIntegration.execute(
+                entities,
+                userId,
+                config
+            );
 
             expect(second.id).toBe(first.id);
-            const history = integrationRepository.getOperationHistory();
-            const createOp = history.find((op) => op.operation === 'create');
-            expect(createOp).toBeDefined();
-            expect(history.find((op) => op.operation === 'delete')).toMatchObject({
-                id: createOp.id,
-                existed: true,
-                success: true,
-            });
-            expect(await integrationRepository.findIntegrationById(createOp.id)).toBeNull();
+            const stored = await integrationRepository.findIntegrationsByUserId(
+                userId
+            );
+            expect(stored).toHaveLength(1);
+            expect(stored[0].id).toBe(first.id);
         });
 
         it('fires ON_CREATE exactly once across both racers', async () => {
             const sendEvents = [];
-            class TrackingIntegration extends DummyIntegration {
+            class SendTrackingIntegration extends DummyIntegration {
                 async send(event, data) {
                     sendEvents.push(event);
                     return super.send(event, data);
                 }
             }
-            const trackingUseCase = new CreateIntegration({
+            const createIntegrationWithSendTracking = new CreateIntegration({
                 integrationRepository,
-                integrationClasses: [TrackingIntegration],
+                integrationClasses: [SendTrackingIntegration],
                 moduleFactory,
             });
             const entities = ['entity-1'];
             const userId = 'user-race-2';
             const config = { type: 'dummy' };
 
-            const first = await trackingUseCase.execute(entities, userId, config);
-            const firstRecord = await integrationRepository.findIntegrationById(first.id);
+            const first = await createIntegrationWithSendTracking.execute(
+                entities,
+                userId,
+                config
+            );
+            const firstRecord = await integrationRepository.findIntegrationById(
+                first.id
+            );
             firstRecord.createdAt = new Date(Date.now() - 60_000);
             makeFirstLookupStale(integrationRepository);
 
-            await trackingUseCase.execute(entities, userId, config);
+            await createIntegrationWithSendTracking.execute(
+                entities,
+                userId,
+                config
+            );
 
-            expect(sendEvents.filter((event) => event === 'ON_CREATE')).toHaveLength(1);
+            expect(
+                sendEvents.filter((event) => event === 'ON_CREATE')
+            ).toHaveLength(1);
         });
 
         it('runs testAuth on the survivor when losing the race', async () => {
             const testAuthCalls = [];
-            class TrackingIntegration extends DummyIntegration {
+            class AuthTrackingIntegration extends DummyIntegration {
                 async testAuth() {
                     testAuthCalls.push(this.id);
                 }
             }
-            const trackingUseCase = new CreateIntegration({
+            const createIntegrationWithAuthTracking = new CreateIntegration({
                 integrationRepository,
-                integrationClasses: [TrackingIntegration],
+                integrationClasses: [AuthTrackingIntegration],
                 moduleFactory,
             });
             const entities = ['entity-1'];
             const userId = 'user-race-3';
             const config = { type: 'dummy' };
 
-            const first = await trackingUseCase.execute(entities, userId, config);
-            const firstRecord = await integrationRepository.findIntegrationById(first.id);
+            const first = await createIntegrationWithAuthTracking.execute(
+                entities,
+                userId,
+                config
+            );
+            const firstRecord = await integrationRepository.findIntegrationById(
+                first.id
+            );
             firstRecord.createdAt = new Date(Date.now() - 60_000);
             makeFirstLookupStale(integrationRepository);
 
-            await trackingUseCase.execute(entities, userId, config);
+            await createIntegrationWithAuthTracking.execute(
+                entities,
+                userId,
+                config
+            );
 
             expect(testAuthCalls).toEqual([first.id]);
         });
@@ -374,17 +496,29 @@ describe('CreateIntegration Use-Case', () => {
             const userId = 'user-race-4';
             const config = { type: 'dummy' };
 
-            const competitor = await useCase.execute(entities, userId, config);
-            const competitorRecord = await integrationRepository.findIntegrationById(competitor.id);
+            const competitor = await createIntegration.execute(
+                entities,
+                userId,
+                config
+            );
+            const competitorRecord =
+                await integrationRepository.findIntegrationById(competitor.id);
             competitorRecord.createdAt = new Date(Date.now() + 60_000);
-            integrationRepository.clearHistory();
             makeFirstLookupStale(integrationRepository);
 
-            const dto = await useCase.execute(entities, userId, config);
+            const dto = await createIntegration.execute(
+                entities,
+                userId,
+                config
+            );
 
             expect(dto.id).not.toBe(competitor.id);
-            const history = integrationRepository.getOperationHistory();
-            expect(history.some((op) => op.operation === 'delete')).toBe(false);
+            const stored = await integrationRepository.findIntegrationsByUserId(
+                userId
+            );
+            expect(stored.map((record) => record.id).sort()).toEqual(
+                [competitor.id, dto.id].sort()
+            );
         });
     });
 });

--- a/packages/core/integrations/tests/use-cases/create-integration.test.js
+++ b/packages/core/integrations/tests/use-cases/create-integration.test.js
@@ -9,6 +9,19 @@ const { CreateIntegration } = require('../../use-cases/create-integration');
 const { TestIntegrationRepository } = require('../doubles/test-integration-repository');
 const { TestModuleFactory } = require('../../../modules/tests/doubles/test-module-factory');
 const { DummyIntegration } = require('../doubles/dummy-integration-class');
+const { IntegrationBase } = require('../../integration-base');
+
+function makeFirstLookupStale(repository) {
+    const realFind = repository.findIntegrationsByUserId.bind(repository);
+    let first = true;
+    repository.findIntegrationsByUserId = async (userId) => {
+        if (first) {
+            first = false;
+            return [];
+        }
+        return realFind(userId);
+    };
+}
 
 describe('CreateIntegration Use-Case', () => {
     let integrationRepository;
@@ -128,4 +141,247 @@ describe('CreateIntegration Use-Case', () => {
             expect(dto.config).toEqual(config);
         });
     });
-}); 
+
+    describe('deduplication on re-authorize', () => {
+        it('reuses an existing integration when userId, type, and entity set all match', async () => {
+            const entities = ['entity-1', 'entity-2'];
+            const userId = 'user-dedupe-1';
+            const config = { type: 'dummy', foo: 'bar' };
+
+            const first = await useCase.execute(entities, userId, config);
+            integrationRepository.clearHistory();
+
+            const second = await useCase.execute(entities, userId, config);
+
+            expect(second.id).toBe(first.id);
+            const history = integrationRepository.getOperationHistory();
+            expect(history.some((op) => op.operation === 'create')).toBe(false);
+            expect(history.find((op) => op.operation === 'findByUserId')).toMatchObject({
+                userId,
+                count: 1,
+            });
+        });
+
+        it('runs testAuth on the reused integration so stale credentials surface', async () => {
+            const testAuthCalls = [];
+            class TrackingIntegration extends DummyIntegration {
+                async testAuth() {
+                    testAuthCalls.push(this.id);
+                }
+            }
+            const trackingUseCase = new CreateIntegration({
+                integrationRepository,
+                integrationClasses: [TrackingIntegration],
+                moduleFactory,
+            });
+            const entities = ['entity-1'];
+            const userId = 'user-dedupe-2';
+            const config = { type: 'dummy' };
+
+            await trackingUseCase.execute(entities, userId, config);
+            await trackingUseCase.execute(entities, userId, config);
+
+            expect(testAuthCalls).toHaveLength(1);
+        });
+
+        it('ignores entity order when checking for duplicates', async () => {
+            const userId = 'user-dedupe-3';
+            const config = { type: 'dummy' };
+
+            const first = await useCase.execute(['entity-1', 'entity-2'], userId, config);
+            const second = await useCase.execute(['entity-2', 'entity-1'], userId, config);
+
+            expect(second.id).toBe(first.id);
+        });
+
+        it('creates a new integration when the type differs', async () => {
+            class OtherIntegration extends DummyIntegration {
+                static Definition = { ...DummyIntegration.Definition, name: 'other-dummy' };
+            }
+            const useCaseWithBoth = new CreateIntegration({
+                integrationRepository,
+                integrationClasses: [DummyIntegration, OtherIntegration],
+                moduleFactory,
+            });
+            const entities = ['entity-1'];
+            const userId = 'user-dedupe-4';
+
+            const first = await useCaseWithBoth.execute(entities, userId, { type: 'dummy' });
+            const second = await useCaseWithBoth.execute(entities, userId, { type: 'other-dummy' });
+
+            expect(second.id).not.toBe(first.id);
+        });
+
+        it('creates a new integration when the entity set differs', async () => {
+            const userId = 'user-dedupe-5';
+            const config = { type: 'dummy' };
+
+            const first = await useCase.execute(['entity-1'], userId, config);
+            const second = await useCase.execute(['entity-1', 'entity-2'], userId, config);
+
+            expect(second.id).not.toBe(first.id);
+        });
+
+        it('creates a new integration when the userId differs', async () => {
+            const entities = ['entity-1'];
+            const config = { type: 'dummy' };
+
+            const first = await useCase.execute(entities, 'user-dedupe-6a', config);
+            const second = await useCase.execute(entities, 'user-dedupe-6b', config);
+
+            expect(second.id).not.toBe(first.id);
+        });
+
+        it('reuses the oldest of multiple pre-existing legacy duplicate integrations', async () => {
+            const entities = ['entity-1'];
+            const userId = 'user-dedupe-7';
+            const config = { type: 'dummy' };
+
+            const older = await integrationRepository.createIntegration(entities, userId, config);
+            const olderRecord = await integrationRepository.findIntegrationById(older.id);
+            olderRecord.createdAt = new Date(Date.now() - 60_000);
+            await integrationRepository.createIntegration(entities, userId, config);
+            integrationRepository.clearHistory();
+
+            const dto = await useCase.execute(entities, userId, config);
+
+            expect(dto.id).toBe(older.id);
+            const history = integrationRepository.getOperationHistory();
+            expect(history.some((op) => op.operation === 'create')).toBe(false);
+        });
+
+        it('heals a reused integration from ERROR to ENABLED when credentials are valid again', async () => {
+            class RealAuthIntegration extends DummyIntegration {
+                testAuth() {
+                    return IntegrationBase.prototype.testAuth.call(this);
+                }
+            }
+            class HealingModuleFactory {
+                async getModuleInstance(entityId, userId) {
+                    return {
+                        getName: () => 'dummy',
+                        api: {},
+                        entityId,
+                        userId,
+                        testAuth: jest.fn().mockResolvedValue(true),
+                    };
+                }
+            }
+            const healingUseCase = new CreateIntegration({
+                integrationRepository,
+                integrationClasses: [RealAuthIntegration],
+                moduleFactory: new HealingModuleFactory(),
+            });
+            const entities = ['entity-1'];
+            const userId = 'user-heal-1';
+            const config = { type: 'dummy' };
+
+            const created = await healingUseCase.execute(entities, userId, config);
+            const record = await integrationRepository.findIntegrationById(created.id);
+            record.status = 'ERROR';
+
+            const reused = await healingUseCase.execute(entities, userId, config);
+
+            expect(reused.id).toBe(created.id);
+            expect(reused.status).toBe('ENABLED');
+        });
+    });
+
+    describe('creation race backstop', () => {
+        it('deletes the just-created row and returns the older competitor when the initial lookup was stale', async () => {
+            const entities = ['entity-1'];
+            const userId = 'user-race-1';
+            const config = { type: 'dummy' };
+
+            const first = await useCase.execute(entities, userId, config);
+            const firstRecord = await integrationRepository.findIntegrationById(first.id);
+            firstRecord.createdAt = new Date(Date.now() - 60_000);
+            integrationRepository.clearHistory();
+            makeFirstLookupStale(integrationRepository);
+
+            const second = await useCase.execute(entities, userId, config);
+
+            expect(second.id).toBe(first.id);
+            const history = integrationRepository.getOperationHistory();
+            const createOp = history.find((op) => op.operation === 'create');
+            expect(createOp).toBeDefined();
+            expect(history.find((op) => op.operation === 'delete')).toMatchObject({
+                id: createOp.id,
+                existed: true,
+                success: true,
+            });
+            expect(await integrationRepository.findIntegrationById(createOp.id)).toBeNull();
+        });
+
+        it('fires ON_CREATE exactly once across both racers', async () => {
+            const sendEvents = [];
+            class TrackingIntegration extends DummyIntegration {
+                async send(event, data) {
+                    sendEvents.push(event);
+                    return super.send(event, data);
+                }
+            }
+            const trackingUseCase = new CreateIntegration({
+                integrationRepository,
+                integrationClasses: [TrackingIntegration],
+                moduleFactory,
+            });
+            const entities = ['entity-1'];
+            const userId = 'user-race-2';
+            const config = { type: 'dummy' };
+
+            const first = await trackingUseCase.execute(entities, userId, config);
+            const firstRecord = await integrationRepository.findIntegrationById(first.id);
+            firstRecord.createdAt = new Date(Date.now() - 60_000);
+            makeFirstLookupStale(integrationRepository);
+
+            await trackingUseCase.execute(entities, userId, config);
+
+            expect(sendEvents.filter((event) => event === 'ON_CREATE')).toHaveLength(1);
+        });
+
+        it('runs testAuth on the survivor when losing the race', async () => {
+            const testAuthCalls = [];
+            class TrackingIntegration extends DummyIntegration {
+                async testAuth() {
+                    testAuthCalls.push(this.id);
+                }
+            }
+            const trackingUseCase = new CreateIntegration({
+                integrationRepository,
+                integrationClasses: [TrackingIntegration],
+                moduleFactory,
+            });
+            const entities = ['entity-1'];
+            const userId = 'user-race-3';
+            const config = { type: 'dummy' };
+
+            const first = await trackingUseCase.execute(entities, userId, config);
+            const firstRecord = await integrationRepository.findIntegrationById(first.id);
+            firstRecord.createdAt = new Date(Date.now() - 60_000);
+            makeFirstLookupStale(integrationRepository);
+
+            await trackingUseCase.execute(entities, userId, config);
+
+            expect(testAuthCalls).toEqual([first.id]);
+        });
+
+        it('keeps its own row when it is the deterministic winner despite a stale initial lookup', async () => {
+            const entities = ['entity-1'];
+            const userId = 'user-race-4';
+            const config = { type: 'dummy' };
+
+            const competitor = await useCase.execute(entities, userId, config);
+            const competitorRecord = await integrationRepository.findIntegrationById(competitor.id);
+            competitorRecord.createdAt = new Date(Date.now() + 60_000);
+            integrationRepository.clearHistory();
+            makeFirstLookupStale(integrationRepository);
+
+            const dto = await useCase.execute(entities, userId, config);
+
+            expect(dto.id).not.toBe(competitor.id);
+            const history = integrationRepository.getOperationHistory();
+            expect(history.some((op) => op.operation === 'delete')).toBe(false);
+        });
+    });
+});

--- a/packages/core/integrations/tests/use-cases/create-integration.test.js
+++ b/packages/core/integrations/tests/use-cases/create-integration.test.js
@@ -197,6 +197,7 @@ describe('CreateIntegration Use-Case', () => {
             class AuthTrackingIntegration extends DummyIntegration {
                 async testAuth() {
                     testAuthCalls.push(this.id);
+                    return true;
                 }
             }
             const createIntegrationWithAuthTracking = new CreateIntegration({
@@ -598,6 +599,7 @@ describe('CreateIntegration Use-Case', () => {
             class AuthTrackingIntegration extends DummyIntegration {
                 async testAuth() {
                     testAuthCalls.push(this.id);
+                    return true;
                 }
             }
             const createIntegrationWithAuthTracking = new CreateIntegration({

--- a/packages/core/integrations/tests/use-cases/create-integration.test.js
+++ b/packages/core/integrations/tests/use-cases/create-integration.test.js
@@ -383,6 +383,144 @@ describe('CreateIntegration Use-Case', () => {
             expect(reused.id).toBe(created.id);
             expect(reused.status).toBe('ENABLED');
         });
+
+        it('re-enables a reused integration that was DISABLED when the user reconnects', async () => {
+            class RealAuthIntegration extends DummyIntegration {
+                testAuth() {
+                    return IntegrationBase.prototype.testAuth.call(this);
+                }
+            }
+            class HealingModuleFactory {
+                async getModuleInstance(entityId, userId) {
+                    return {
+                        getName: () => 'dummy',
+                        api: {},
+                        entityId,
+                        userId,
+                        testAuth: jest.fn().mockResolvedValue(true),
+                    };
+                }
+            }
+            const createIntegrationWithRealAuth = new CreateIntegration({
+                integrationRepository,
+                integrationClasses: [RealAuthIntegration],
+                moduleFactory: new HealingModuleFactory(),
+            });
+            const entities = ['entity-1'];
+            const userId = 'user-reconnect-1';
+            const config = { type: 'dummy' };
+
+            const created = await createIntegrationWithRealAuth.execute(
+                entities,
+                userId,
+                config
+            );
+            const record = await integrationRepository.findIntegrationById(
+                created.id
+            );
+            record.status = 'DISABLED';
+
+            const reused = await createIntegrationWithRealAuth.execute(
+                entities,
+                userId,
+                config
+            );
+
+            expect(reused.id).toBe(created.id);
+            expect(reused.status).toBe('ENABLED');
+        });
+
+        it('does not force-enable a reused integration still in NEEDS_CONFIG', async () => {
+            class RealAuthIntegration extends DummyIntegration {
+                testAuth() {
+                    return IntegrationBase.prototype.testAuth.call(this);
+                }
+            }
+            class HealingModuleFactory {
+                async getModuleInstance(entityId, userId) {
+                    return {
+                        getName: () => 'dummy',
+                        api: {},
+                        entityId,
+                        userId,
+                        testAuth: jest.fn().mockResolvedValue(true),
+                    };
+                }
+            }
+            const createIntegrationWithRealAuth = new CreateIntegration({
+                integrationRepository,
+                integrationClasses: [RealAuthIntegration],
+                moduleFactory: new HealingModuleFactory(),
+            });
+            const entities = ['entity-1'];
+            const userId = 'user-reconnect-2';
+            const config = { type: 'dummy' };
+
+            const created = await createIntegrationWithRealAuth.execute(
+                entities,
+                userId,
+                config
+            );
+            const record = await integrationRepository.findIntegrationById(
+                created.id
+            );
+            record.status = 'NEEDS_CONFIG';
+
+            const reused = await createIntegrationWithRealAuth.execute(
+                entities,
+                userId,
+                config
+            );
+
+            expect(reused.id).toBe(created.id);
+            expect(reused.status).toBe('NEEDS_CONFIG');
+        });
+
+        it('flips a reused DISABLED integration to ERROR instead of ENABLED when credentials are actually invalid', async () => {
+            class RealAuthIntegration extends DummyIntegration {
+                testAuth() {
+                    return IntegrationBase.prototype.testAuth.call(this);
+                }
+            }
+            class FailingModuleFactory {
+                async getModuleInstance(entityId, userId) {
+                    return {
+                        getName: () => 'dummy',
+                        api: {},
+                        entityId,
+                        userId,
+                        testAuth: jest.fn().mockResolvedValue(false),
+                    };
+                }
+            }
+            const createIntegrationWithFailingAuth = new CreateIntegration({
+                integrationRepository,
+                integrationClasses: [RealAuthIntegration],
+                moduleFactory: new FailingModuleFactory(),
+            });
+            const entities = ['entity-1'];
+            const userId = 'user-reconnect-3';
+            const config = { type: 'dummy' };
+
+            const created = await createIntegrationWithFailingAuth.execute(
+                entities,
+                userId,
+                config
+            );
+            const record = await integrationRepository.findIntegrationById(
+                created.id
+            );
+            record.status = 'DISABLED';
+
+            const reused = await createIntegrationWithFailingAuth.execute(
+                entities,
+                userId,
+                config
+            );
+
+            expect(reused.id).toBe(created.id);
+            expect(reused.status).toBe('ERROR');
+        });
     });
 
     describe('creation race backstop', () => {

--- a/packages/core/integrations/use-cases/create-integration.js
+++ b/packages/core/integrations/use-cases/create-integration.js
@@ -78,13 +78,14 @@ class CreateIntegration {
         const integrationInstance = await this._buildInstance(
             integrationRecord
         );
-        // testAuth reconciles the auth-health axis (ERROR ↔ ENABLED). Reaching
-        // this reuse path means the user is actively reconnecting, so also
-        // clear a deliberate pause — the same ERROR/DISABLED restoration
-        // ProcessAuthorizationCallback performs on entity re-auth. A reconnect
-        // whose credentials fail is left in ERROR by testAuth, so this only
-        // fires when auth is confirmed good.
-        await integrationInstance.testAuth();
+        // Reaching this reuse path means the user is actively reconnecting.
+        // Reconcile the auth-health axis from the check, then also clear a
+        // deliberate pause — the same ERROR/DISABLED restoration
+        // ProcessAuthorizationCallback performs on entity re-auth. A failed
+        // reconnect is left in ERROR by reconcileAuthStatus, so DISABLED is
+        // only cleared when auth is confirmed good.
+        const authPassed = await integrationInstance.testAuth();
+        await integrationInstance.reconcileAuthStatus(authPassed);
         if (integrationInstance.status === 'DISABLED') {
             await integrationInstance.persistStatus('ENABLED');
         }

--- a/packages/core/integrations/use-cases/create-integration.js
+++ b/packages/core/integrations/use-cases/create-integration.js
@@ -79,6 +79,19 @@ class CreateIntegration {
             integrationRecord
         );
         await integrationInstance.testAuth();
+
+        // testAuth() only restores from ERROR. A user going through this
+        // create/connect flow again for a DISABLED integration is a
+        // deliberate reconnect — mirrors the same ERROR/DISABLED restoration
+        // ProcessAuthorizationCallback performs on entity re-auth.
+        if (integrationInstance.status === 'DISABLED') {
+            await integrationInstance.updateIntegrationStatus.execute(
+                integrationInstance.id,
+                'ENABLED'
+            );
+            integrationInstance.status = 'ENABLED';
+        }
+
         return mapIntegrationClassToIntegrationDTO(integrationInstance);
     }
 

--- a/packages/core/integrations/use-cases/create-integration.js
+++ b/packages/core/integrations/use-cases/create-integration.js
@@ -78,18 +78,15 @@ class CreateIntegration {
         const integrationInstance = await this._buildInstance(
             integrationRecord
         );
+        // testAuth reconciles the auth-health axis (ERROR ↔ ENABLED). Reaching
+        // this reuse path means the user is actively reconnecting, so also
+        // clear a deliberate pause — the same ERROR/DISABLED restoration
+        // ProcessAuthorizationCallback performs on entity re-auth. A reconnect
+        // whose credentials fail is left in ERROR by testAuth, so this only
+        // fires when auth is confirmed good.
         await integrationInstance.testAuth();
-
-        // testAuth() only restores from ERROR. A user going through this
-        // create/connect flow again for a DISABLED integration is a
-        // deliberate reconnect — mirrors the same ERROR/DISABLED restoration
-        // ProcessAuthorizationCallback performs on entity re-auth.
         if (integrationInstance.status === 'DISABLED') {
-            await integrationInstance.updateIntegrationStatus.execute(
-                integrationInstance.id,
-                'ENABLED'
-            );
-            integrationInstance.status = 'ENABLED';
+            await integrationInstance.persistStatus('ENABLED');
         }
 
         return mapIntegrationClassToIntegrationDTO(integrationInstance);

--- a/packages/core/integrations/use-cases/create-integration.js
+++ b/packages/core/integrations/use-cases/create-integration.js
@@ -34,12 +34,19 @@ class CreateIntegration {
      * @throws {Error} When integration class is not found for the specified type.
      */
     async execute(entities, userId, config) {
+        console.log(
+            `[Frigg] Creating ${config?.type} integration for user ${userId} with entities [${entities}]`
+        );
+
         const existing = await this._findDuplicate(
             userId,
             config?.type,
             entities
         );
         if (existing) {
+            console.log(
+                `[Frigg] Found existing integration ${existing.id} for the same user, type, and entities — reusing it`
+            );
             return this._reuseExisting(existing);
         }
 
@@ -49,6 +56,9 @@ class CreateIntegration {
                 userId,
                 config
             );
+        console.log(
+            `[Frigg] Created integration ${integrationRecord.id} for user ${userId}`
+        );
 
         // A concurrent request may have created a matching row between the
         // lookup above and this insert; re-check before any side effects run.
@@ -58,6 +68,9 @@ class CreateIntegration {
             entities
         );
         if (survivor && String(survivor.id) !== String(integrationRecord.id)) {
+            console.log(
+                `[Frigg] Concurrent create detected — deleting duplicate ${integrationRecord.id} and reusing ${survivor.id}`
+            );
             await this.integrationRepository.deleteIntegrationById(
                 integrationRecord.id
             );
@@ -66,6 +79,9 @@ class CreateIntegration {
 
         const integrationInstance = await this._buildInstance(
             integrationRecord
+        );
+        console.log(
+            `[Frigg] Sending ON_CREATE for integration ${integrationRecord.id}`
         );
         await integrationInstance.send('ON_CREATE', {
             integrationId: integrationRecord.id,
@@ -83,6 +99,9 @@ class CreateIntegration {
         const authPassed = await integrationInstance.testAuth();
         await integrationInstance.reconcileAuthStatus(authPassed);
         if (integrationInstance.status === 'DISABLED') {
+            console.log(
+                `[Frigg] Integration ${integrationInstance.id} changed status from DISABLED to ENABLED`
+            );
             await integrationInstance.persistStatus('ENABLED');
         }
 

--- a/packages/core/integrations/use-cases/create-integration.js
+++ b/packages/core/integrations/use-cases/create-integration.js
@@ -22,16 +22,27 @@ class CreateIntegration {
     }
 
     /**
-     * Executes the integration creation process.
+     * Executes the integration creation process. Reuses an existing
+     * integration when one already exists for the same userId, config.type,
+     * and entity set, instead of creating a duplicate.
      * @async
      * @param {string[]} entities - Array of entity IDs to associate with the integration.
      * @param {string} userId - ID of the user creating the integration.
      * @param {Object} config - Configuration object for the integration.
      * @param {string} config.type - Type of integration to create.
-     * @returns {Promise<Object>} The created integration DTO.
+     * @returns {Promise<Object>} The created or reused integration DTO.
      * @throws {Error} When integration class is not found for the specified type.
      */
     async execute(entities, userId, config) {
+        const existing = await this._findDuplicate(
+            userId,
+            config?.type,
+            entities
+        );
+        if (existing) {
+            return this._reuseExisting(existing);
+        }
+
         const integrationRecord =
             await this.integrationRepository.createIntegration(
                 entities,
@@ -39,6 +50,69 @@ class CreateIntegration {
                 config
             );
 
+        // A concurrent request may have created a matching row between the
+        // lookup above and this insert; re-check before any side effects run.
+        const survivor = await this._findDuplicate(
+            userId,
+            config?.type,
+            entities
+        );
+        if (survivor && String(survivor.id) !== String(integrationRecord.id)) {
+            await this.integrationRepository.deleteIntegrationById(
+                integrationRecord.id
+            );
+            return this._reuseExisting(survivor);
+        }
+
+        const integrationInstance = await this._buildInstance(
+            integrationRecord
+        );
+        await integrationInstance.send('ON_CREATE', {
+            integrationId: integrationRecord.id,
+        });
+
+        return mapIntegrationClassToIntegrationDTO(integrationInstance);
+    }
+
+    async _reuseExisting(integrationRecord) {
+        const integrationInstance = await this._buildInstance(
+            integrationRecord
+        );
+        await integrationInstance.testAuth();
+        return mapIntegrationClassToIntegrationDTO(integrationInstance);
+    }
+
+    async _findDuplicate(userId, type, entityIds) {
+        const candidates =
+            await this.integrationRepository.findIntegrationsByUserId(userId);
+        const target = [...(entityIds ?? [])].map(String).sort();
+
+        const matches = candidates.filter((integration) => {
+            if (integration.config?.type !== type) return false;
+            const current = [...(integration.entitiesIds ?? [])]
+                .map(String)
+                .sort();
+            return (
+                current.length === target.length &&
+                current.every((id, index) => id === target[index])
+            );
+        });
+
+        return matches.length ? this._pickOldest(matches) : null;
+    }
+
+    _pickOldest(records) {
+        return [...records].sort((a, b) => {
+            const diff =
+                new Date(a.createdAt ?? 0) - new Date(b.createdAt ?? 0);
+            if (diff !== 0) return diff;
+            return String(a.id).localeCompare(String(b.id), 'en', {
+                numeric: true,
+            });
+        })[0];
+    }
+
+    async _buildInstance(integrationRecord) {
         const integrationClass = this.integrationClasses.find(
             (integrationClass) =>
                 integrationClass.Definition.name ===
@@ -72,11 +146,8 @@ class CreateIntegration {
         });
 
         await integrationInstance.initialize();
-        await integrationInstance.send('ON_CREATE', {
-            integrationId: integrationRecord.id,
-        });
 
-        return mapIntegrationClassToIntegrationDTO(integrationInstance);
+        return integrationInstance;
     }
 }
 

--- a/packages/core/integrations/use-cases/create-integration.js
+++ b/packages/core/integrations/use-cases/create-integration.js
@@ -78,12 +78,8 @@ class CreateIntegration {
         const integrationInstance = await this._buildInstance(
             integrationRecord
         );
-        // Reaching this reuse path means the user is actively reconnecting.
-        // Reconcile the auth-health axis from the check, then also clear a
-        // deliberate pause — the same ERROR/DISABLED restoration
-        // ProcessAuthorizationCallback performs on entity re-auth. A failed
-        // reconnect is left in ERROR by reconcileAuthStatus, so DISABLED is
-        // only cleared when auth is confirmed good.
+        // User is actively trying to reconnect; here if the integration is
+        // disabled, we can enable it again.
         const authPassed = await integrationInstance.testAuth();
         await integrationInstance.reconcileAuthStatus(authPassed);
         if (integrationInstance.status === 'DISABLED') {


### PR DESCRIPTION
## Summary

`CreateIntegration` inserted a new `Integration` row on every call, with no check for an existing one. Re-authorizing the same third-party account, or a client retrying after a 5xx, created duplicate rows sharing the same entities. In production this doubled all webhook traffic for the affected org — two Attio integrations for one org each registered their own webhook, so every event fired twice, causing roughly 4,500 needless upstream 500s/day.

- `CreateIntegration.execute()` now looks up an existing integration for the same `(userId, config.type, entity set)` via the existing `findIntegrationsByUserId` port — **no new repository method** — matching order-insensitively and picking the oldest on multiple legacy duplicates. On a match it reuses the existing integration, calls `testAuth()` so stale credentials surface through the normal status pipeline, and does **not** re-fire `ON_CREATE` or overwrite config.
- A **race backstop** re-runs the same lookup after insert but before `ON_CREATE`: if a concurrent request already created an older matching row, the just-inserted row is deleted and the flow defers to the older row, so `ON_CREATE` still fires exactly once. This is check-then-act, not transactional — the dedupe key spans a JSON path and a many-to-many entity set, which can't be expressed as a DB unique constraint on either Prisma schema (verified against both `prisma-postgresql` and `prisma-mongodb`).
- `findIntegrationsByUserId` now also returns `createdAt` (mongo, postgres, documentdb) for deterministic oldest-wins selection — additive, no migration needed.
- **`IntegrationBase.testAuth()` healing**: it never cleared `ERROR` back to `ENABLED` on success, and never synced the in-memory `status` after either transition. That meant re-authorizing a broken integration silently returned it still broken — exactly the population most likely to trigger the reuse path. Fixed both, mirroring the existing tested `CREDENTIAL_VALIDATED` healing pattern in `receiveNotification`. Also fixes the same latent bug in `GET /api/integrations/:id/test-auth`.
- **A resolved `false` from `Module.testAuth()` is now treated as a failure.** `Module.testAuth()` catches its own request failures internally and resolves `false` rather than rejecting — the normal way real modules (Attio, AxisCare, HouseCallPro) report a 401. The healing branch above would otherwise reactivate an integration whose credentials are still invalid, since only a thrown exception was previously treated as failure. Found by [@chatgpt-codex-connector's review](https://github.com/friggframework/frigg/pull/613#discussion_r3514775553).
- **Fixed a crash in the same error path**: the error-message builder called `this[module].constructor.getName()`, but `getName()` is an instance method on `Module`, not a static one on its constructor — every genuine auth failure crashed here instead of recording the error. This was previously unreachable dead code (masked by the `false`-vs-throw bug above); fixing that bug exposed it.
- **Reconnecting a `DISABLED` integration now re-enables it.** `testAuth()` deliberately only restores from `ERROR`, not `DISABLED` — a background token-refresh event shouldn't silently un-pause something the user turned off. But reaching the reuse path via `CreateIntegration` means the user went through the connect flow again, a deliberate reconnect. The framework already treats this distinction as convention: `ProcessAuthorizationCallback`'s `STATUSES_RESET_ON_REAUTH` resets both `ERROR` and `DISABLED` (not `NEEDS_CONFIG` or `PROCESSING`) when a re-authorized entity's linked integrations are restored. `_reuseExisting()` now applies the same rule after `testAuth()` confirms auth still passes.

Supersedes commit `dd85498e` (branch `fix/dedupe-integration-on-reauth`), which is 92 commits behind `next` and predates the current `create-integration.js` (not cherry-pickable). Two deliberate deltas from that design: matching lives in the use-case over the existing repository port rather than a new one, and this adds the race backstop plus legacy-duplicate oldest-wins.

## Known limitations (by design, not overlooked)

- The backstop is best-effort. A tie on `createdAt` combined with a Mongo ObjectId sort that doesn't align with insert order, or read-replica lag on both rechecks, can still leave a duplicate — only a DB unique constraint closes this fully, and none is expressible for this key shape. Degrades to today's status quo (a duplicate persists), never to data loss.
- Dedupe is scoped per `userId`. Two different users installing an org-scoped integration independently are not caught by entity-set matching.
- On reuse, a client-supplied `config` beyond `type` is intentionally discarded — the existing config wins.
- The router still returns `201` on a reuse hit (semantically closer to `200`, left as-is to avoid a client-facing contract change).
- `NEEDS_CONFIG` and `PROCESSING` are never force-changed by the reuse path — reconnecting doesn't mean required configuration is complete, and forcing `ENABLED` mid-setup would race the in-flight setup.

## Test plan

- [x] 22 tests in `create-integration.test.js` (7 pre-existing regression + 7 dedupe-matching + 4 race-backstop + 4 status-healing composition tests: ERROR→ENABLED, DISABLED→ENABLED, NEEDS_CONFIG untouched, DISABLED+bad-creds→ERROR) — all passing.
- [x] 10 tests in `integration-base-test-auth.test.js` covering the `testAuth()` ERROR↔ENABLED transition, its guards (does not heal NEEDS_CONFIG/DISABLED/PROCESSING), the resolved-`false`-as-failure contract, and the `getName()` crash fix — using a module fake shaped like a real `Module` instance, not an artificially-patched shim.
- [x] Full `packages/core` suite: baseline (before this branch) = 17 failed suites / 70 failed tests / 1143 passed; current = same 17 failed suites / 70 failed tests / 1171 passed. The 70 pre-existing failures are AWS-SDK/network-dependent tests unrelated to this change, confirmed byte-for-byte identical failure set before/after every commit on this branch.
- [x] `eslint`: 0 errors on all touched files (warnings are pre-existing, none introduced).
- [x] Mutation-tested the race-backstop assertions: disabling the backstop in the implementation fails exactly the 3 backstop-dependent tests, confirming they aren't passing by accident.
- [x] Assertions go through the real repository interface (`findIntegrationsByUserId`, `findIntegrationById`) rather than test-only instrumentation on the fake double, so tests reflect what a real caller could observe.
- [x] Two rounds of independent adversarial review during development (concurrency correctness, hexagonal-architecture fit, blast radius, mutation testing) plus a third-party bot review — all findings addressed.

## Known pre-existing behaviors left as follow-ups (explicit non-goals)

Surfaced during review; deliberately not fixed here to keep this PR scoped.

- **`testAuth()` stamps `ERROR` over a `DISABLED` integration on auth failure.** A passive `GET /test-auth` probe of a paused integration with bad credentials flips it `DISABLED → ERROR`, destroying the pause; a later successful check can then heal it to `ENABLED`. The root cause (testAuth reconciling status at all, rather than being a pure verifier the caller reconciles from) predates this branch — this PR only made the success-side heal symmetric. A proper fix distinguishes passive verification from active reconnect and belongs with the testAuth-purity refactor.
- **`validateConfig()` persists `NEEDS_CONFIG` without syncing the in-memory `this.status`.** A DTO mapped from the same instance in that request shows stale status. Now trivially fixable with `persistStatus()`, but converting it is an observable behavior change (`needsConfiguration()`, mid-request DTO output), so it's left for a separate change.

## Adopter note (testAuth contract)

`IntegrationBase.testAuth()` is now a pure verifier: it returns a `boolean` and no longer mutates integration status (that moved to the new `reconcileAuthStatus(authPassed)`). **API modules are unaffected** — they define `testAuthRequest`, consumed by `Module.testAuth()`, neither of which changed. The only migration this could require is for a *custom integration subclass that overrides `IntegrationBase.testAuth`* with the old void-returning, self-status-mutating shape: it must now return a boolean and let the caller reconcile status. No such overrides exist in-tree, so there are no code changes required here — this is a heads-up for the canary release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


