### PR TITLE
fix(core): don't abort integration deletion when ON_DELETE handler throws

### DIFF
--- a/packages/core/integrations/tests/doubles/dummy-integration-class.js
+++ b/packages/core/integrations/tests/doubles/dummy-integration-class.js
@@ -60,6 +60,9 @@ class DummyIntegration extends IntegrationBase {
         if (event === 'ON_UPDATE') {
             await this.onUpdate(data);
         }
+        if (event === 'ON_DELETE') {
+            await this.onDelete(data);
+        }
         return { event, data };
     }
 

--- a/packages/core/integrations/tests/use-cases/delete-integration-for-user.test.js
+++ b/packages/core/integrations/tests/use-cases/delete-integration-for-user.test.js
@@ -129,6 +129,30 @@ describe('DeleteIntegrationForUser Use-Case', () => {
             const found = await integrationRepository.findIntegrationById(record.id);
             expect(found).toBeNull();
         });
+
+        it('deletes the integration row even when onDelete rejects with a non-Error value', async () => {
+            class NullRejectingOnDeleteIntegration extends DummyIntegration {
+                static Definition = {
+                    ...DummyIntegration.Definition,
+                    name: 'null-rejecting-on-delete',
+                };
+
+                async onDelete(params) {
+                    throw null;
+                }
+            }
+
+            const useCaseWithNullRejectingIntegration = new DeleteIntegrationForUser({
+                integrationRepository,
+                integrationClasses: [NullRejectingOnDeleteIntegration],
+            });
+            const record = await integrationRepository.createIntegration(['e1'], 'user-1', { type: 'null-rejecting-on-delete' });
+
+            await useCaseWithNullRejectingIntegration.execute(record.id, 'user-1');
+
+            const found = await integrationRepository.findIntegrationById(record.id);
+            expect(found).toBeNull();
+        });
     });
 
     describe('edge cases', () => {

--- a/packages/core/integrations/tests/use-cases/delete-integration-for-user.test.js
+++ b/packages/core/integrations/tests/use-cases/delete-integration-for-user.test.js
@@ -105,6 +105,32 @@ describe('DeleteIntegrationForUser Use-Case', () => {
         });
     });
 
+    describe('resilience to onDelete failures', () => {
+        it('deletes the integration row even when onDelete throws', async () => {
+            class ThrowingOnDeleteIntegration extends DummyIntegration {
+                static Definition = {
+                    ...DummyIntegration.Definition,
+                    name: 'throwing-on-delete',
+                };
+
+                async onDelete(params) {
+                    throw new Error('webhook deregistration failed');
+                }
+            }
+
+            const useCaseWithThrowingIntegration = new DeleteIntegrationForUser({
+                integrationRepository,
+                integrationClasses: [ThrowingOnDeleteIntegration],
+            });
+            const record = await integrationRepository.createIntegration(['e1'], 'user-1', { type: 'throwing-on-delete' });
+
+            await useCaseWithThrowingIntegration.execute(record.id, 'user-1');
+
+            const found = await integrationRepository.findIntegrationById(record.id);
+            expect(found).toBeNull();
+        });
+    });
+
     describe('edge cases', () => {
         it('handles deletion of already deleted integration', async () => {
             const record = await integrationRepository.createIntegration(['e1'], 'user-1', { type: 'dummy' });

--- a/packages/core/integrations/use-cases/delete-integration-for-user.js
+++ b/packages/core/integrations/use-cases/delete-integration-for-user.js
@@ -96,9 +96,10 @@ class DeleteIntegrationForUser {
         try {
             await integrationInstance.send('ON_DELETE');
         } catch (error) {
+            const reason = error?.message ?? String(error);
             console.error(
                 `[Integration Deletion] onDelete failed for integration ${integrationId}, continuing with deletion:`,
-                error.message
+                reason
             );
         }
 

--- a/packages/core/integrations/use-cases/delete-integration-for-user.js
+++ b/packages/core/integrations/use-cases/delete-integration-for-user.js
@@ -92,7 +92,15 @@ class DeleteIntegrationForUser {
 
         // Complete async initialization (load dynamic actions, register handlers)
         await integrationInstance.initialize();
-        await integrationInstance.send('ON_DELETE');
+
+        try {
+            await integrationInstance.send('ON_DELETE');
+        } catch (error) {
+            console.error(
+                `[Integration Deletion] onDelete failed for integration ${integrationId}, continuing with deletion:`,
+                error.message
+            );
+        }
 
         await this.integrationRepository.deleteIntegrationById(integrationId);
     }


### PR DESCRIPTION
## Summary

`DeleteIntegrationForUser.execute()` deleted the integration row only after `integrationInstance.send('ON_DELETE')` resolved. Any vendor-side webhook deregistration failure inside an integration's `onDelete` (network error, expired token, already-revoked webhook) aborted the entire uninstall after whatever partial cleanup had already happened — leaving the row alive, vendor webhooks in an unknown state, and no way for the customer to retry (the adopter app still shows the integration as installed).

Found while hardening webhook teardown in a downstream adopter (Quo Integrations); see [quo-integrations PR #20](https://github.com/OpenPhone/integrations/pull/20) for the companion per-integration fix. That PR makes each integration's own `onDelete` resilient to partial vendor failures, but a throw could still surface from a bug in that logic or a completely unexpected error shape — this closes the gap at the framework level so uninstall always completes regardless of what a specific integration's `onDelete` does.

- `onDelete` failures are now caught, logged with the integration id, and deletion proceeds to `deleteIntegrationById`.
- Cleanup is inherently best-effort; leaving the row (and its credentials) alive because cleanup half-failed is worse than leaving orphaned vendor-side webhooks for out-of-band reconciliation.
- `DummyIntegration`'s test double `send()` now dispatches the `ON_DELETE` event to `onDelete()`, mirroring its existing `ON_UPDATE` → `onUpdate()` dispatch, so tests can exercise this path through the double's real interface (no new instrumentation methods added).

## Test plan

- [x] New test: `onDelete` throwing → integration row is still deleted, asserted via `findIntegrationById` returning `null` (the real repository interface, not instrumentation-only methods on the double).
- [x] RED confirmed: test fails against the unguarded code, with the thrown error propagating out of `execute()` and the row never reaching `deleteIntegrationById`.
- [x] GREEN confirmed after wrapping `send('ON_DELETE')` in try/catch.
- [x] `packages/core` full suite: baseline (before this branch) = 17 failed suites / 70 failed tests / 1173 passed; after this branch = same 17 failed suites / 70 failed tests / 1174 passed (the one new test). The 70 pre-existing failures are unrelated to this change — confirmed identical failure set with this branch's changes stashed vs. applied.
- [x] `prettier --check` clean on all three touched files (reverted an unrelated prettier-version reformatting pass to keep the diff scoped to the actual fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)