### PR TITLE
fix(core): make malformed/unregistered integrations deletable (undeletable-row guard)

### DIFF
--- a/packages/core/integrations/tests/use-cases/delete-integration-for-user.test.js
+++ b/packages/core/integrations/tests/use-cases/delete-integration-for-user.test.js
@@ -97,7 +97,7 @@ describe('DeleteIntegrationForUser Use-Case', () => {
                 .toThrow(`Integration ${record.id} does not belong to User different-user`);
         });
 
-        it('throws error when integration class not found', async () => {
+        it('best-effort deletes the row when no registered class matches the type (avoids a permanently undeletable row)', async () => {
             const useCaseWithoutClasses = new DeleteIntegrationForUser({
                 integrationRepository,
                 integrationClasses: [],
@@ -106,8 +106,11 @@ describe('DeleteIntegrationForUser Use-Case', () => {
             const record = await integrationRepository.createIntegration(['e1'], 'user-1', { type: 'dummy' });
 
             await expect(useCaseWithoutClasses.execute(record.id, 'user-1'))
-                .rejects
-                .toThrow();
+                .resolves
+                .toBeUndefined();
+
+            const found = await integrationRepository.findIntegrationById(record.id);
+            expect(found).toBeNull();
         });
 
         it('tracks failed delete operation for non-existent integration', async () => {
@@ -220,6 +223,63 @@ describe('DeleteIntegrationForUser Use-Case', () => {
                 expect.stringContaining('webhook deregistration failed'),
                 expect.any(Number)
             );
+        });
+    });
+
+    describe('undeletable-row guard (malformed / unregistered config)', () => {
+        it('best-effort deletes the row when config is null (no TypeError, no permanent 500)', async () => {
+            const record = await integrationRepository.createIntegration(['e1'], 'user-1', null);
+
+            await expect(useCase.execute(record.id, 'user-1'))
+                .resolves
+                .toBeUndefined();
+
+            const found = await integrationRepository.findIntegrationById(record.id);
+            expect(found).toBeNull();
+        });
+
+        it('best-effort deletes the row when config.type is unregistered', async () => {
+            const record = await integrationRepository.createIntegration(['e1'], 'user-1', { type: 'decommissioned-type' });
+
+            await expect(useCase.execute(record.id, 'user-1'))
+                .resolves
+                .toBeUndefined();
+
+            const found = await integrationRepository.findIntegrationById(record.id);
+            expect(found).toBeNull();
+        });
+
+        it('best-effort deletes the row when config is present but has no type', async () => {
+            const record = await integrationRepository.createIntegration(['e1'], 'user-1', { settings: { foo: 'bar' } });
+
+            await expect(useCase.execute(record.id, 'user-1'))
+                .resolves
+                .toBeUndefined();
+
+            const found = await integrationRepository.findIntegrationById(record.id);
+            expect(found).toBeNull();
+        });
+
+        it('best-effort deletes the row when config.type is an empty string', async () => {
+            const record = await integrationRepository.createIntegration(['e1'], 'user-1', { type: '' });
+
+            await expect(useCase.execute(record.id, 'user-1'))
+                .resolves
+                .toBeUndefined();
+
+            const found = await integrationRepository.findIntegrationById(record.id);
+            expect(found).toBeNull();
+        });
+
+        it('still enforces ownership before the best-effort path (null config, wrong user)', async () => {
+            const record = await integrationRepository.createIntegration(['e1'], 'user-1', null);
+
+            await expect(useCase.execute(record.id, 'different-user'))
+                .rejects
+                .toThrow(`Integration ${record.id} does not belong to User different-user`);
+
+            const found = await integrationRepository.findIntegrationById(record.id);
+            expect(found).not.toBeNull();
         });
     });
 

--- a/packages/core/integrations/use-cases/delete-integration-for-user.js
+++ b/packages/core/integrations/use-cases/delete-integration-for-user.js
@@ -27,7 +27,10 @@ class DeleteIntegrationForUser {
      * @async
      * @param {string} integrationId - ID of the integration to delete.
      * @param {string} userId - ID of the user requesting the deletion.
-     * @returns {Promise<void>} Resolves when the integration is successfully deleted.
+     * @returns {Promise<void>} Resolves when the integration is deleted. If the
+     *   record's config.type is missing or maps to no registered integration
+     *   class, the record is deleted best-effort WITHOUT running ON_DELETE
+     *   teardown (any external webhooks may need manual cleanup).
      * @throws {Boom.notFound} When integration with the specified ID does not exist.
      * @throws {Error} When the integration doesn't belong to the specified user.
      */
@@ -41,16 +44,37 @@ class DeleteIntegrationForUser {
             );
         }
 
-        const integrationClass = this.integrationClasses.find(
-            (integrationClass) =>
-                integrationClass.Definition.name ===
-                integrationRecord.config.type
-        );
-
+        // Ownership is independent of config shape — enforce it first so a row
+        // with a malformed or unregistered config still cannot be deleted by
+        // the wrong user.
         if (integrationRecord.userId !== userId) {
             throw new Error(
                 `Integration ${integrationId} does not belong to User ${userId}`
             );
+        }
+
+        const integrationType = integrationRecord.config?.type;
+        const integrationClass = integrationType
+            ? this.integrationClasses.find(
+                  (integrationClass) =>
+                      integrationClass.Definition.name === integrationType
+              )
+            : undefined;
+
+        // Without a registered class we cannot instantiate the integration to
+        // run ON_DELETE teardown. Rather than throw and leave the row
+        // permanently undeletable (a null or decommissioned config.type used to
+        // TypeError here and return a 500 forever), delete the record
+        // best-effort and log loudly so any external webhooks it still owns get
+        // cleaned up out of band.
+        if (!integrationClass) {
+            console.error(
+                `[Integration Deletion] No registered integration class for type ${JSON.stringify(
+                    integrationType
+                )} (integration ${integrationId}). Deleting the record WITHOUT teardown — any external webhooks may require manual cleanup.`
+            );
+            await this.integrationRepository.deleteIntegrationById(integrationId);
+            return;
         }
 
         // Load modules with API clients for webhook deletion


### PR DESCRIPTION
## What

`DeleteIntegrationForUser.execute()` resolves the integration class from `integrationRecord.config.type` and then does `new integrationClass(...)`. A row whose `config` is `null`, or whose `type` is not a registered integration (decommissioned/renamed type, or corrupted config), threw a **TypeError before any teardown ran** — a null config dereferenced at the `.find`, an unknown type produced `undefined is not a constructor`. The endpoint returned **500 on every attempt**, so the row was **permanently undeletable via the management API**.

This PR:
1. **Moves the ownership check ahead of the class lookup.** A malformed row still cannot be deleted by the wrong user — previously the null-config dereference threw *before* ownership was ever evaluated, so ownership wasn't just un-enforced, it was un-reachable for those rows.
2. **Resolves the type null-safely and, on no class match, logs loudly and best-effort deletes the record** instead of throwing. There is no class to instantiate for `ON_DELETE`, and an unregistered type has no live integration code that could own webhooks; the log calls out any external webhooks for out-of-band cleanup.

## Why this is safe (not a transient condition)

"No class match" is a genuinely terminal state, never a transient one:
- `integrationClasses` comes from `loadAppDefinition()` → a **synchronous** `require(backendDir/index.js)` of a static `Definition.integrations` array (`handlers/app-definition-loader.js:29-33`). There is no async/lazy registration and no deploy-race window where it is momentarily `[]` for one request; if the `require` fails, every route 500s (a mode this change neither causes nor worsens).
- `create-integration.js` **throws** `No integration class found for type` on an unknown type, so a row can only be *created* with a registered type. A later "no match" therefore means the type was removed/renamed or the config corrupted — exactly the rows we want to be able to delete.

The no-class path deliberately skips `persistStatus('IN_DELETION')` and `send('ON_DELETE')`: both are instance methods, and there is no instance to call them on (and writing a status to a row you hard-delete in the same call is pointless).

## Tests (TDD)

`delete-integration-for-user.test.js`: 21/21 green. Added cases for null config, `config` present with no `type`, empty-string type, unregistered type, and ownership-precedence (wrong user + null config). Verified each new/changed case **fails against the prior source** (the ownership-precedence case fails because the old code TypeErrors on the null-config deref before the ownership check). Full `integrations/` suite: no new failures (the 2 pre-existing failing suites — documentdb-encryption and find-integration-context — are unrelated and fail identically on `next`).

## Reviewed

Adversarial code review (approved) specifically confirmed the transient-empty-`integrationClasses` risk is not real (static synchronous require) and that skipping teardown for the no-class path introduces no new inconsistency.

## Scope note

This PR is the **delete-guard half of "Wave 1"** from an install/uninstall RCA. The second half (Entity/Credential composite unique indexes) is intentionally **not** included: a unique index alone converts the concurrent-authorize race into an uncaught Prisma P2002 (a 500 during OAuth) unless `upsertCredential`/`findOrCreateEntity` also gain retry-as-find handling across all three repo backends, and that work sequences more cleanly alongside the planned entity-identity rework (which rewrites the `externalId` column the index would cover). Tracking that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)