### PR TITLE
docs(adr): consolidate named ADRs into the numbered register (015–026)

### DIFF
--- a/.claude/skills/frigg-extensions/SKILL.md
+++ b/.claude/skills/frigg-extensions/SKILL.md
@@ -5,7 +5,7 @@ description: "Frigg Tier 3 Integration Extensions — reusable handler bundles (
 
 # Frigg Integration Extensions
 
-Tier 3 **Integration Extensions** let an API module ship reusable handler bundles — receiver routes, event handlers, queues, workers — that an integration consumes declaratively via `Definition.extensions`. Canonical docs: `packages/core/integrations/EXTENSIONS.md` and `docs/architecture/ADR-EXTENSIONS.md` (the three-tier taxonomy). For the per-account `Definition.webhooks: true` pattern, see `packages/core/integrations/WEBHOOK-QUICKSTART.md`.
+Tier 3 **Integration Extensions** let an API module ship reusable handler bundles — receiver routes, event handlers, queues, workers — that an integration consumes declaratively via `Definition.extensions`. Canonical docs: `packages/core/integrations/EXTENSIONS.md` and `docs/architecture-decisions/015-extensions-taxonomy.md` (the extensions taxonomy). For the per-account `Definition.webhooks: true` pattern, see `packages/core/integrations/WEBHOOK-QUICKSTART.md`.
 
 ## Extensions vs `Definition.webhooks: true`
 

--- a/docs/architecture-decisions/015-extensions-taxonomy.md
+++ b/docs/architecture-decisions/015-extensions-taxonomy.md
@@ -1,18 +1,18 @@
-# Architecture Decision Record: Extensions Taxonomy
+# ADR-015: Extensions Taxonomy
 
 **Status**: Proposed
 **Date**: 2026-06-09
-**Author**: Sean Matthews
+**Deciders**: Sean Matthews
 
 ## Context
 
 Frigg has used the word "extension" for several different things: app-level functionality additions, integration-class plugged-in bundles, provider-specific webhook handlers, and (in conversation) sometimes for templates and artifacts. Adopters and contributors cannot tell which is meant from context, and the prior ADR set bundled three distinct shapes into one document.
 
-This ADR defines **Extensions** as one of Frigg's two top-level categories of swap-in code, alongside [Plugins](./ADR-PLUGINS.md), and points to per-type ADRs for each kind.
+This ADR defines **Extensions** as one of Frigg's two top-level categories of swap-in code, alongside [Plugins](./016-plugins.md), and points to per-type ADRs for each kind.
 
 ## Decision
 
-An **Extension** is a package that adds optional functionality to a Frigg app, an integration, or an API module. Extensions differ from [Plugins](./ADR-PLUGINS.md):
+An **Extension** is a package that adds optional functionality to a Frigg app, an integration, or an API module. Extensions differ from [Plugins](./016-plugins.md):
 
 | | Plugins | Extensions |
 |---|---|---|
@@ -25,16 +25,16 @@ Extensions split into three types, each with its own ADR:
 
 | Type | Lives on | Authored by | Concern |
 |---|---|---|---|
-| **[Core Extensions](./ADR-CORE-EXTENSIONS.md)** | `appDefinition.extensions` | App developer, framework, community | App-level functionality (alerting, monitoring, agents, Slack interaction) |
-| **[Integration Extensions](./ADR-INTEGRATION-EXTENSIONS.md)** | `IntegrationBase.Definition.extensions` | API module, shared library, app developer | Integration-level patterns (sync engine, durable workflows, fan-out and fan-in, state machines, common user actions, multi-page config, field mapping) |
-| **[API Module Extensions](./ADR-API-MODULE-EXTENSIONS.md)** | `apiModule.extensions` | API module author | Provider-specific bundles (e.g. `hubspot.extensions.webhooks`) consumed by Integration Extensions |
+| **[Core Extensions](./017-core-extensions.md)** | `appDefinition.extensions` | App developer, framework, community | App-level functionality (alerting, monitoring, agents, Slack interaction) |
+| **[Integration Extensions](./018-integration-extensions.md)** | `IntegrationBase.Definition.extensions` | API module, shared library, app developer | Integration-level patterns (sync engine, durable workflows, fan-out and fan-in, state machines, common user actions, multi-page config, field mapping) |
+| **[API Module Extensions](./019-api-module-extensions.md)** | `apiModule.extensions` | API module author | Provider-specific bundles (e.g. `hubspot.extensions.webhooks`) consumed by Integration Extensions |
 
 ### Adjacent siblings
 
 Two concepts are often discussed alongside extensions but belong to their own categories:
 
-- **[Integration Templates](./ADR-INTEGRATION-TEMPLATES.md)**: ShadCN-mirror, copy-into-your-codebase base integrations. Templates are owned by the adopter after the copy; extensions are imported and consumed. Different lifecycle, different authoring story.
-- **[Artifacts](./ADR-ARTIFACTS.md)**: code or configuration that runs outside Frigg (HubSpot Project, Slack manifest, Salesforce managed package). Extensions run inside Frigg's runtime; artifacts run on the target platform.
+- **[Integration Templates](./023-integration-templates.md)**: ShadCN-mirror, copy-into-your-codebase base integrations. Templates are owned by the adopter after the copy; extensions are imported and consumed. Different lifecycle, different authoring story.
+- **[Artifacts](./022-artifacts.md)**: code or configuration that runs outside Frigg (HubSpot Project, Slack manifest, Salesforce managed package). Extensions run inside Frigg's runtime; artifacts run on the target platform.
 
 ## Architecture
 
@@ -70,10 +70,10 @@ Combining them into one ADR or one runtime mechanism mixes those concerns. Split
 
 ## Cross-references
 
-- [PLUGINS](./ADR-PLUGINS.md): the other top-level category (required-with-defaults infrastructure swaps)
-- [CORE-EXTENSIONS](./ADR-CORE-EXTENSIONS.md), [INTEGRATION-EXTENSIONS](./ADR-INTEGRATION-EXTENSIONS.md), [API-MODULE-EXTENSIONS](./ADR-API-MODULE-EXTENSIONS.md): the three extension types
-- [INTEGRATION-TEMPLATES](./ADR-INTEGRATION-TEMPLATES.md), [ARTIFACTS](./ADR-ARTIFACTS.md): adjacent siblings
-- [CAPABILITIES](./ADR-CAPABILITIES.md): capabilities can be `implementedBy` an extension of any of the three types
+- [PLUGINS](./016-plugins.md): the other top-level category (required-with-defaults infrastructure swaps)
+- [CORE-EXTENSIONS](./017-core-extensions.md), [INTEGRATION-EXTENSIONS](./018-integration-extensions.md), [API-MODULE-EXTENSIONS](./019-api-module-extensions.md): the three extension types
+- [INTEGRATION-TEMPLATES](./023-integration-templates.md), [ARTIFACTS](./022-artifacts.md): adjacent siblings
+- [CAPABILITIES](./020-capabilities.md): capabilities can be `implementedBy` an extension of any of the three types
 
 ## Open questions
 

--- a/docs/architecture-decisions/016-plugins.md
+++ b/docs/architecture-decisions/016-plugins.md
@@ -1,8 +1,8 @@
-# Architecture Decision Record: Plugins
+# ADR-016: Plugins
 
 **Status**: Proposed
 **Date**: 2026-06-09
-**Author**: Sean Matthews
+**Deciders**: Sean Matthews
 
 ## Context
 
@@ -19,7 +19,7 @@ Plugins let adopters swap required infrastructure pieces without forking core.
 
 A **Plugin** is a package that satisfies a core-defined interface so the framework can run on top of it. Plugins are required-with-defaults: core needs some plugin of each type to function, but the adopter picks which.
 
-Plugins differ from [Extensions](./ADR-EXTENSIONS-TAXONOMY.md) in two ways:
+Plugins differ from [Extensions](./015-extensions-taxonomy.md) in two ways:
 
 - **Required vs optional.** Without a database plugin selected, the framework cannot run. Without an alerting extension, the framework does not alert.
 - **Infrastructure vs functionality.** Plugins swap infrastructure under the framework (deploy target, persistence, encryption). Extensions add functionality on top of the framework (alerting, sync engines, provider webhooks).
@@ -84,15 +84,15 @@ Adding a new deployment target (Cloudflare Workers, Fly.io) means publishing a p
 
 ## Relationship to capabilities and the harness
 
-[Capabilities](./ADR-CAPABILITIES.md) can declare `requires` against plugin types. A capability that uses signed S3 URLs declares `requires: { provider: 'aws' }`. The capability resolver warns at boot if the selected provider plugin does not support a required capability, instead of failing at runtime.
+[Capabilities](./020-capabilities.md) can declare `requires` against plugin types. A capability that uses signed S3 URLs declares `requires: { provider: 'aws' }`. The capability resolver warns at boot if the selected provider plugin does not support a required capability, instead of failing at runtime.
 
-The [Agent Harness](./ADR-AGENT-HARNESS.md) reads the selected plugins at session start and uses them to constrain its planning. An agent working in a Netlify-deployed Frigg app does not suggest AWS-specific primitives.
+The [Agent Harness](./025-agent-harness.md) reads the selected plugins at session start and uses them to constrain its planning. An agent working in a Netlify-deployed Frigg app does not suggest AWS-specific primitives.
 
 ## Cross-references
 
-- [CAPABILITIES](./ADR-CAPABILITIES.md): capabilities may declare plugin-type requirements
-- [EXTENSIONS-TAXONOMY](./ADR-EXTENSIONS-TAXONOMY.md): extensions are optional and add functionality; plugins are required and swap infrastructure
-- [AGENT-HARNESS](./ADR-AGENT-HARNESS.md): the harness reads selected plugins to constrain agent planning
+- [CAPABILITIES](./020-capabilities.md): capabilities may declare plugin-type requirements
+- [EXTENSIONS-TAXONOMY](./015-extensions-taxonomy.md): extensions are optional and add functionality; plugins are required and swap infrastructure
+- [AGENT-HARNESS](./025-agent-harness.md): the harness reads selected plugins to constrain agent planning
 
 ## Open questions
 

--- a/docs/architecture-decisions/017-core-extensions.md
+++ b/docs/architecture-decisions/017-core-extensions.md
@@ -1,12 +1,12 @@
-# Architecture Decision Record: Core Extensions
+# ADR-017: Core Extensions
 
 **Status**: Proposed
 **Date**: 2026-06-09
-**Author**: Sean Matthews
+**Deciders**: Sean Matthews
 
 ## Context
 
-Frigg apps need cross-cutting functionality that is not tied to any one integration: alerting when a sync fails, monitoring of queue depth, an admin Slack bot, an agent that answers "what does this app do" against the [Capability](./ADR-CAPABILITIES.md) graph. This functionality operates at the application layer, observing or augmenting Frigg as a whole.
+Frigg apps need cross-cutting functionality that is not tied to any one integration: alerting when a sync fails, monitoring of queue depth, an admin Slack bot, an agent that answers "what does this app do" against the [Capability](./020-capabilities.md) graph. This functionality operates at the application layer, observing or augmenting Frigg as a whole.
 
 Today there is no defined place for this code. Adopters copy boilerplate into `index.js`, fork core, or wire it into an integration where it does not belong. This ADR establishes **Core Extensions** as the app-level optional functionality layer.
 
@@ -16,8 +16,8 @@ A **Core Extension** is a package that adds optional functionality at the applic
 
 Core Extensions differ from the other two extension types:
 
-- [Integration Extensions](./ADR-INTEGRATION-EXTENSIONS.md) add functionality to one integration (sync engine, webhook receiver). Core Extensions add functionality to the whole app.
-- [API Module Extensions](./ADR-API-MODULE-EXTENSIONS.md) are provider-specific bundles consumed by Integration Extensions. Core Extensions are app-level and provider-agnostic.
+- [Integration Extensions](./018-integration-extensions.md) add functionality to one integration (sync engine, webhook receiver). Core Extensions add functionality to the whole app.
+- [API Module Extensions](./019-api-module-extensions.md) are provider-specific bundles consumed by Integration Extensions. Core Extensions are app-level and provider-agnostic.
 
 ### Examples in scope
 
@@ -26,7 +26,7 @@ Core Extensions differ from the other two extension types:
 | `@friggframework/extension-alerting-pagerduty` | Routes integration errors and sync failures to PagerDuty |
 | `@friggframework/extension-monitoring-datadog` | Emits Frigg runtime metrics to Datadog |
 | `@friggframework/extension-slack-admin` | Slack bot that responds to `/frigg status`, `/frigg replay`, `/frigg integrations` against the running app |
-| `@friggframework/extension-agent-frigg-claude` | Embedded agent surface that queries the [Capability](./ADR-CAPABILITIES.md) graph, proposes sync flows, scaffolds integrations |
+| `@friggframework/extension-agent-frigg-claude` | Embedded agent surface that queries the [Capability](./020-capabilities.md) graph, proposes sync flows, scaffolds integrations |
 | `@friggframework/extension-audit-log` | Append-only audit log of every credential change, integration toggle, admin action |
 | `@friggframework/extension-mcp-server` | Exposes the app's capabilities as MCP tools for external agent consumption |
 
@@ -98,14 +98,14 @@ Each Core Extension is its own concern; they do not call each other directly. Co
 
 ## Relationship to the harness
 
-The [Agent Harness](./ADR-AGENT-HARNESS.md) reads `appDefinition.extensions` at session start to know what app-level capabilities exist. If `extension-agent-frigg-claude` is loaded, the harness knows the app already has a Claude surface. If `extension-mcp-server` is loaded, the harness can suggest MCP-tool patterns. Without this declaration, the agent reads source to find out.
+The [Agent Harness](./025-agent-harness.md) reads `appDefinition.extensions` at session start to know what app-level capabilities exist. If `extension-agent-frigg-claude` is loaded, the harness knows the app already has a Claude surface. If `extension-mcp-server` is loaded, the harness can suggest MCP-tool patterns. Without this declaration, the agent reads source to find out.
 
 ## Cross-references
 
-- [EXTENSIONS-TAXONOMY](./ADR-EXTENSIONS-TAXONOMY.md): Core Extensions in context
-- [INTEGRATION-EXTENSIONS](./ADR-INTEGRATION-EXTENSIONS.md): the other optional-functionality type, scoped to a single integration
-- [CAPABILITIES](./ADR-CAPABILITIES.md): Core Extensions can declare capabilities at the app level
-- [AGENT-HARNESS](./ADR-AGENT-HARNESS.md): the harness reads installed Core Extensions to constrain planning
+- [EXTENSIONS-TAXONOMY](./015-extensions-taxonomy.md): Core Extensions in context
+- [INTEGRATION-EXTENSIONS](./018-integration-extensions.md): the other optional-functionality type, scoped to a single integration
+- [CAPABILITIES](./020-capabilities.md): Core Extensions can declare capabilities at the app level
+- [AGENT-HARNESS](./025-agent-harness.md): the harness reads installed Core Extensions to constrain planning
 
 ## Open questions
 

--- a/docs/architecture-decisions/018-integration-extensions.md
+++ b/docs/architecture-decisions/018-integration-extensions.md
@@ -1,8 +1,8 @@
-# Architecture Decision Record: Integration Extensions
+# ADR-018: Integration Extensions
 
 **Status**: Implemented ([PR #590](https://github.com/friggframework/frigg/pull/590) and [PR #596](https://github.com/friggframework/frigg/pull/596)). Authoritative quick-start: [`packages/core/integrations/EXTENSIONS.md`](../../packages/core/integrations/EXTENSIONS.md).
 **Date**: 2026-06-09 (decision ratified retroactively)
-**Author**: Sean Matthews (decision), Daniel Klotz (implementation)
+**Deciders**: Sean Matthews (decision), Daniel Klotz (implementation)
 
 ## Context
 
@@ -121,10 +121,10 @@ Each is a candidate for a published extension package.
 
 ## Cross-references
 
-- [EXTENSIONS-TAXONOMY](./ADR-EXTENSIONS-TAXONOMY.md): Integration Extensions in context
-- [API-MODULE-EXTENSIONS](./ADR-API-MODULE-EXTENSIONS.md): Integration Extensions are typically consumed from an API Module Extension (e.g. `hubspot.extensions.webhooks`)
-- [INTEGRATION-TEMPLATES](./ADR-INTEGRATION-TEMPLATES.md): templates often pre-wire Integration Extensions for a category (a CRM sync template binds a sync-engine extension)
-- [CAPABILITIES](./ADR-CAPABILITIES.md): capabilities can be `implementedBy: { kind: 'extension', ref: 'extensions.webhooks' }`
+- [EXTENSIONS-TAXONOMY](./015-extensions-taxonomy.md): Integration Extensions in context
+- [API-MODULE-EXTENSIONS](./019-api-module-extensions.md): Integration Extensions are typically consumed from an API Module Extension (e.g. `hubspot.extensions.webhooks`)
+- [INTEGRATION-TEMPLATES](./023-integration-templates.md): templates often pre-wire Integration Extensions for a category (a CRM sync template binds a sync-engine extension)
+- [CAPABILITIES](./020-capabilities.md): capabilities can be `implementedBy: { kind: 'extension', ref: 'extensions.webhooks' }`
 - Quick-start in code: [`packages/core/integrations/EXTENSIONS.md`](../../packages/core/integrations/EXTENSIONS.md) is authoritative for current shape
 
 ## Open questions and deferred items

--- a/docs/architecture-decisions/019-api-module-extensions.md
+++ b/docs/architecture-decisions/019-api-module-extensions.md
@@ -1,12 +1,12 @@
-# Architecture Decision Record: API Module Extensions
+# ADR-019: API Module Extensions
 
 **Status**: Proposed (the Integration Extension mechanism shipped in #590 and #596; this ADR formalizes the api-module-side authoring story)
 **Date**: 2026-06-09
-**Author**: Sean Matthews
+**Deciders**: Sean Matthews
 
 ## Context
 
-[Integration Extensions](./ADR-INTEGRATION-EXTENSIONS.md) describes the consumer side: an integration class binds an extension bundle and gets routes, events, queues, and workers merged into its surface. This ADR describes the producer side: how an API module ships those bundles.
+[Integration Extensions](./018-integration-extensions.md) describes the consumer side: an integration class binds an extension bundle and gets routes, events, queues, and workers merged into its surface. This ADR describes the producer side: how an API module ships those bundles.
 
 An API module is the typed wrapper around one external provider's API (HubSpot, Slack, Asana, Salesforce). Provider-specific concerns (webhook signature schemes, OAuth refresh quirks, rate limits, paginated listing) belong in the API module, not in every integration that uses it. **API Module Extensions** are the namespace where an API module exposes these bundled patterns for any integration to consume.
 
@@ -103,10 +103,10 @@ Bundling these per module keeps the platform vocabulary in one place and lets ea
 
 ## Cross-references
 
-- [EXTENSIONS-TAXONOMY](./ADR-EXTENSIONS-TAXONOMY.md): API Module Extensions in context
-- [INTEGRATION-EXTENSIONS](./ADR-INTEGRATION-EXTENSIONS.md): the consumer side of the same contract
-- [ARTIFACTS](./ADR-ARTIFACTS.md): API modules also ship Artifact scaffolds; some API Module Extensions are the Frigg-side bridge that pairs with a deployed Artifact
-- [CAPABILITIES](./ADR-CAPABILITIES.md): API Module Extensions are `implementedBy` targets for capabilities at the API module level
+- [EXTENSIONS-TAXONOMY](./015-extensions-taxonomy.md): API Module Extensions in context
+- [INTEGRATION-EXTENSIONS](./018-integration-extensions.md): the consumer side of the same contract
+- [ARTIFACTS](./022-artifacts.md): API modules also ship Artifact scaffolds; some API Module Extensions are the Frigg-side bridge that pairs with a deployed Artifact
+- [CAPABILITIES](./020-capabilities.md): API Module Extensions are `implementedBy` targets for capabilities at the API module level
 
 ## Open questions
 
@@ -118,4 +118,4 @@ Bundling these per module keeps the platform vocabulary in one place and lets ea
 ## References
 
 - The Frigg core and API module boundary example from the original ADR-EXTENSIONS now lives here. `findIntegrationByPortalId` is the HubSpot vocabulary wrapper around core's `findIntegrationByEntityExternalId`.
-- HubSpot Developer Projects (see [ADR-ARTIFACTS](./ADR-ARTIFACTS.md)) is an example of an Artifact paired with an API Module Extension bridge.
+- HubSpot Developer Projects (see [ADR-ARTIFACTS](./022-artifacts.md)) is an example of an Artifact paired with an API Module Extension bridge.

--- a/docs/architecture-decisions/020-capabilities.md
+++ b/docs/architecture-decisions/020-capabilities.md
@@ -1,8 +1,8 @@
-# Architecture Decision Record: Capabilities
+# ADR-020: Capabilities
 
 **Status**: Proposed
 **Date**: 2026-06-09
-**Author**: Sean Matthews
+**Deciders**: Sean Matthews
 
 ## Context
 
@@ -43,10 +43,10 @@ An agent queries the capability graph instead of reading source. For a task like
 
 - HubSpot module has capability `crm.contact.list` (spec: `hubspot-openapi#/contacts.list`)
 - HubSpot module has capability `crm.contact.watch` (spec: `hubspot-asyncapi#/contact.changed`)
-- No adopter-side module exists; the agent scaffolds one using [INTEGRATION-TEMPLATES](./ADR-INTEGRATION-TEMPLATES.md)
+- No adopter-side module exists; the agent scaffolds one using [INTEGRATION-TEMPLATES](./023-integration-templates.md)
 - Integration capability `crm.contact.sync.bidir` composes from both modules' capabilities
 
-The [Agent Harness](./ADR-AGENT-HARNESS.md) wires this query into session start. The [Ontology](./ADR-ONTOLOGY.md) provides the convention layer for interpreting the graph.
+The [Agent Harness](./025-agent-harness.md) wires this query into session start. The [Ontology](./021-ontology.md) provides the convention layer for interpreting the graph.
 
 ### Visibility consumption
 
@@ -127,12 +127,12 @@ App level capabilities are usually computed (the union of declared integration c
 
 ## Cross-references
 
-- [PLUGINS](./ADR-PLUGINS.md): plugins are not capabilities (they swap infrastructure), but capabilities can declare `requires` against plugin types (e.g. a capability that needs an AWS deployment)
-- [EXTENSIONS-TAXONOMY](./ADR-EXTENSIONS-TAXONOMY.md), [CORE-EXTENSIONS](./ADR-CORE-EXTENSIONS.md), [INTEGRATION-EXTENSIONS](./ADR-INTEGRATION-EXTENSIONS.md), [API-MODULE-EXTENSIONS](./ADR-API-MODULE-EXTENSIONS.md): extensions are referenced by `implementedBy`
-- [INTEGRATION-TEMPLATES](./ADR-INTEGRATION-TEMPLATES.md): templates are referenced by `implementedBy` and typically declare the capability set the template promises
-- [ARTIFACTS](./ADR-ARTIFACTS.md): artifacts are referenced by `implementedBy` when a capability requires outside-Frigg code (HubSpot Project, Slack manifest)
-- [ONTOLOGY](./ADR-ONTOLOGY.md): the ontology contains capability naming and surface-kind conventions
-- [AGENT-HARNESS](./ADR-AGENT-HARNESS.md): the harness compiles and injects the capability graph at session start
+- [PLUGINS](./016-plugins.md): plugins are not capabilities (they swap infrastructure), but capabilities can declare `requires` against plugin types (e.g. a capability that needs an AWS deployment)
+- [EXTENSIONS-TAXONOMY](./015-extensions-taxonomy.md), [CORE-EXTENSIONS](./017-core-extensions.md), [INTEGRATION-EXTENSIONS](./018-integration-extensions.md), [API-MODULE-EXTENSIONS](./019-api-module-extensions.md): extensions are referenced by `implementedBy`
+- [INTEGRATION-TEMPLATES](./023-integration-templates.md): templates are referenced by `implementedBy` and typically declare the capability set the template promises
+- [ARTIFACTS](./022-artifacts.md): artifacts are referenced by `implementedBy` when a capability requires outside-Frigg code (HubSpot Project, Slack manifest)
+- [ONTOLOGY](./021-ontology.md): the ontology contains capability naming and surface-kind conventions
+- [AGENT-HARNESS](./025-agent-harness.md): the harness compiles and injects the capability graph at session start
 
 ## Open questions
 

--- a/docs/architecture-decisions/021-ontology.md
+++ b/docs/architecture-decisions/021-ontology.md
@@ -1,8 +1,8 @@
-# Architecture Decision Record: Ontology
+# ADR-021: Ontology
 
 **Status**: Proposed
 **Date**: 2026-06-09
-**Author**: Sean Matthews
+**Deciders**: Sean Matthews
 
 ## Context
 
@@ -19,11 +19,11 @@ A Frigg ontology is a stack of four layers, each progressively more specific:
 | Layer | Scope | Authored by | Examples |
 |---|---|---|---|
 | **L1 (Universal)** | Cross-framework conventions | Cross-framework working group (with Freya) | "Capability declarations point at specs and implementations." "Friction is captured to a shared `@freyaframework/friction` log." |
-| **L2 (Framework)** | Frigg conventions, locked constraints | Frigg core maintainers | "Routes ride [Capabilities](./ADR-CAPABILITIES.md), not raw handlers." "Credentials use field-level encryption." "Provider-vocabulary helpers belong in API Module Extensions." |
+| **L2 (Framework)** | Frigg conventions, locked constraints | Frigg core maintainers | "Routes ride [Capabilities](./020-capabilities.md), not raw handlers." "Credentials use field-level encryption." "Provider-vocabulary helpers belong in API Module Extensions." |
 | **L3 (Vendor-domain)** | Per-API-module conventions | API module authors (shipped with the module) | "HubSpot signature verification uses v3 URL-signing." "Salesforce credential refresh requires `apiPropertiesToPersist` for sandbox vs prod." |
 | **L4 (Instance)** | This specific Frigg app | The adopter | "This app uses Aurora Postgres." "Multi-tenant: every webhook receiver looks up portalId to integrationId." |
 
-Layers compose bottom-up at session start. Higher layers override or refine lower ones. The compiled result is a single XML-tagged context block (`<FRIGG-HARNESS-CONTEXT>...</FRIGG-HARNESS-CONTEXT>`) injected by the [Agent Harness](./ADR-AGENT-HARNESS.md).
+Layers compose bottom-up at session start. Higher layers override or refine lower ones. The compiled result is a single XML-tagged context block (`<FRIGG-HARNESS-CONTEXT>...</FRIGG-HARNESS-CONTEXT>`) injected by the [Agent Harness](./025-agent-harness.md).
 
 ### Module-exported ontology
 
@@ -76,7 +76,7 @@ Composition is additive: each higher layer adds or overrides conventions from th
 
 ## Session protocol
 
-At session start, the [Agent Harness](./ADR-AGENT-HARNESS.md):
+At session start, the [Agent Harness](./025-agent-harness.md):
 
 1. Walks the four layers in order (L1, L2, L3, L4)
 2. Compiles them into a single ontology object
@@ -94,20 +94,20 @@ The recommended use of the ontology by an agent:
 3. Validation subagent checks the design against L1–L4 conventions and locked constraints
 4. Validation subagent returns findings; parent agent corrects or proceeds
 
-This is one of the three interventions tested in the [Evals](./ADR-EVALS.md) precursor.
+This is one of the three interventions tested in the [Evals](./026-evals.md) precursor.
 
 ## Friction capture and ontology evolution
 
-When an agent encounters a question the ontology should have answered but did not, it logs a friction event to the shared `@freyaframework/friction` package (see [ADR-AGENT-HARNESS](./ADR-AGENT-HARNESS.md) for cross-framework alignment with Freya). Friction events are triaged into PR proposals against the relevant ontology layer.
+When an agent encounters a question the ontology should have answered but did not, it logs a friction event to the shared `@freyaframework/friction` package (see [ADR-AGENT-HARNESS](./025-agent-harness.md) for cross-framework alignment with Freya). Friction events are triaged into PR proposals against the relevant ontology layer.
 
 The ontology fills its own gaps from real agent traces rather than from anyone enumerating every constraint up front.
 
 ## Cross-references
 
-- [AGENT-HARNESS](./ADR-AGENT-HARNESS.md): the harness compiles, injects, and propagates the ontology
-- [CAPABILITIES](./ADR-CAPABILITIES.md): capability naming and surface-kind conventions live in the L2 ontology
-- [INTEGRATION-TEMPLATES](./ADR-INTEGRATION-TEMPLATES.md): templates may declare their own ontology fragment for adopter-specific conventions
-- [EVALS](./ADR-EVALS.md): measures whether ontology injection improves agent output
+- [AGENT-HARNESS](./025-agent-harness.md): the harness compiles, injects, and propagates the ontology
+- [CAPABILITIES](./020-capabilities.md): capability naming and surface-kind conventions live in the L2 ontology
+- [INTEGRATION-TEMPLATES](./023-integration-templates.md): templates may declare their own ontology fragment for adopter-specific conventions
+- [EVALS](./026-evals.md): measures whether ontology injection improves agent output
 
 ## Open questions
 

--- a/docs/architecture-decisions/022-artifacts.md
+++ b/docs/architecture-decisions/022-artifacts.md
@@ -1,14 +1,14 @@
-# Architecture Decision Record: Artifacts
+# ADR-022: Artifacts
 
 **Status**: Proposed
 **Date**: 2026-06-09
-**Author**: Sean Matthews
+**Deciders**: Sean Matthews
 
 ## Context
 
 Some Frigg integrations only work when a piece of code or configuration is deployed outside the Frigg runtime, on the provider's platform. A HubSpot UI Extension requires a deployed HubSpot Developer Project. A Slack app requires a published Slack App Manifest. A Salesforce-installed package requires a managed-package upload. None of this code runs in Frigg. Frigg often acts as the backend the deployed code talks to.
 
-These outside-Frigg deliverables do not fit any of the [Extensions](./ADR-EXTENSIONS-TAXONOMY.md) types (extensions run inside the Frigg runtime) and are not [Plugins](./ADR-PLUGINS.md). They are a distinct category.
+These outside-Frigg deliverables do not fit any of the [Extensions](./015-extensions-taxonomy.md) types (extensions run inside the Frigg runtime) and are not [Plugins](./016-plugins.md). They are a distinct category.
 
 ## Decision
 
@@ -16,7 +16,7 @@ An **Artifact** is code or configuration that an API module helps a developer ge
 
 1. Point at the provider's scaffolding mechanism (typically a vendor CLI like `hs project add` or `slack scaffold`)
 2. Optionally ship a starter template the developer copies into their artifact
-3. Provide the Frigg-side bridge (typically an [API Module Extension](./ADR-API-MODULE-EXTENSIONS.md)) that serves the artifact at runtime
+3. Provide the Frigg-side bridge (typically an [API Module Extension](./019-api-module-extensions.md)) that serves the artifact at runtime
 
 Artifacts live on the API module's Definition under `apiModule.Definition.artifacts`.
 
@@ -36,7 +36,7 @@ Three reasons:
 
 1. **Different runtime location.** Extensions run inside Frigg's Lambda. Artifacts run on the provider's platform. Different deployment story, different security boundary, different debugging surface.
 2. **Different developer workflow.** Extensions are imported and bound. Artifacts are scaffolded via vendor CLI and deployed to the provider. The Frigg CLI points at the vendor CLI rather than running anything itself.
-3. **Required-or-optional varies per capability.** Some [Capabilities](./ADR-CAPABILITIES.md) (HubSpot CRM Card UI) require the artifact to be deployed. Others can use a different mechanism. The capability declaration surfaces this requirement so the agent and adopter know ahead of time.
+3. **Required-or-optional varies per capability.** Some [Capabilities](./020-capabilities.md) (HubSpot CRM Card UI) require the artifact to be deployed. Others can use a different mechanism. The capability declaration surfaces this requirement so the agent and adopter know ahead of time.
 
 ## Shape (worked example)
 
@@ -98,10 +98,10 @@ The artifact is produced, deployed, and runs outside Frigg. It talks to Frigg vi
 
 ## Cross-references
 
-- [API-MODULE-EXTENSIONS](./ADR-API-MODULE-EXTENSIONS.md): bridge extensions (the Frigg-side runtime that serves an artifact) are typically API Module Extensions
-- [CAPABILITIES](./ADR-CAPABILITIES.md): capabilities can declare `requires: { artifact: ... }` to surface deployment dependencies
-- [EXTENSIONS-TAXONOMY](./ADR-EXTENSIONS-TAXONOMY.md): Artifacts are a sibling, not a fourth extension type
-- [AGENT-HARNESS](./ADR-AGENT-HARNESS.md): the harness knows which capabilities require artifact deployment and surfaces that as a planning constraint
+- [API-MODULE-EXTENSIONS](./019-api-module-extensions.md): bridge extensions (the Frigg-side runtime that serves an artifact) are typically API Module Extensions
+- [CAPABILITIES](./020-capabilities.md): capabilities can declare `requires: { artifact: ... }` to surface deployment dependencies
+- [EXTENSIONS-TAXONOMY](./015-extensions-taxonomy.md): Artifacts are a sibling, not a fourth extension type
+- [AGENT-HARNESS](./025-agent-harness.md): the harness knows which capabilities require artifact deployment and surfaces that as a planning constraint
 
 ## Open questions
 

--- a/docs/architecture-decisions/023-integration-templates.md
+++ b/docs/architecture-decisions/023-integration-templates.md
@@ -1,8 +1,8 @@
-# Architecture Decision Record: Integration Templates
+# ADR-023: Integration Templates
 
 **Status**: Proposed (new concept)
 **Date**: 2026-06-09
-**Author**: Sean Matthews
+**Deciders**: Sean Matthews
 
 ## Context
 
@@ -10,8 +10,8 @@
 
 Two existing concepts are adjacent but do not solve this:
 
-- [API Module Extensions](./ADR-API-MODULE-EXTENSIONS.md) are provider-specific bundles. They are coupled to one provider.
-- [Integration Extensions](./ADR-INTEGRATION-EXTENSIONS.md) are reusable handler bundles. They are plug-in libraries the adopter imports, not a starting point the adopter owns.
+- [API Module Extensions](./019-api-module-extensions.md) are provider-specific bundles. They are coupled to one provider.
+- [Integration Extensions](./018-integration-extensions.md) are reusable handler bundles. They are plug-in libraries the adopter imports, not a starting point the adopter owns.
 
 What is missing is a starting point: a working integration base class for a category (CRM sync, notification fanout, billing reconciliation, support-ticket bridge) that the adopter copies into their codebase, owns, and customizes for the specific provider pair.
 
@@ -111,11 +111,11 @@ Two reasons a sufficiently rich Integration Extension does not solve the same pr
 
 ## Cross-references
 
-- [EXTENSIONS-TAXONOMY](./ADR-EXTENSIONS-TAXONOMY.md): Integration Templates are a sibling to extensions, not a type of extension
-- [INTEGRATION-EXTENSIONS](./ADR-INTEGRATION-EXTENSIONS.md): templates can bind Integration Extensions internally (a CRM sync template binds a sync-engine extension)
-- [API-MODULE-EXTENSIONS](./ADR-API-MODULE-EXTENSIONS.md): templates know their partner module's API Module Extensions and bind them
-- [CAPABILITIES](./ADR-CAPABILITIES.md): each template declares the capability set it promises; the adopter inherits and can extend
-- [AGENT-HARNESS](./ADR-AGENT-HARNESS.md): the harness uses templates as the dominant scaffold path for new integration work
+- [EXTENSIONS-TAXONOMY](./015-extensions-taxonomy.md): Integration Templates are a sibling to extensions, not a type of extension
+- [INTEGRATION-EXTENSIONS](./018-integration-extensions.md): templates can bind Integration Extensions internally (a CRM sync template binds a sync-engine extension)
+- [API-MODULE-EXTENSIONS](./019-api-module-extensions.md): templates know their partner module's API Module Extensions and bind them
+- [CAPABILITIES](./020-capabilities.md): each template declares the capability set it promises; the adopter inherits and can extend
+- [AGENT-HARNESS](./025-agent-harness.md): the harness uses templates as the dominant scaffold path for new integration work
 
 ## Open questions
 

--- a/docs/architecture-decisions/024-global-entities.md
+++ b/docs/architecture-decisions/024-global-entities.md
@@ -1,8 +1,8 @@
-# Architecture Decision Record: Global Entities
+# ADR-024: Global Entities
 
 **Status**: Proposed
 **Date**: 2024-12-18
-**Author**: Claude Code
+**Deciders**: Claude Code
 
 ## Context
 

--- a/docs/architecture-decisions/025-agent-harness.md
+++ b/docs/architecture-decisions/025-agent-harness.md
@@ -1,8 +1,8 @@
-# Architecture Decision Record: Agent Harness
+# ADR-025: Agent Harness
 
 **Status**: Proposed
 **Date**: 2026-06-09
-**Author**: Sean Matthews
+**Deciders**: Sean Matthews
 
 ## Context
 
@@ -25,8 +25,8 @@ agent + CLI + harness + templates + capabilities → predictable, testable, vali
 | Agent (LLM inference) | Reasoning, code generation, planning |
 | CLI (`frigg` commands) | Deterministic actions: scaffold, install, deploy, test |
 | Harness | Session wiring: inject ontology, query capabilities, spawn validators, log friction |
-| [Integration Templates](./ADR-INTEGRATION-TEMPLATES.md) | ShadCN-mirror starting points the agent copies and customizes |
-| [Capabilities](./ADR-CAPABILITIES.md) | Machine-readable model of what exists and what can be added |
+| [Integration Templates](./023-integration-templates.md) | ShadCN-mirror starting points the agent copies and customizes |
+| [Capabilities](./020-capabilities.md) | Machine-readable model of what exists and what can be added |
 
 The harness on its own does nothing. It is the composition layer that brings the other four into the agent's session. With all five in place, the agent's remaining work is the finishing portion: adopter-specific API mapping, business logic, edge cases.
 
@@ -104,14 +104,14 @@ module.exports = async ({ workingDirectory }) => {
 }
 ```
 
-Friction capture is a separate small surface: `friction.log(event)` appends to `.frigg/friction/<session-id>.jsonl`, which a daily job triages into PR proposals against the [Ontology](./ADR-ONTOLOGY.md) layers.
+Friction capture is a separate small surface: `friction.log(event)` appends to `.frigg/friction/<session-id>.jsonl`, which a daily job triages into PR proposals against the [Ontology](./021-ontology.md) layers.
 
 The hook wiring, compiler internals, and friction storage shape are implementation details. The hooks should be replaceable with MCP server equivalents without changing the five-piece composition above.
 
 ## Cross-references
 
-- [CAPABILITIES](./ADR-CAPABILITIES.md), [ONTOLOGY](./ADR-ONTOLOGY.md), [INTEGRATION-TEMPLATES](./ADR-INTEGRATION-TEMPLATES.md), [PLUGINS](./ADR-PLUGINS.md), [EXTENSIONS-TAXONOMY](./ADR-EXTENSIONS-TAXONOMY.md): the five pieces the harness composes
-- [EVALS](./ADR-EVALS.md): measures whether the composed harness output is better than agent-alone
+- [CAPABILITIES](./020-capabilities.md), [ONTOLOGY](./021-ontology.md), [INTEGRATION-TEMPLATES](./023-integration-templates.md), [PLUGINS](./016-plugins.md), [EXTENSIONS-TAXONOMY](./015-extensions-taxonomy.md): the five pieces the harness composes
+- [EVALS](./026-evals.md): measures whether the composed harness output is better than agent-alone
 
 ## Open questions
 

--- a/docs/architecture-decisions/026-evals.md
+++ b/docs/architecture-decisions/026-evals.md
@@ -1,8 +1,8 @@
-# Architecture Decision Record: Evals
+# ADR-026: Evals
 
 **Status**: Proposed
 **Date**: 2026-06-09
-**Author**: Sean Matthews
+**Deciders**: Sean Matthews
 
 ## Context
 
@@ -115,8 +115,8 @@ The precursor is a cheap upstream check: three arms (Raw, Skill, Skill+Ontology+
 
 ## Cross-references
 
-- [CAPABILITIES](./ADR-CAPABILITIES.md), [ONTOLOGY](./ADR-ONTOLOGY.md), [AGENT-HARNESS](./ADR-AGENT-HARNESS.md): the three variables under test
-- [INTEGRATION-TEMPLATES](./ADR-INTEGRATION-TEMPLATES.md), [PLUGINS](./ADR-PLUGINS.md), [EXTENSIONS-TAXONOMY](./ADR-EXTENSIONS-TAXONOMY.md): additional pieces the harness composes. Tested as part of the harness condition rather than as independent variables (their lift is mechanistically tied to the harness wiring them in).
+- [CAPABILITIES](./020-capabilities.md), [ONTOLOGY](./021-ontology.md), [AGENT-HARNESS](./025-agent-harness.md): the three variables under test
+- [INTEGRATION-TEMPLATES](./023-integration-templates.md), [PLUGINS](./016-plugins.md), [EXTENSIONS-TAXONOMY](./015-extensions-taxonomy.md): additional pieces the harness composes. Tested as part of the harness condition rather than as independent variables (their lift is mechanistically tied to the harness wiring them in).
 
 ## Open questions
 

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -31,6 +31,18 @@ An ADR documents a significant architectural decision made in the project, inclu
 | [012](./012-database-schema-migrations.md) | Database Schema Migrations | Proposed | 2026-07-04 |
 | [013](./013-integration-version-migrations.md) | Integration Version Migrations | Proposed | 2026-07-04 |
 | [014](./014-consolidate-adr-register.md) | One Numbered ADR Register | Accepted | 2026-07-04 |
+| [015](./015-extensions-taxonomy.md) | Extensions Taxonomy | Proposed | 2026-06-09 |
+| [016](./016-plugins.md) | Plugins | Proposed | 2026-06-09 |
+| [017](./017-core-extensions.md) | Core Extensions | Proposed | 2026-06-09 |
+| [018](./018-integration-extensions.md) | Integration Extensions | Implemented | 2026-06-09 |
+| [019](./019-api-module-extensions.md) | API Module Extensions | Proposed | 2026-06-09 |
+| [020](./020-capabilities.md) | Capabilities | Proposed | 2026-06-09 |
+| [021](./021-ontology.md) | Ontology | Proposed | 2026-06-09 |
+| [022](./022-artifacts.md) | Artifacts | Proposed | 2026-06-09 |
+| [023](./023-integration-templates.md) | Integration Templates | Proposed | 2026-06-09 |
+| [024](./024-global-entities.md) | Global Entities | Proposed | 2024-12-18 |
+| [025](./025-agent-harness.md) | Agent Harness | Proposed | 2026-06-09 |
+| [026](./026-evals.md) | Evals | Proposed | 2026-06-09 |
 
 ## Conventions
 

--- a/docs/guides/GLOBAL-ENTITIES-GUIDE.md
+++ b/docs/guides/GLOBAL-ENTITIES-GUIDE.md
@@ -272,7 +272,7 @@ model Entity {
 
 ## Current Limitations
 
-> **Note**: As of this writing, the global entity feature requires a schema migration to add the `isGlobal` field to the Entity model. See ADR-GLOBAL-ENTITIES.md for details.
+> **Note**: As of this writing, the global entity feature requires a schema migration to add the `isGlobal` field to the Entity model. See [ADR-024: Global Entities](../architecture-decisions/024-global-entities.md) for details.
 
 **Key Implementation Details:**
 - `moduleName` is used for entity lookups (already exists in schema)

--- a/packages/core/integrations/EXTENSIONS.md
+++ b/packages/core/integrations/EXTENSIONS.md
@@ -1,6 +1,6 @@
 # Integration Extensions Quick Start
 
-Tier 3 **Integration Extensions** let an API module ship reusable handler bundles — receiver routes, event handlers, queues, workers — that an integration consumes declaratively via `Definition.extensions`. See [ADR-EXTENSIONS](../../../docs/architecture/ADR-EXTENSIONS.md) for the full taxonomy.
+Tier 3 **Integration Extensions** let an API module ship reusable handler bundles — receiver routes, event handlers, queues, workers — that an integration consumes declaratively via `Definition.extensions`. See [ADR-015: Extensions Taxonomy](../../../docs/architecture-decisions/015-extensions-taxonomy.md) for the full taxonomy.
 
 ## When to use this vs `Definition.webhooks: true`
 
@@ -235,6 +235,6 @@ This keeps core platform-neutral and reusable while keeping the api-module code 
 
 ## See also
 
-- [ADR-EXTENSIONS](../../../docs/architecture/ADR-EXTENSIONS.md) — the three-tier taxonomy (Core Plugins / Application Extensions / Integration Extensions)
+- [ADR-015: Extensions Taxonomy](../../../docs/architecture-decisions/015-extensions-taxonomy.md) — the three-tier taxonomy (Core Plugins / Application Extensions / Integration Extensions)
 - [WEBHOOK-QUICKSTART](./WEBHOOK-QUICKSTART.md) — per-account `Definition.webhooks: true` pattern
 - `extension.js` — the validation + flattening helpers (`validateExtensionBinding`, `getExtensionRoutes`, `getExtensionWorkers`)


### PR DESCRIPTION
## Summary

Pure restructure — **no content changes** — executing the consolidation proposed in **ADR-014**. Folds the 12 name-slugged `docs/architecture/ADR-*.md` docs into the single numbered register at `docs/architecture-decisions/` so there's one location, one structure, one index.

Per file:
- `git mv` into the register as `015`–`026` (**tracked as renames — git history preserved**).
- Rewrite each heading to `# ADR-NNN: Title` (number **and** name).
- Map `**Author**` → `**Deciders**`.
- Repoint intra-cluster cross-links to the new `NNN-slug.md` paths.
- Add index rows to `README.md`.

| New | From | Title | Status |
|---|---|---|---|
| 015 | ADR-EXTENSIONS-TAXONOMY | Extensions Taxonomy | Proposed |
| 016 | ADR-PLUGINS | Plugins | Proposed |
| 017 | ADR-CORE-EXTENSIONS | Core Extensions | Proposed |
| 018 | ADR-INTEGRATION-EXTENSIONS | Integration Extensions | Implemented |
| 019 | ADR-API-MODULE-EXTENSIONS | API Module Extensions | Proposed |
| 020 | ADR-CAPABILITIES | Capabilities | Proposed |
| 021 | ADR-ONTOLOGY | Ontology | Proposed |
| 022 | ADR-ARTIFACTS | Artifacts | Proposed |
| 023 | ADR-INTEGRATION-TEMPLATES | Integration Templates | Proposed |
| 024 | ADR-GLOBAL-ENTITIES | Global Entities | Proposed |
| 025 | ADR-AGENT-HARNESS | Agent Harness | Proposed |
| 026 | ADR-EVALS | Evals | Proposed |

### Also (link integrity)
Repoints three references that pointed at the **already-deleted** `ADR-EXTENSIONS.md` (its successor is `015-extensions-taxonomy.md`) — in `packages/core/integrations/EXTENSIONS.md`, the `frigg-extensions` skill, and the global-entities guide. These were dangling before this PR.

## Notes for reviewers

- **Statuses preserved** on move — consolidation is not acceptance.
- Non-ADR files under `docs/architecture/` are left in place (only `ADR-*.md` moved).
- Docs only — **no `release`/`prerelease` labels** (nothing ships).
- **Depends on / complements #617**, which adds ADR-012/013/014 and accepts 010/011. The `README.md` index rows for 012–014 come from #617; this PR adds 015–026. If #617 merges first, this rebases cleanly; otherwise a trivial index-table merge. Recommend merging #617 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019BQcoqYva5TXM2DQAyEG5o)_