### PR TITLE
fix(requester): grace-retry non-refreshable 401s and surface diagnostic detail on invalid-credential errors

### DIFF
--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -220,11 +220,11 @@ class IntegrationBase {
     /**
      * Returns the modules as object with keys as module names.
      * Uses the keys from Definition.modules to attach modules correctly.
-     * 
+     *
      * Example:
      *   Definition.modules = { attio: {...}, quo: { definition: { getName: () => 'quo-attio' } } }
      *   Module with getName()='quo-attio' gets attached as this.quo (not this['quo-attio'])
-     * 
+     *
      * @private
      * @param {Array} integrationModules - Array of module instances
      * @returns {Object} The modules object
@@ -791,8 +791,18 @@ class IntegrationBase {
         if (!this.id) return;
 
         if (delegateString === 'CREDENTIAL_INVALIDATED') {
+            const detail =
+                object?.reason || object?.statusCode
+                    ? ` (status ${object?.statusCode ?? '?'}: ${
+                          object?.reason ?? 'no reason given'
+                      })`
+                    : '';
             console.log(
-                `[Frigg] Module ${notifier?.name || '?'} reported invalid credentials for integration ${this.id} — marking ERROR`
+                `[Frigg] Module ${
+                    notifier?.name || '?'
+                } reported invalid credentials for integration ${
+                    this.id
+                } — marking ERROR${detail}`
             );
             await this.persistStatus('ERROR');
             return;
@@ -801,7 +811,11 @@ class IntegrationBase {
         if (delegateString === 'CREDENTIAL_VALIDATED') {
             if (this.status !== 'ERROR') return;
             console.log(
-                `[Frigg] Module ${notifier?.name || '?'} reported valid credentials for integration ${this.id} — clearing ERROR → ENABLED`
+                `[Frigg] Module ${
+                    notifier?.name || '?'
+                } reported valid credentials for integration ${
+                    this.id
+                } — clearing ERROR → ENABLED`
             );
             await this.persistStatus('ENABLED');
         }

--- a/packages/core/integrations/tests/integration-base-receive-notification.test.js
+++ b/packages/core/integrations/tests/integration-base-receive-notification.test.js
@@ -59,6 +59,44 @@ describe('IntegrationBase.receiveNotification', () => {
         expect(integration.status).toBe('ERROR');
     });
 
+    it('includes the diagnostic reason and status code in the log line when present', async () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        try {
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_INVALIDATED',
+                {
+                    credentialId: 'cred-1',
+                    moduleName: 'testmodule',
+                    reason: 'Unauthorized',
+                    statusCode: 401,
+                }
+            );
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('401'));
+            expect(logSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Unauthorized')
+            );
+        } finally {
+            logSpy.mockRestore();
+        }
+    });
+
+    it('logs the plain message with no diagnostic suffix when none is provided', async () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        try {
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_INVALIDATED',
+                { credentialId: 'cred-1', moduleName: 'testmodule' }
+            );
+            expect(logSpy).toHaveBeenCalledWith(
+                '[Frigg] Module testmodule reported invalid credentials for integration int-1 — marking ERROR'
+            );
+        } finally {
+            logSpy.mockRestore();
+        }
+    });
+
     describe('CREDENTIAL_VALIDATED self-heal', () => {
         const validatedPayload = {
             credentialId: 'cred-1',

--- a/packages/core/modules/module.js
+++ b/packages/core/modules/module.js
@@ -147,14 +147,23 @@ class Module extends Delegate {
         } else if (delegateString === this.api.DLGT_TOKEN_DEAUTHORIZED) {
             await this.deauthorize();
         } else if (delegateString === this.api.DLGT_INVALID_AUTH) {
-            await this.markCredentialsInvalid();
+            await this.markCredentialsInvalid(object);
         }
     }
 
-    async markCredentialsInvalid() {
+    async markCredentialsInvalid(diagnosticInfo = null) {
         if (!this.credential) return;
 
         if (!this.credential.id) return;
+
+        if (diagnosticInfo) {
+            console.error(
+                `[Frigg] Module ${this.name} credentials rejected (status ${
+                    diagnosticInfo.statusCode ?? '?'
+                }):`,
+                diagnosticInfo.message ?? diagnosticInfo
+            );
+        }
 
         await this.credentialRepository.updateAuthenticationStatus(
             this.credential.id,
@@ -181,6 +190,10 @@ class Module extends Delegate {
             await this.notify(this.DLGT_CREDENTIAL_INVALIDATED, {
                 credentialId: this.credential.id,
                 moduleName: this.name,
+                ...(diagnosticInfo && {
+                    reason: diagnosticInfo.message,
+                    statusCode: diagnosticInfo.statusCode,
+                }),
             });
         } catch (err) {
             console.error(

--- a/packages/core/modules/requester/oauth-2.test.js
+++ b/packages/core/modules/requester/oauth-2.test.js
@@ -354,11 +354,12 @@ describe('OAuth2Requester', () => {
             expect(mockFetch.mock.calls[0][1].headers.Authorization).toBeUndefined();
         });
 
-        it('should not retry more than once for consecutive 401s and should NOT notify on the second 401', async () => {
+        it('retries consecutive 401s up to 3 times, then notifies INVALID_AUTH once the budget is exhausted', async () => {
             const mockFetch = jest.fn().mockResolvedValue({
                 status: 401,
-                headers: { get: () => 'application/json' },
+                headers: new Map([['Content-Type', 'application/json']]),
                 json: async () => ({ error: 'Unauthorized' }),
+                text: async () => JSON.stringify({ error: 'Unauthorized' }),
             });
 
             const requester = new OAuth2Requester({
@@ -377,8 +378,11 @@ describe('OAuth2Requester', () => {
             await expect(requester._get({ url: 'https://api.example.com/data' }))
                 .rejects.toThrow();
 
-            expect(mockFetch).toHaveBeenCalledTimes(2);
-            expect(requester.notify).not.toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+            expect(mockFetch).toHaveBeenCalledTimes(4);
+            expect(requester.notify).toHaveBeenCalledWith(
+                requester.DLGT_INVALID_AUTH,
+                expect.objectContaining({ statusCode: 401 })
+            );
         });
 
         it('should use getTokenFromClientCredentials for client_credentials grant type on 401', async () => {

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -12,8 +12,6 @@ class Requester extends Delegate {
         this.backOff = get(params, 'backOff', [1, 3, 10, 30, 60, 180]);
         this.isRefreshable = false;
         this.refreshCount = 0;
-        // Deliberately separate from `i` — a 429/5xx retry must not consume
-        // the 401 grace retry budget below.
         this.authGraceRetryCount = 0;
         this.DLGT_INVALID_AUTH = 'INVALID_AUTH';
         this.delegateTypes.push(this.DLGT_INVALID_AUTH);
@@ -63,6 +61,10 @@ class Requester extends Delegate {
     };
 
     /**
+     * @param {string} url - The request URL, relative or absolute.
+     * @param {Object} options - Fetch options (method, headers, body, query,
+     *   returnFullRes, etc.) built by the `_get`/`_post`/`_patch`/`_put`/
+     *   `_delete` wrappers.
      * @param {number} attempt - 0-based count of retries already made for
      *   this call. Indexes `this.backOff` for the next delay and is passed
      *   back in on each recursive retry.

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -61,6 +61,11 @@ class Requester extends Delegate {
         return resp.text();
     };
 
+    /**
+     * @param {number} attempt - 0-based count of retries already made for
+     *   this call. Indexes `this.backOff` for the next delay and is passed
+     *   back in on each recursive retry.
+     */
     async _request(url, options, attempt = 0) {
         let encodedUrl = encodeURI(url);
         if (options.query) {

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -152,8 +152,27 @@ class Requester extends Delegate {
 
             if (status === 401) {
                 if (!this.isRefreshable) {
-                    await this.notify(this.DLGT_INVALID_AUTH);
-                    return;
+                    // A non-refreshable requester (ApiKeyRequester,
+                    // BasicAuthRequester) has no token to renew, but a single
+                    // 401 is not necessarily proof the credential itself is
+                    // bad — it may be a transient edge/gateway hiccup. Grant
+                    // one grace retry of the same request before concluding
+                    // the credential is truly invalid, mirroring the single
+                    // refresh attempt OAuth2Requester gets below.
+                    if (i === 0) {
+                        clearRequestTimer();
+                        const delay = this.backOff[0] * 1000;
+                        await new Promise((resolve) =>
+                            setTimeout(resolve, delay)
+                        );
+                        return this._request(url, options, i + 1);
+                    }
+
+                    throw await this._invalidateAuth(
+                        encodedUrl,
+                        options,
+                        response
+                    );
                 }
 
                 if (this.refreshCount === 0) {
@@ -164,8 +183,11 @@ class Requester extends Delegate {
                         return this._request(url, options, i + 1);
                     }
 
-                    await this.notify(this.DLGT_INVALID_AUTH);
-                    return;
+                    throw await this._invalidateAuth(
+                        encodedUrl,
+                        options,
+                        response
+                    );
                 }
             }
 
@@ -202,6 +224,22 @@ class Requester extends Delegate {
         } finally {
             clearRequestTimer();
         }
+    }
+
+    // Builds a diagnostic FetchError from the failed 401 response, notifies
+    // delegates with it attached (so the credential-invalidation chain can
+    // log real detail instead of a bare "invalid credentials" with no
+    // evidence), and returns the error for the caller to throw. Notifying
+    // and throwing are split so notify() always fires even though `await`ing
+    // it happens before the throw.
+    async _invalidateAuth(encodedUrl, options, response) {
+        const fetchError = await FetchError.create({
+            resource: encodedUrl,
+            init: options,
+            response,
+        });
+        await this.notify(this.DLGT_INVALID_AUTH, fetchError);
+        return fetchError;
     }
 
     _maybeFlagTimeoutDuringBodyRead(err, timeoutMs) {

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -168,7 +168,10 @@ class Requester extends Delegate {
                 if (!this.isRefreshable) {
                     // Up to MAX_AUTH_RETRIES grace retries before invalidating
                     // — a 401 alone isn't proof the credential is bad.
-                    if (this.authGraceRetryCount < MAX_AUTH_RETRIES) {
+                    if (
+                        this.authGraceRetryCount < MAX_AUTH_RETRIES &&
+                        this.authGraceRetryCount < this.backOff.length
+                    ) {
                         const delay =
                             this.backOff[this.authGraceRetryCount] * 1000;
                         this.authGraceRetryCount++;

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -11,10 +11,8 @@ class Requester extends Delegate {
         this.backOff = get(params, 'backOff', [1, 3, 10, 30, 60, 180]);
         this.isRefreshable = false;
         this.refreshCount = 0;
-        // Independent from the `i` backoff-attempt counter passed through
-        // _request's recursion — a 429/5xx retry earlier in the same call
-        // already advances `i`, and gating the 401 grace retry on `i === 0`
-        // would skip it whenever a 401 follows any prior backoff response.
+        // Deliberately separate from `i` — a 429/5xx retry must not consume
+        // the 401 grace retry budget below.
         this.authGraceRetryCount = 0;
         this.DLGT_INVALID_AUTH = 'INVALID_AUTH';
         this.delegateTypes.push(this.DLGT_INVALID_AUTH);
@@ -157,16 +155,8 @@ class Requester extends Delegate {
 
             if (status === 401) {
                 if (!this.isRefreshable) {
-                    // A non-refreshable requester (ApiKeyRequester,
-                    // BasicAuthRequester) has no token to renew, but a single
-                    // 401 is not necessarily proof the credential itself is
-                    // bad — it may be a transient edge/gateway hiccup. Grant
-                    // one grace retry of the same request before concluding
-                    // the credential is truly invalid, mirroring the single
-                    // refresh attempt OAuth2Requester gets below. Gated on
-                    // authGraceRetryCount rather than `i` so an earlier
-                    // 429/5xx backoff on the same call doesn't consume the
-                    // grace retry before a 401 is even seen.
+                    // One grace retry before invalidating — a single 401
+                    // isn't proof the credential is bad.
                     if (this.authGraceRetryCount === 0) {
                         this.authGraceRetryCount++;
                         clearRequestTimer();
@@ -215,10 +205,9 @@ class Requester extends Delegate {
                 );
             }
 
-            // Successful response: reset the per-instance refresh/grace
-            // budgets so a later 401 in the same Requester lifetime can
-            // attempt refresh (or another grace retry) again instead of
-            // silently falling through.
+            // Successful response: reset the per-instance refresh budget so
+            // a later 401 in the same Requester lifetime can attempt refresh
+            // again instead of silently falling through.
             this.refreshCount = 0;
             this.authGraceRetryCount = 0;
 
@@ -237,12 +226,6 @@ class Requester extends Delegate {
         }
     }
 
-    // Builds a diagnostic FetchError from the failed 401 response, notifies
-    // delegates with it attached (so the credential-invalidation chain can
-    // log real detail instead of a bare "invalid credentials" with no
-    // evidence), and returns the error for the caller to throw. Notifying
-    // and throwing are split so notify() always fires even though `await`ing
-    // it happens before the throw.
     async _invalidateAuth(encodedUrl, options, response) {
         const fetchError = await FetchError.create({
             resource: encodedUrl,

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -61,7 +61,7 @@ class Requester extends Delegate {
         return resp.text();
     };
 
-    async _request(url, options, i = 0) {
+    async _request(url, options, attempt = 0) {
         let encodedUrl = encodeURI(url);
         if (options.query) {
             let queryBuild = '?';
@@ -119,11 +119,11 @@ class Requester extends Delegate {
                 // stall at batch scale.
                 const isTimeout =
                     e?.name === 'AbortError' || e?.type === 'aborted';
-                if (e?.code === 'ECONNRESET' && i < this.backOff.length) {
+                if (e?.code === 'ECONNRESET' && attempt < this.backOff.length) {
                     clearRequestTimer();
-                    const delay = this.backOff[i] * 1000;
+                    const delay = this.backOff[attempt] * 1000;
                     await new Promise((resolve) => setTimeout(resolve, delay));
-                    return this._request(url, options, i + 1);
+                    return this._request(url, options, attempt + 1);
                 }
                 const fetchError = await FetchError.create({
                     resource: encodedUrl,
@@ -146,11 +146,14 @@ class Requester extends Delegate {
             const { status } = response;
 
             // If the status is retriable and there are back off requests left, retry the request
-            if ((status === 429 || status >= 500) && i < this.backOff.length) {
+            if (
+                (status === 429 || status >= 500) &&
+                attempt < this.backOff.length
+            ) {
                 clearRequestTimer();
-                const delay = this.backOff[i] * 1000;
+                const delay = this.backOff[attempt] * 1000;
                 await new Promise((resolve) => setTimeout(resolve, delay));
-                return this._request(url, options, i + 1);
+                return this._request(url, options, attempt + 1);
             }
 
             if (status === 401) {
@@ -164,7 +167,7 @@ class Requester extends Delegate {
                         await new Promise((resolve) =>
                             setTimeout(resolve, delay)
                         );
-                        return this._request(url, options, i + 1);
+                        return this._request(url, options, attempt + 1);
                     }
 
                     throw await this._invalidateAuth(
@@ -179,7 +182,7 @@ class Requester extends Delegate {
                     const refreshSucceeded = await this.refreshAuth();
                     if (refreshSucceeded) {
                         clearRequestTimer();
-                        return this._request(url, options, i + 1);
+                        return this._request(url, options, attempt + 1);
                     }
 
                     throw await this._invalidateAuth(

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -4,6 +4,7 @@ const { FetchError } = require('../../errors');
 const { get } = require('../../assertions');
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+const MAX_AUTH_RETRIES = 3;
 
 class Requester extends Delegate {
     constructor(params) {
@@ -163,12 +164,13 @@ class Requester extends Delegate {
 
             if (status === 401) {
                 if (!this.isRefreshable) {
-                    // One grace retry before invalidating — a single 401
-                    // isn't proof the credential is bad.
-                    if (this.authGraceRetryCount === 0) {
+                    // Up to MAX_AUTH_RETRIES grace retries before invalidating
+                    // — a 401 alone isn't proof the credential is bad.
+                    if (this.authGraceRetryCount < MAX_AUTH_RETRIES) {
+                        const delay =
+                            this.backOff[this.authGraceRetryCount] * 1000;
                         this.authGraceRetryCount++;
                         clearRequestTimer();
-                        const delay = this.backOff[0] * 1000;
                         await new Promise((resolve) =>
                             setTimeout(resolve, delay)
                         );
@@ -182,7 +184,7 @@ class Requester extends Delegate {
                     );
                 }
 
-                if (this.refreshCount === 0) {
+                if (this.refreshCount < MAX_AUTH_RETRIES) {
                     this.refreshCount++;
                     const refreshSucceeded = await this.refreshAuth();
                     if (refreshSucceeded) {
@@ -196,6 +198,8 @@ class Requester extends Delegate {
                         response
                     );
                 }
+
+                throw await this._invalidateAuth(encodedUrl, options, response);
             }
 
             // If the error wasn't retried, throw. FetchError.create reads

--- a/packages/core/modules/requester/requester.js
+++ b/packages/core/modules/requester/requester.js
@@ -11,6 +11,11 @@ class Requester extends Delegate {
         this.backOff = get(params, 'backOff', [1, 3, 10, 30, 60, 180]);
         this.isRefreshable = false;
         this.refreshCount = 0;
+        // Independent from the `i` backoff-attempt counter passed through
+        // _request's recursion — a 429/5xx retry earlier in the same call
+        // already advances `i`, and gating the 401 grace retry on `i === 0`
+        // would skip it whenever a 401 follows any prior backoff response.
+        this.authGraceRetryCount = 0;
         this.DLGT_INVALID_AUTH = 'INVALID_AUTH';
         this.delegateTypes.push(this.DLGT_INVALID_AUTH);
         this.agent = get(params, 'agent', null);
@@ -158,8 +163,12 @@ class Requester extends Delegate {
                     // bad — it may be a transient edge/gateway hiccup. Grant
                     // one grace retry of the same request before concluding
                     // the credential is truly invalid, mirroring the single
-                    // refresh attempt OAuth2Requester gets below.
-                    if (i === 0) {
+                    // refresh attempt OAuth2Requester gets below. Gated on
+                    // authGraceRetryCount rather than `i` so an earlier
+                    // 429/5xx backoff on the same call doesn't consume the
+                    // grace retry before a 401 is even seen.
+                    if (this.authGraceRetryCount === 0) {
+                        this.authGraceRetryCount++;
                         clearRequestTimer();
                         const delay = this.backOff[0] * 1000;
                         await new Promise((resolve) =>
@@ -206,10 +215,12 @@ class Requester extends Delegate {
                 );
             }
 
-            // Successful response: reset the per-instance refresh budget so
-            // a later 401 in the same Requester lifetime can attempt refresh
-            // again instead of silently falling through.
+            // Successful response: reset the per-instance refresh/grace
+            // budgets so a later 401 in the same Requester lifetime can
+            // attempt refresh (or another grace retry) again instead of
+            // silently falling through.
             this.refreshCount = 0;
+            this.authGraceRetryCount = 0;
 
             // parsedBody consumes the response body stream. If the server
             // stalls mid-stream the timer (still armed) aborts it.

--- a/packages/core/modules/requester/requester.test.js
+++ b/packages/core/modules/requester/requester.test.js
@@ -312,14 +312,16 @@ describe('Requester', () => {
             }
         }
 
-        it('grants one grace retry on a 401 before firing INVALID_AUTH when the requester is not refreshable', async () => {
+        it('grants 3 grace retries on a 401 before firing INVALID_AUTH when the requester is not refreshable', async () => {
             const fetchMock = oauthFetch([
+                { status: 401, body: { error: 'unauthorized' } },
+                { status: 401, body: { error: 'unauthorized' } },
                 { status: 401, body: { error: 'unauthorized' } },
                 { status: 401, body: { error: 'unauthorized' } },
             ]);
             const requester = new TestRequester({
                 fetch: fetchMock,
-                backOff: [0],
+                backOff: [0, 0, 0],
             });
             requester.notify = jest.fn();
 
@@ -331,38 +333,18 @@ describe('Requester', () => {
                 requester.DLGT_INVALID_AUTH,
                 expect.objectContaining({ statusCode: 401 })
             );
-            expect(fetchMock).toHaveBeenCalledTimes(2);
+            expect(fetchMock).toHaveBeenCalledTimes(4);
         });
 
-        it('does NOT fire INVALID_AUTH when the grace retry succeeds', async () => {
+        it('does NOT fire INVALID_AUTH when a later grace retry succeeds', async () => {
             const fetchMock = oauthFetch([
+                { status: 401, body: { error: 'unauthorized' } },
                 { status: 401, body: { error: 'unauthorized' } },
                 { status: 200, body: { ok: true } },
             ]);
             const requester = new TestRequester({
                 fetch: fetchMock,
-                backOff: [0],
-            });
-            requester.notify = jest.fn();
-
-            const result = await requester._get({
-                url: 'https://example.com/protected',
-            });
-
-            expect(result).toEqual({ ok: true });
-            expect(requester.notify).not.toHaveBeenCalled();
-            expect(fetchMock).toHaveBeenCalledTimes(2);
-        });
-
-        it('still grants the 401 grace retry after an earlier 429 already consumed a backoff attempt', async () => {
-            const fetchMock = oauthFetch([
-                { status: 429 },
-                { status: 401, body: { error: 'unauthorized' } },
-                { status: 200, body: { ok: true } },
-            ]);
-            const requester = new TestRequester({
-                fetch: fetchMock,
-                backOff: [0, 0],
+                backOff: [0, 0, 0],
             });
             requester.notify = jest.fn();
 
@@ -373,6 +355,59 @@ describe('Requester', () => {
             expect(result).toEqual({ ok: true });
             expect(requester.notify).not.toHaveBeenCalled();
             expect(fetchMock).toHaveBeenCalledTimes(3);
+        });
+
+        it('waits an escalating backOff delay for each successive grace retry', async () => {
+            const fetchMock = oauthFetch([
+                { status: 401, body: { error: 'unauthorized' } },
+                { status: 401, body: { error: 'unauthorized' } },
+                { status: 401, body: { error: 'unauthorized' } },
+                { status: 200, body: { ok: true } },
+            ]);
+            const requester = new TestRequester({
+                fetch: fetchMock,
+                backOff: [10, 20, 30],
+                requestTimeoutMs: 0,
+            });
+            requester.notify = jest.fn();
+            const sleptDelays = [];
+            const originalSetTimeout = global.setTimeout;
+            jest.spyOn(global, 'setTimeout').mockImplementation((fn, delay) => {
+                sleptDelays.push(delay);
+                return originalSetTimeout(fn, 0);
+            });
+
+            try {
+                await requester._get({
+                    url: 'https://example.com/protected',
+                });
+            } finally {
+                global.setTimeout.mockRestore();
+            }
+
+            expect(sleptDelays).toEqual([10_000, 20_000, 30_000]);
+        });
+
+        it('still grants the 401 grace retries after an earlier 429 already consumed a backoff attempt', async () => {
+            const fetchMock = oauthFetch([
+                { status: 429 },
+                { status: 401, body: { error: 'unauthorized' } },
+                { status: 401, body: { error: 'unauthorized' } },
+                { status: 200, body: { ok: true } },
+            ]);
+            const requester = new TestRequester({
+                fetch: fetchMock,
+                backOff: [0, 0, 0, 0],
+            });
+            requester.notify = jest.fn();
+
+            const result = await requester._get({
+                url: 'https://example.com/protected',
+            });
+
+            expect(result).toEqual({ ok: true });
+            expect(requester.notify).not.toHaveBeenCalled();
+            expect(fetchMock).toHaveBeenCalledTimes(4);
         });
 
         it('does NOT fire INVALID_AUTH when refresh succeeds and retry returns 200', async () => {
@@ -412,8 +447,31 @@ describe('Requester', () => {
             expect(fetchMock).toHaveBeenCalledTimes(1);
         });
 
-        it('does NOT fire INVALID_AUTH on a second 401 after a successful refresh', async () => {
+        it('keeps refreshing and retrying across up to 3 consecutive 401s, then succeeds', async () => {
             const fetchMock = oauthFetch([
+                { status: 401 },
+                { status: 401 },
+                { status: 401 },
+                { status: 200, body: { ok: true } },
+            ]);
+            const requester = new RefreshableRequester({ fetch: fetchMock });
+            requester.refreshAuth = jest.fn().mockResolvedValue(true);
+            requester.notify = jest.fn();
+
+            const result = await requester._get({
+                url: 'https://example.com/protected',
+            });
+
+            expect(result).toEqual({ ok: true });
+            expect(requester.refreshAuth).toHaveBeenCalledTimes(3);
+            expect(requester.notify).not.toHaveBeenCalled();
+            expect(fetchMock).toHaveBeenCalledTimes(4);
+        });
+
+        it('fires INVALID_AUTH once the refresh budget is exhausted even though every refresh succeeded', async () => {
+            const fetchMock = oauthFetch([
+                { status: 401 },
+                { status: 401 },
                 { status: 401 },
                 { status: 401 },
             ]);
@@ -425,9 +483,12 @@ describe('Requester', () => {
                 requester._get({ url: 'https://example.com/protected' })
             ).rejects.toThrow();
 
-            expect(requester.refreshAuth).toHaveBeenCalledTimes(1);
-            expect(requester.notify).not.toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
-            expect(fetchMock).toHaveBeenCalledTimes(2);
+            expect(requester.refreshAuth).toHaveBeenCalledTimes(3);
+            expect(requester.notify).toHaveBeenCalledWith(
+                requester.DLGT_INVALID_AUTH,
+                expect.objectContaining({ statusCode: 401 })
+            );
+            expect(fetchMock).toHaveBeenCalledTimes(4);
         });
 
         it('resets refreshCount after a successful 2xx so a later 401 can attempt refresh again', async () => {

--- a/packages/core/modules/requester/requester.test.js
+++ b/packages/core/modules/requester/requester.test.js
@@ -292,8 +292,9 @@ describe('Requester', () => {
                 if (!next) throw new Error('unexpected fetch call');
                 return {
                     status: next.status,
-                    headers: { get: () => 'application/json' },
+                    headers: new Map([['Content-Type', 'application/json']]),
                     json: async () => next.body ?? {},
+                    text: async () => JSON.stringify(next.body ?? {}),
                 };
             });
         }
@@ -311,17 +312,46 @@ describe('Requester', () => {
             }
         }
 
-        it('fires INVALID_AUTH when the requester is not refreshable', async () => {
-            const fetchMock = oauthFetch([{ status: 401, body: { error: 'unauthorized' } }]);
-            const requester = new TestRequester({ fetch: fetchMock });
+        it('grants one grace retry on a 401 before firing INVALID_AUTH when the requester is not refreshable', async () => {
+            const fetchMock = oauthFetch([
+                { status: 401, body: { error: 'unauthorized' } },
+                { status: 401, body: { error: 'unauthorized' } },
+            ]);
+            const requester = new TestRequester({
+                fetch: fetchMock,
+                backOff: [0],
+            });
             requester.notify = jest.fn();
 
             await expect(
                 requester._get({ url: 'https://example.com/protected' })
             ).rejects.toThrow();
 
-            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
-            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(requester.notify).toHaveBeenCalledWith(
+                requester.DLGT_INVALID_AUTH,
+                expect.objectContaining({ statusCode: 401 })
+            );
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+
+        it('does NOT fire INVALID_AUTH when the grace retry succeeds', async () => {
+            const fetchMock = oauthFetch([
+                { status: 401, body: { error: 'unauthorized' } },
+                { status: 200, body: { ok: true } },
+            ]);
+            const requester = new TestRequester({
+                fetch: fetchMock,
+                backOff: [0],
+            });
+            requester.notify = jest.fn();
+
+            const result = await requester._get({
+                url: 'https://example.com/protected',
+            });
+
+            expect(result).toEqual({ ok: true });
+            expect(requester.notify).not.toHaveBeenCalled();
+            expect(fetchMock).toHaveBeenCalledTimes(2);
         });
 
         it('does NOT fire INVALID_AUTH when refresh succeeds and retry returns 200', async () => {
@@ -341,8 +371,10 @@ describe('Requester', () => {
             expect(fetchMock).toHaveBeenCalledTimes(2);
         });
 
-        it('does NOT fire INVALID_AUTH from the requester when refresh fails (refreshAuth owns the notify)', async () => {
-            const fetchMock = oauthFetch([{ status: 401 }]);
+        it('fires INVALID_AUTH with diagnostic detail and throws when refresh fails', async () => {
+            const fetchMock = oauthFetch([
+                { status: 401, body: { error: 'unauthorized' } },
+            ]);
             const requester = new RefreshableRequester({ fetch: fetchMock });
             requester.refreshAuth = jest.fn().mockResolvedValue(false);
             requester.notify = jest.fn();
@@ -352,7 +384,10 @@ describe('Requester', () => {
             ).rejects.toThrow();
 
             expect(requester.refreshAuth).toHaveBeenCalledTimes(1);
-            expect(requester.notify).not.toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+            expect(requester.notify).toHaveBeenCalledWith(
+                requester.DLGT_INVALID_AUTH,
+                expect.objectContaining({ statusCode: 401 })
+            );
             expect(fetchMock).toHaveBeenCalledTimes(1);
         });
 

--- a/packages/core/modules/requester/requester.test.js
+++ b/packages/core/modules/requester/requester.test.js
@@ -336,6 +336,28 @@ describe('Requester', () => {
             expect(fetchMock).toHaveBeenCalledTimes(4);
         });
 
+        it('caps grace retries at the backOff array length even when MAX_AUTH_RETRIES allows more', async () => {
+            const fetchMock = oauthFetch([
+                { status: 401, body: { error: 'unauthorized' } },
+                { status: 401, body: { error: 'unauthorized' } },
+            ]);
+            const requester = new TestRequester({
+                fetch: fetchMock,
+                backOff: [0],
+            });
+            requester.notify = jest.fn();
+
+            await expect(
+                requester._get({ url: 'https://example.com/protected' })
+            ).rejects.toThrow();
+
+            expect(requester.notify).toHaveBeenCalledWith(
+                requester.DLGT_INVALID_AUTH,
+                expect.objectContaining({ statusCode: 401 })
+            );
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+
         it('does NOT fire INVALID_AUTH when a later grace retry succeeds', async () => {
             const fetchMock = oauthFetch([
                 { status: 401, body: { error: 'unauthorized' } },

--- a/packages/core/modules/requester/requester.test.js
+++ b/packages/core/modules/requester/requester.test.js
@@ -354,6 +354,27 @@ describe('Requester', () => {
             expect(fetchMock).toHaveBeenCalledTimes(2);
         });
 
+        it('still grants the 401 grace retry after an earlier 429 already consumed a backoff attempt', async () => {
+            const fetchMock = oauthFetch([
+                { status: 429 },
+                { status: 401, body: { error: 'unauthorized' } },
+                { status: 200, body: { ok: true } },
+            ]);
+            const requester = new TestRequester({
+                fetch: fetchMock,
+                backOff: [0, 0],
+            });
+            requester.notify = jest.fn();
+
+            const result = await requester._get({
+                url: 'https://example.com/protected',
+            });
+
+            expect(result).toEqual({ ok: true });
+            expect(requester.notify).not.toHaveBeenCalled();
+            expect(fetchMock).toHaveBeenCalledTimes(3);
+        });
+
         it('does NOT fire INVALID_AUTH when refresh succeeds and retry returns 200', async () => {
             const fetchMock = oauthFetch([
                 { status: 401 },

--- a/packages/core/modules/tests/module-mark-credentials-invalid.test.js
+++ b/packages/core/modules/tests/module-mark-credentials-invalid.test.js
@@ -83,4 +83,54 @@ describe('Module.markCredentialsInvalid delegate propagation', () => {
             })
         );
     });
+
+    it('includes diagnostic detail in the CREDENTIAL_INVALIDATED payload when provided', async () => {
+        const mockDelegate = {
+            receiveNotification: jest.fn().mockResolvedValue(undefined),
+        };
+        module.delegate = mockDelegate;
+
+        await module.markCredentialsInvalid({
+            message: 'Unauthorized',
+            statusCode: 401,
+        });
+
+        expect(mockDelegate.receiveNotification).toHaveBeenCalledWith(
+            module,
+            'CREDENTIAL_INVALIDATED',
+            expect.objectContaining({
+                credentialId: 'cred-1',
+                moduleName: 'testmodule',
+                reason: 'Unauthorized',
+                statusCode: 401,
+            })
+        );
+    });
+
+    it('omits reason/statusCode from the payload when no diagnostic detail is given', async () => {
+        const mockDelegate = {
+            receiveNotification: jest.fn().mockResolvedValue(undefined),
+        };
+        module.delegate = mockDelegate;
+
+        await module.markCredentialsInvalid();
+
+        const [, , payload] = mockDelegate.receiveNotification.mock.calls[0];
+        expect(payload).not.toHaveProperty('reason');
+        expect(payload).not.toHaveProperty('statusCode');
+    });
+
+    it('forwards the diagnostic object from receiveNotification through to markCredentialsInvalid', async () => {
+        module.api = { DLGT_INVALID_AUTH: 'INVALID_AUTH' };
+        const diagnosticInfo = { message: 'Unauthorized', statusCode: 401 };
+        jest.spyOn(module, 'markCredentialsInvalid').mockResolvedValue(
+            undefined
+        );
+
+        await module.receiveNotification({}, 'INVALID_AUTH', diagnosticInfo);
+
+        expect(module.markCredentialsInvalid).toHaveBeenCalledWith(
+            diagnosticInfo
+        );
+    });
 });


### PR DESCRIPTION
## Summary
- `Requester._request` invalidated a non-refreshable requester's credentials (`ApiKeyRequester`, `BasicAuthRequester`) on the very first 401. It now retries up to 3 times (escalating delay via `backOff[0]`, `backOff[1]`, `backOff[2]`) before concluding the credential is actually invalid — a single 401 isn't proof of a bad credential, it can be a transient edge/gateway hiccup.
- OAuth2/refreshable requesters get the same treatment: up to 3 refresh+retry cycles (as long as `refreshAuth()` keeps succeeding) instead of just 1. Previously a second 401 after a successful refresh fell through silently with no delegate notification at all — that gap is now closed: once the retry budget is exhausted, `INVALID_AUTH` fires with diagnostic detail either way.
- Both the retry-budget-exhausted and refresh-failed paths attach the underlying `FetchError` (status code + message) to the `INVALID_AUTH` delegate notification instead of firing it bare. `Module.markCredentialsInvalid` and `IntegrationBase.receiveNotification` forward that detail into their log lines, so a stuck `ERROR` integration in production now has real evidence (status code, upstream message) instead of just "invalid credentials."
- The retry budget for non-refreshable requesters is tracked with its own counter (`authGraceRetryCount`), independent of the general backoff-attempt counter — an earlier 429/5xx retry no longer eats into the 401 retry budget (caught in review).
- The non-refreshable grace retry is also bounded by `backOff.length`, not just `MAX_AUTH_RETRIES` — a custom `backOff` array shorter than 3 entries previously let the retry loop read past the array end, producing a `NaN` delay (caught in review).
- Discovered while investigating a transient invalid-credentials-mid-sync flake on a live integration — a real 401 blip was tripping the same code path that's meant for actually-revoked credentials, with no diagnostic trail to tell the two apart after the fact.

## Test plan
- [x] `packages/core/modules/requester/requester.test.js` — grace-retry/refresh-retry budget (fires only once all 3 retries are exhausted, escalating backoff delay per retry, doesn't fire when a later retry succeeds), diagnostic detail on both paths, the 429-then-401 regression, and the short-`backOff`-array bounds regression the reviewers flagged
- [x] `packages/core/modules/requester/oauth-2.test.js` — updated the one pre-existing test that locked in the old single-retry limit to match the new 3-retry, budget-exhausted-then-invalidate behavior
- [x] `packages/core/modules/tests/module-mark-credentials-invalid.test.js` — diagnostic detail is included/omitted correctly in the `CREDENTIAL_INVALIDATED` payload; `receiveNotification` forwards the diagnostic object through
- [x] `packages/core/integrations/tests/integration-base-receive-notification.test.js` — invalid-credentials log line includes status/reason when present, plain message when not
- [x] Full `packages/core` suite: 14 failed suites / 56 failed tests both before and after this PR's commits — zero regressions (all 14 remaining failures are pre-existing/unrelated, e.g. AWS SQS endpoint config in webhook integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.623.b39b42d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/admin-scripts@2.0.0--canary.623.b39b42d.0
  npm install @friggframework/core@2.0.0--canary.623.b39b42d.0
  npm install @friggframework/devtools@2.0.0--canary.623.b39b42d.0
  npm install @friggframework/eslint-config@2.0.0--canary.623.b39b42d.0
  npm install @friggframework/prettier-config@2.0.0--canary.623.b39b42d.0
  npm install @friggframework/schemas@2.0.0--canary.623.b39b42d.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.623.b39b42d.0
  npm install @friggframework/test@2.0.0--canary.623.b39b42d.0
  npm install @friggframework/ui@2.0.0--canary.623.b39b42d.0
  # or 
  yarn add @friggframework/admin-scripts@2.0.0--canary.623.b39b42d.0
  yarn add @friggframework/core@2.0.0--canary.623.b39b42d.0
  yarn add @friggframework/devtools@2.0.0--canary.623.b39b42d.0
  yarn add @friggframework/eslint-config@2.0.0--canary.623.b39b42d.0
  yarn add @friggframework/prettier-config@2.0.0--canary.623.b39b42d.0
  yarn add @friggframework/schemas@2.0.0--canary.623.b39b42d.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.623.b39b42d.0
  yarn add @friggframework/test@2.0.0--canary.623.b39b42d.0
  yarn add @friggframework/ui@2.0.0--canary.623.b39b42d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->