### PR TITLE
feat: Extend support for SSM parameter offload + per-function env scoping (Lambda 4KB env limit)

### DIFF
--- a/docs/architecture-decisions/027-ssm-parameter-offload-and-env-scoping.md
+++ b/docs/architecture-decisions/027-ssm-parameter-offload-and-env-scoping.md
@@ -74,11 +74,13 @@ the runtime at cold start; its value never enters the Lambda environment.
 - **Runtime — handler fallback** (`parametersToEnv()`, invoked from the
   `createHandler` bootstrap next to `secretsToEnv()`): a belt-and-suspenders
   loader for values read lazily (request-time) and a TTL refresh path
-  (default 300s, `FRIGG_SSM_CACHE_TTL`, `0` = cache forever). Precedence is
-  **real env > INIT preload > Secrets Manager (`secretsToEnv`) > SSM**: it
-  never touches a key already in `process.env` (so the preload's values and
-  console overrides win), and on TTL refresh only updates keys it itself set.
-  Missing declared parameters fail fast with an error naming the keys.
+  (default 300s, `FRIGG_SSM_CACHE_TTL`, `0` = cache forever). Precedence on a
+  key collision is **real env > Secrets Manager (`secretsToEnv`) > SSM**: the
+  SSM loaders (INIT preload and handler) never touch a key already in
+  `process.env` (so real env and console overrides win), while `secretsToEnv`
+  runs first in the handler and overwrites, so it wins over SSM; on TTL refresh
+  the loader only updates keys it itself set. Missing declared parameters fail
+  fast with an error naming the keys.
 - **Provisioning** (`frigg ssm push`, also run automatically by
   `frigg deploy` before the serverless deploy): reads offloaded values from
   the CLI process environment (CI secrets or `.env`), validates them

--- a/docs/architecture-decisions/027-ssm-parameter-offload-and-env-scoping.md
+++ b/docs/architecture-decisions/027-ssm-parameter-offload-and-env-scoping.md
@@ -1,0 +1,208 @@
+# ADR-027: SSM Parameter Offload and Per-Function Environment Scoping
+
+**Status**: Accepted
+**Date**: 2026-07-10
+**Deciders**: Daniel Klotz
+
+## Context
+
+AWS Lambda enforces a hard 4096-byte cap on the JSON-serialized environment
+variables of a function. Frigg composes a single app-wide environment block
+(`provider.environment`) and broadcasts it to every function in the stack:
+each integration's OAuth credentials and API keys, every per-integration SQS
+queue URL, migration and scheduler variables, and any observability config.
+A multi-integration app therefore sits near the ceiling on *every* Lambda.
+Measured on a production app (~25 functions): base functions 3817/4096 bytes,
+`dbMigrationRouter` 3881, `adminScriptRouter` 4009. Adding three
+`OTEL_EXPORTER_OTLP_*` variables (~243 bytes) pushed the heaviest functions
+over the limit, and because the limit is enforced per function inside one
+CloudFormation update, a single over-budget function fails and rolls back the
+entire deploy.
+
+Two aggravating facts shaped the solution:
+
+1. Deploy-time indirection does not help. A `${ssm:...}` reference is
+   resolved at package time and the *value* still lands in the function's
+   environment — the 4KB footprint is unchanged.
+2. `ssm.enable` was documented (in `docs/reference/ssm-configuration.md`) as
+   attaching the AWS Parameters and Secrets Lambda Extension, scoping IAM to
+   `/${service}/${stage}/*`, and exporting `SSM_PARAMETER_PREFIX` — but none
+   of that was ever implemented. The real `SsmBuilder` only granted broad
+   read IAM (`parameter/*`) and `ssm.parameters` was schema-validated but
+   never consumed. `secretsManager.enable` is likewise a dead flag.
+
+The root cause has two independent axes: **payload** (large static secret
+values on every function) and **count** (framework-generated variables such
+as `<NAME>_QUEUE_URL` broadcast to functions that never use them, growing
+O(N) with integration count).
+
+## Decision
+
+Attack both axes with two composable, individually opt-in mechanisms.
+
+### 1. SSM runtime-fetch offload (payload axis)
+
+A variable marked for offload lives in SSM Parameter Store and is fetched by
+the runtime at cold start; its value never enters the Lambda environment.
+
+- **API**: `environment: { MY_SECRET: 'ssm' }` marks a variable for offload;
+  `ssm.parameters: { MY_SECRET: { type: 'SecureString' } }` is the typed,
+  secret-aware form. The union of both is the offload set. Framework-managed
+  keys (`DATABASE_*`, `KMS_KEY_ARN`, `STAGE`, `FRIGG_*`, `SECRET_ARN`, …) are
+  blocklisted from offload because the migration handlers bypass the loader
+  and read them directly.
+- **Build time** (`SsmBuilder`, `environment-builder`): offloaded keys are
+  excluded from `provider.environment`; only two small pointers are
+  broadcast — `SSM_PARAMETER_PREFIX` (default
+  `/frigg/${service}/${stage}`) and `FRIGG_SSM_OFFLOADED_KEYS` (the declared
+  key list, enabling fail-fast). A prefix-scoped read statement is added to
+  the Lambda role. In local mode the same keys fall back to plain
+  `${env:KEY, ''}` references so `frigg start` + `.env` is unaffected.
+- **Runtime** (`parametersToEnv()` in `@friggframework/core`, invoked from
+  the `createHandler` bootstrap next to `secretsToEnv()`): fetches the
+  declared keys by explicit name (`GetParameters`, batched by 10,
+  `WithDecryption: true`), populates `process.env`, and caches per container
+  with a configurable TTL (default 300s, `FRIGG_SSM_CACHE_TTL`, `0` = cache
+  forever). Precedence is **real env > Secrets Manager (`secretsToEnv`) >
+  SSM**: the loader never touches a key that already exists in
+  `process.env`, and on TTL refresh only updates keys it itself set. A
+  console-set env var on a single function therefore overrides SSM instantly
+  — the established debugging workflow keeps working. Missing declared
+  parameters fail the cold start with an error naming the missing keys.
+- **Provisioning** (`frigg ssm push`, also run automatically by
+  `frigg deploy` before the serverless deploy): reads offloaded values from
+  the CLI process environment (CI secrets or `.env`), validates them
+  (non-empty, ≤4KB), and writes them via `PutParameter` with
+  `Overwrite: true`. Running before the code deploy guarantees parameters
+  exist before the first cold start of new code.
+- **Encryption**: SecureString parameters default to the AWS-managed
+  `aws/ssm` key. An optional `ssm.kmsKeyArn` selects a customer-managed key,
+  in which case the Lambda role is granted `kms:Decrypt` on that key.
+- **VPC**: when the offload set is non-empty and VPC is enabled, an SSM
+  interface endpoint (`FriggSSMVPCEndpoint`) is created so private-subnet
+  Lambdas can reach Parameter Store.
+
+Everything above activates only when the offload set is non-empty. An app
+with `ssm.enable: true` and no offload markers keeps today's exact behavior
+(broad `parameter/*` read IAM, no new env vars, no loader activity, no VPC
+endpoint). The legacy broad read grant is retained even with offload active
+unless `ssm.restrictIamToPrefix: true` is set.
+
+### 2. Per-function environment scoping (count axis)
+
+Behind `lambda.scopedEnvironment: true` (default `false`), framework builders
+emit function-scoped environment maps (`result.functionEnvironments`) instead
+of pushing everything into the global block. The orchestrator merges these
+after all functions exist; unknown target names are a hard build error, and
+a key a builder already set directly on a function is never clobbered.
+
+Verified consumer sets (the reason this is not a naive "each integration's
+functions only" split):
+
+- `<NAME>_QUEUE_URL` → `auth` (the shared router dispatches integration
+  actions synchronously) ∪ `adminScriptExecutor` and `adminScriptRouter`
+  (admin scripts instantiate arbitrary integrations, including sync
+  in-process execution) ∪ the owning integration's full function set
+  (router, webhook, every extension handler, queue worker).
+- `SCHEDULER_ROLE_ARN` / `SCHEDULE_GROUP_NAME` → the same union **except**
+  `adminScriptRouter`, which keeps its already-scoped admin-scheduler role
+  value.
+- Migration vars (`S3_BUCKET_NAME`, `MIGRATION_STATUS_BUCKET`,
+  `DB_MIGRATION_QUEUE_URL`) → `dbMigrationRouter` / `dbMigrationWorker` only.
+- `ADMIN_SCRIPT_QUEUE_URL` → `adminScriptRouter` / `adminScriptExecutor`.
+- Stays global: `STAGE`, `FRIGG_*`, `KMS_KEY_ARN`, `DATABASE_*`, `DB_TYPE`
+  (tiny values with broad or bootstrap-time consumers).
+
+Scoping is skipped entirely in local mode: the serverless-plugin injects
+LocalStack queue URLs at provider level only, and function-level values would
+shadow them.
+
+## Consequences
+
+### Positive
+
+- Offloading an app's secrets/config removes their full byte weight from
+  every function. On the measured app, the worst function drops from 4009B
+  to ~1,640B with offload alone; base functions that also shed scoped
+  framework vars reach ~500–700B.
+- Adding integration N+1 no longer adds queue-URL bytes to unrelated
+  functions (scoping), and adding observability/config vars no longer risks
+  a stack-wide rollback (offload).
+- Parameter Store adds version history and CloudTrail audit for config
+  changes, and one `put-parameter` updates all functions (within the cache
+  TTL) without a redeploy.
+- Both features are inert until opted into; no existing app changes behavior
+  on upgrade.
+
+### Negative
+
+- One extra API call per container cold start (and per TTL window), plus an
+  SSM interface endpoint cost (~$7–22/month) for VPC deployments with
+  offload.
+- Warm containers hold values fetched at cold start; after an out-of-band
+  parameter edit, containers converge only within the cache TTL. The
+  Lambda console no longer shows offloaded values (they are in Parameter
+  Store instead).
+- A missing parameter fails cold starts app-wide (deliberate fail-fast);
+  the auto-push in `frigg deploy` makes this practically unreachable in the
+  normal flow.
+- If a CloudFormation deploy fails *after* parameters were pushed, the
+  rolled-back (old) code reads the new parameter values. Accepted risk;
+  parameter version history enables manual revert. Concurrent deploys to
+  one stage are last-writer-wins on parameters.
+- Scoping can break app code that reads *another* integration's queue URL
+  from its own env — the reason it ships opt-in. A `dependsOnQueues`
+  declaration is the designed escape hatch if a real app needs
+  cross-integration enqueue (not implemented until needed).
+
+### Neutral
+
+- The deployment IAM policies gain `ssm:PutParameter` / `ssm:DeleteParameter`
+  / `ssm:AddTagsToResource`, still scoped to `*frigg*` parameter names; the
+  default prefix `/frigg/${service}/${stage}` was chosen precisely to stay
+  inside that scope. Overriding `ssm.parameterPrefix` to a path without
+  "frigg" requires widening those policies manually.
+- The management UI's parameter utilities use a two-segment
+  `/frigg/${environment}` namespace that does not intersect with this
+  feature's three-segment prefix. They remain separate namespaces; unifying
+  them is follow-up work.
+- `docs/reference/ssm-configuration.md` is rewritten to describe the
+  implemented behavior (the extension-layer design it previously described
+  was never built and is explicitly rejected below).
+
+## Alternatives Considered
+
+- **Deploy-time `${ssm:...}` resolution**: rejected — values are baked into
+  the function environment at package time, so the 4KB footprint is
+  unchanged.
+- **AWS Parameters and Secrets Lambda Extension** (as the old docs
+  promised): rejected in favor of `@aws-sdk/client-ssm`. The extension layer
+  ARN is region-specific (per-region account IDs), it cannot batch-read by
+  name list the way `GetParameters` can, and per-container memoization in
+  the loader already provides the extension's caching benefit.
+- **`AWS::SSM::Parameter` CloudFormation resources for provisioning**:
+  rejected — CloudFormation does not support creating `SecureString`
+  parameters, and secret values would leak into S3-stored templates.
+- **Secrets Manager instead of Parameter Store**: the `SECRET_ARN` +
+  `secretsToEnv()` path already exists and is retained (it runs first and
+  wins over SSM on key collisions). Parameter Store was chosen for offload
+  because standard-tier parameters are free, IAM/path scoping is simple,
+  and no rotation machinery is needed for static config.
+- **Per-function scoping as the only fix (no SSM)**: rejected as
+  insufficient — `auth` and the admin-script functions must retain all queue
+  URLs plus app secrets by design, leaving them near the ceiling; only
+  removing secret payloads from the env entirely gives durable headroom.
+- **Default-on scoping**: rejected for safety — a variable missing from a
+  function that needs it is a runtime failure, worse than the deploy-time
+  failure being fixed. Opt-in with a composer audit path first.
+
+## Related
+
+- [ADR-005](./005-admin-script-runner.md) — admin-script functions are why
+  queue URLs cannot be scoped to owning integrations only.
+- `docs/reference/ssm-configuration.md` — user-facing reference for the
+  offload feature.
+- `packages/devtools/infrastructure/domains/parameters/` — `SsmBuilder`,
+  offload utilities.
+- `packages/core/core/parameters-to-env.js` — runtime loader.
+- `packages/devtools/frigg-cli/ssm-command/` — provisioning CLI.

--- a/docs/architecture-decisions/027-ssm-parameter-offload-and-env-scoping.md
+++ b/docs/architecture-decisions/027-ssm-parameter-offload-and-env-scoping.md
@@ -58,17 +58,27 @@ the runtime at cold start; its value never enters the Lambda environment.
   key list, enabling fail-fast). A prefix-scoped read statement is added to
   the Lambda role. In local mode the same keys fall back to plain
   `${env:KEY, ''}` references so `frigg start` + `.env` is unaffected.
-- **Runtime** (`parametersToEnv()` in `@friggframework/core`, invoked from
-  the `createHandler` bootstrap next to `secretsToEnv()`): fetches the
-  declared keys by explicit name (`GetParameters`, batched by 10,
-  `WithDecryption: true`), populates `process.env`, and caches per container
-  with a configurable TTL (default 300s, `FRIGG_SSM_CACHE_TTL`, `0` = cache
-  forever). Precedence is **real env > Secrets Manager (`secretsToEnv`) >
-  SSM**: the loader never touches a key that already exists in
-  `process.env`, and on TTL refresh only updates keys it itself set. A
-  console-set env var on a single function therefore overrides SSM instantly
-  — the established debugging workflow keeps working. Missing declared
-  parameters fail the cold start with an error naming the missing keys.
+- **Runtime — INIT phase** (`ssm-preload.mjs` in `@friggframework/core`,
+  loaded via `NODE_OPTIONS=--import`): fetches the declared keys and populates
+  `process.env` **before the Lambda handler and any api-module is required**.
+  This is required for correctness: api-modules capture their OAuth client
+  credentials in a top-level `const Definition = { env: { client_secret:
+  process.env.X } }` evaluated at module-require (cold-start INIT). A loader
+  that runs *inside* the handler is too late — the module has already
+  snapshotted `undefined`, and the OAuth token exchange fails with 401. The
+  `--import` ESM preload's top-level await completes before the entry module,
+  so the fetch lands first; a fetch failure rejects the preload and fails
+  INIT loudly (fail-fast). SsmBuilder sets `NODE_OPTIONS` (appended to any
+  app value) only when the offload set is non-empty. The preload ships in
+  core, so it is packaged into every `skipEsbuild` handler at a stable path.
+- **Runtime — handler fallback** (`parametersToEnv()`, invoked from the
+  `createHandler` bootstrap next to `secretsToEnv()`): a belt-and-suspenders
+  loader for values read lazily (request-time) and a TTL refresh path
+  (default 300s, `FRIGG_SSM_CACHE_TTL`, `0` = cache forever). Precedence is
+  **real env > INIT preload > Secrets Manager (`secretsToEnv`) > SSM**: it
+  never touches a key already in `process.env` (so the preload's values and
+  console overrides win), and on TTL refresh only updates keys it itself set.
+  Missing declared parameters fail fast with an error naming the keys.
 - **Provisioning** (`frigg ssm push`, also run automatically by
   `frigg deploy` before the serverless deploy): reads offloaded values from
   the CLI process environment (CI secrets or `.env`), validates them

--- a/docs/architecture-decisions/027-ssm-parameter-offload-and-env-scoping.md
+++ b/docs/architecture-decisions/027-ssm-parameter-offload-and-env-scoping.md
@@ -68,9 +68,10 @@ the runtime at cold start; its value never enters the Lambda environment.
   snapshotted `undefined`, and the OAuth token exchange fails with 401. The
   `--import` ESM preload's top-level await completes before the entry module,
   so the fetch lands first; a fetch failure rejects the preload and fails
-  INIT loudly (fail-fast). SsmBuilder sets `NODE_OPTIONS` (appended to any
-  app value) only when the offload set is non-empty. The preload ships in
-  core, so it is packaged into every `skipEsbuild` handler at a stable path.
+  INIT loudly (fail-fast). The composer sets `NODE_OPTIONS` on `skipEsbuild`
+  functions when the offload set is non-empty, appending to (never clobbering)
+  any NODE_OPTIONS the app or a builder already set. The preload ships in core,
+  so it is packaged into every `skipEsbuild` handler at a stable path.
 - **Runtime — handler fallback** (`parametersToEnv()`, invoked from the
   `createHandler` bootstrap next to `secretsToEnv()`): a belt-and-suspenders
   loader for values read lazily (request-time) and a TTL refresh path
@@ -80,7 +81,11 @@ the runtime at cold start; its value never enters the Lambda environment.
   `process.env` (so real env and console overrides win), while `secretsToEnv`
   runs first in the handler and overwrites, so it wins over SSM; on TTL refresh
   the loader only updates keys it itself set. Missing declared parameters fail
-  fast with an error naming the keys.
+  fast with an error naming the keys. This ordering assumes offloaded keys and
+  `SECRET_ARN` bundle keys are **disjoint**; a key in both has undefined
+  precedence (module-load reads see SSM, the handler sees Secrets Manager, a TTL
+  refresh flips back to SSM). It stays disjoint in practice because the
+  framework secrets in the bundle are on the offload blocklist.
 - **Provisioning** (`frigg ssm push`, also run automatically by
   `frigg deploy` before the serverless deploy): reads offloaded values from
   the CLI process environment (CI secrets or `.env`), validates them

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -43,6 +43,7 @@ An ADR documents a significant architectural decision made in the project, inclu
 | [024](./024-global-entities.md) | Global Entities | Proposed | 2024-12-18 |
 | [025](./025-agent-harness.md) | Agent Harness | Proposed | 2026-06-09 |
 | [026](./026-evals.md) | Evals | Proposed | 2026-06-09 |
+| [027](./027-ssm-parameter-offload-and-env-scoping.md) | SSM Parameter Offload and Per-Function Environment Scoping | Accepted | 2026-07-10 |
 
 ## Conventions
 

--- a/docs/reference/ssm-configuration.md
+++ b/docs/reference/ssm-configuration.md
@@ -80,24 +80,42 @@ The Lambda execution role receives read access scoped to the prefix (the
 pre-existing broad `parameter/*` grant from `ssm.enable` is kept for
 backward compatibility; set `ssm.restrictIamToPrefix: true` to drop it).
 
-### Runtime
+### Runtime — INIT phase (primary)
 
-On a container's first invocation, the Frigg handler bootstrap fetches the
-declared parameters (batched `GetParameters` with decryption) and writes them
-into `process.env` before your code runs. The result is cached per container
-with a TTL (default 300 seconds, configurable via `FRIGG_SSM_CACHE_TTL`;
-`0` caches for the container lifetime).
+Offloaded values are fetched and written into `process.env` during Lambda
+**INIT**, before your handler and any API module is loaded. This is required
+for credentials: API modules capture their OAuth client secret in a top-level
+`const Definition = { env: { client_secret: process.env.X } }` evaluated at
+module-require — a handler-time fetch would be too late and the value would be
+`undefined`. Frigg sets `NODE_OPTIONS=--import` on each function to load
+`ssm-preload.mjs` (shipped in `@friggframework/core`), whose top-level `await`
+completes before the entry module. A fetch failure rejects the preload and
+fails INIT loudly (fail-fast), naming the missing key.
+
+The preload is attached only to Frigg-generated (`skipEsbuild`) handlers, which
+package the preload file. **Adopter custom functions that are esbuild-bundled
+do not receive it** — they fall back to the handler-time loader below, which is
+too late for module-load credential reads. A custom function that needs an
+offloaded credential at module-load must be `skipEsbuild`.
+
+### Runtime — handler fallback
+
+For values read lazily (request time) and for TTL refresh, a loader also runs
+in the `createHandler` bootstrap. It never touches a key already in
+`process.env` (so the preload's values and console overrides win), and
+refreshes the preloaded keys per container on a TTL (default 300 seconds,
+`FRIGG_SSM_CACHE_TTL`; `0` caches for the container lifetime).
 
 **Precedence** (highest wins):
 
 1. Real Lambda environment variables — a value set directly on a function's
-   configuration always wins, and the loader never touches it.
-2. Secrets Manager values injected via `SECRET_ARN` (`secretsToEnv`).
-3. SSM parameters.
+   configuration always wins, and the loaders never touch it.
+2. INIT preload / handler loader SSM values.
+3. Secrets Manager values injected via `SECRET_ARN` (`secretsToEnv`).
 
-If a declared parameter is missing from Parameter Store, the cold start
-fails immediately with an error naming the missing key — a deliberate
-fail-fast instead of `undefined` surfacing somewhere downstream.
+If a declared parameter is missing from Parameter Store, INIT fails
+immediately with an error naming the missing key — a deliberate fail-fast
+instead of `undefined` surfacing somewhere downstream.
 
 ### What cannot be offloaded
 

--- a/docs/reference/ssm-configuration.md
+++ b/docs/reference/ssm-configuration.md
@@ -2,337 +2,207 @@
 
 ## Overview
 
-Frigg provides **automatic SSM Parameter Store integration** for secure configuration management. When enabled, it configures AWS Systems Manager Parameter Store access for your Lambda functions, allowing you to store and retrieve configuration values, secrets, and other sensitive data.
+Frigg integrates with AWS Systems Manager Parameter Store in two ways:
 
-## Quick Start
+1. **Read access** (`ssm.enable`): grants your Lambda functions IAM
+   permission to read parameters, so application code can fetch its own
+   configuration from Parameter Store.
+2. **Environment variable offload** (`environment: { KEY: 'ssm' }`): Frigg
+   stores the variable's value in Parameter Store and fetches it at runtime,
+   so the value never enters the Lambda environment. This is the built-in
+   answer to AWS Lambda's hard **4KB environment-variable limit** — offloaded
+   variables cost ~0 bytes of Lambda env instead of their full key+value
+   size on *every* function.
 
-Enable SSM Parameter Store with a single flag:
+Your application code does not change either way: offloaded variables are
+populated into `process.env` before your handler runs.
+
+See [ADR-027](../architecture-decisions/027-ssm-parameter-offload-and-env-scoping.md)
+for the full design rationale.
+
+## Quick Start: Offloading Variables
 
 ```javascript
+// backend/index.js
 const appDefinition = {
     name: 'my-frigg-app',
-    integrations: [
-        // your integrations...
-    ],
+    integrations: [/* ... */],
     ssm: {
-        enable: true  // Enables SSM Parameter Store access
-    }
-}
-
-module.exports = appDefinition;
-```
-
-## What Gets Configured Automatically
-
-When `ssm.enable` is `true`, Frigg automatically:
-
-1. **Adds Lambda Extension Layer**: Includes AWS Parameters and Secrets Lambda Extension for optimized parameter retrieval
-2. **Grants SSM Permissions**: Adds parameter read permissions scoped to your application
-3. **Sets Environment Variables**: Configures parameter prefix for organized parameter storage
-4. **VPC Integration**: Creates SSM VPC Endpoint when VPC is enabled for secure access
-
-### Generated Infrastructure
-
-The framework generates the following serverless configuration:
-
-```yaml
-# Lambda Layer (for performance optimization)
-provider:
-  layers:
-    - arn:aws:lambda:${self:provider.region}:177933569100:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11
-
-# IAM Permissions (scoped to your application)
-provider:
-  iamRoleStatements:
-    - Effect: Allow
-      Action:
-        - ssm:GetParameter
-        - ssm:GetParameters  
-        - ssm:GetParametersByPath
-      Resource:
-        - arn:aws:ssm:${self:provider.region}:*:parameter/${self:service}/${self:provider.stage}/*
-
-# Environment Variables
-provider:
-  environment:
-    SSM_PARAMETER_PREFIX: /${self:service}/${self:provider.stage}
-```
-
-## Using SSM Parameters in Your Code
-
-### Accessing Parameters via Environment Variable
-
-The parameter prefix is available in your Lambda functions:
-
-```javascript
-const parameterPrefix = process.env.SSM_PARAMETER_PREFIX;
-// Example: "/my-frigg-app/prod"
-
-// Parameter naming convention:
-// /${service}/${stage}/parameter-name
-// Example: "/my-frigg-app/prod/database-url"
-```
-
-### Using AWS Parameters and Secrets Extension
-
-The Lambda extension provides optimized parameter retrieval:
-
-```javascript
-// Using HTTP calls to the extension (recommended)
-const http = require('http');
-
-async function getParameter(parameterName) {
-    const options = {
-        hostname: 'localhost',
-        port: 2773,
-        path: `/systemsmanager/parameters/get?name=${parameterName}`,
-        method: 'GET',
-        headers: {
-            'X-Aws-Parameters-Secrets-Token': process.env.AWS_SESSION_TOKEN
-        }
-    };
-    
-    return new Promise((resolve, reject) => {
-        const req = http.request(options, (res) => {
-            let data = '';
-            res.on('data', (chunk) => data += chunk);
-            res.on('end', () => {
-                const response = JSON.parse(data);
-                resolve(response.Parameter.Value);
-            });
-        });
-        req.on('error', reject);
-        req.end();
-    });
-}
-
-// Usage
-const databaseUrl = await getParameter(`${process.env.SSM_PARAMETER_PREFIX}/database-url`);
-```
-
-### Using AWS SDK (Alternative)
-
-```javascript
-const { SSMClient, GetParameterCommand, GetParametersByPathCommand } = require('@aws-sdk/client-ssm');
-
-const ssmClient = new SSMClient({ region: process.env.AWS_REGION });
-
-// Get single parameter
-async function getParameter(name) {
-    const command = new GetParameterCommand({
-        Name: `${process.env.SSM_PARAMETER_PREFIX}/${name}`,
-        WithDecryption: true
-    });
-    
-    const response = await ssmClient.send(command);
-    return response.Parameter.Value;
-}
-
-// Get multiple parameters by path
-async function getAllParameters() {
-    const command = new GetParametersByPathCommand({
-        Path: process.env.SSM_PARAMETER_PREFIX,
-        Recursive: true,
-        WithDecryption: true
-    });
-    
-    const response = await ssmClient.send(command);
-    return response.Parameters;
-}
-```
-
-## Parameter Organization
-
-### Recommended Parameter Structure
-
-Frigg automatically creates a parameter hierarchy for your application:
-
-```
-/${service-name}/${stage}/
-├── database-url          # Database connection strings
-├── api-keys/
-│   ├── salesforce-key   # Integration API keys
-│   ├── hubspot-key
-│   └── slack-token
-├── features/
-│   ├── enable-webhooks  # Feature flags
-│   └── rate-limit
-└── secrets/
-    ├── jwt-secret       # Application secrets
-    └── webhook-secret
-```
-
-### Parameter Types
-
-```javascript
-// String parameters (default)
-await putParameter('/my-app/prod/database-url', 'mongodb://...');
-
-// SecureString parameters (encrypted)
-await putParameter('/my-app/prod/secrets/api-key', 'secret-value', 'SecureString');
-
-// StringList parameters
-await putParameter('/my-app/prod/allowed-domains', 'domain1.com,domain2.com', 'StringList');
-```
-
-## VPC Integration
-
-### SSM with VPC Enabled
-
-When both SSM and VPC are enabled, Frigg optimizes for security and performance:
-
-```javascript
-const appDefinition = {
-    ssm: { enable: true },
-    vpc: { enable: true },
-    integrations: [/* your integrations */]
+        enable: true,
+    },
+    environment: {
+        STAGE_URL: true,                    // stays in the Lambda environment
+        HUBSPOT_CLIENT_SECRET: 'ssm',       // offloaded to Parameter Store
+        OTEL_EXPORTER_OTLP_HEADERS: 'ssm',  // offloaded to Parameter Store
+    },
 };
 ```
 
-This configuration automatically:
-- **Creates SSM VPC Endpoint** (~$22/month) for secure parameter access
-- **Avoids NAT Gateway costs** for parameter operations  
-- **Reduces latency** by keeping SSM traffic within your VPC
-- **Improves security** by avoiding internet routing for parameter retrieval
+For secrets, use the typed form so the parameter is stored encrypted
+(`SecureString`):
 
-### Cost Considerations
-
-| Configuration | Monthly Cost | Security | Performance |
-|---------------|--------------|----------|-------------|
-| SSM only (no VPC) | $0 | Medium | Good |
-| SSM + VPC (no endpoints) | ~$45 | High | Good |
-| SSM + VPC + Endpoints | ~$67 | Very High | Excellent |
-
-## Configuration Options
-
-### Basic SSM (Default)
-```javascript
-ssm: {
-    enable: true  // Uses default configuration
-}
-```
-
-### Custom Parameter Prefix
 ```javascript
 ssm: {
     enable: true,
-    parameterPrefix: '/custom-prefix'  // Override default prefix
-}
+    parameters: {
+        HUBSPOT_CLIENT_SECRET: {
+            type: 'SecureString',
+            description: 'HubSpot OAuth app client secret',
+        },
+    },
+},
 ```
 
-### Environment-Specific Configuration
-```javascript
-ssm: {
-    enable: process.env.STAGE !== 'local',  // Disable for local development
-    parameterPrefix: `/${appName}/${process.env.STAGE}`
-}
+The offload set is the union of `environment` keys valued `'ssm'` and the
+keys of `ssm.parameters`. Keys in both places take their type from
+`ssm.parameters`.
+
+## How It Works
+
+### Deploy time
+
+`frigg deploy` (or a standalone `frigg ssm push --stage <stage>`) reads each
+offloaded value from the deploy process environment — your CI secrets or
+local `.env` — and writes it to Parameter Store **before** the serverless
+deploy runs, so parameters always exist before new code cold-starts:
+
+```
+/frigg/<service>/<stage>/HUBSPOT_CLIENT_SECRET
 ```
 
-## Security Best Practices
+The generated stack excludes offloaded keys from `provider.environment` and
+broadcasts only two small pointers to every function:
 
-### When to Use SSM Parameter Store
+- `SSM_PARAMETER_PREFIX` — e.g. `/frigg/my-frigg-app/prod`
+- `FRIGG_SSM_OFFLOADED_KEYS` — the declared key names
 
-Enable SSM Parameter Store for:
-- **Configuration values** that vary by environment
-- **API keys and tokens** for third-party services
-- **Database connection strings** and credentials
-- **Feature flags** and runtime configuration
-- **Sensitive application settings**
+The Lambda execution role receives read access scoped to the prefix (the
+pre-existing broad `parameter/*` grant from `ssm.enable` is kept for
+backward compatibility; set `ssm.restrictIamToPrefix: true` to drop it).
 
-### Parameter Security
+### Runtime
 
-- **Use SecureString** for sensitive values (encrypted with KMS)
-- **Scope IAM permissions** to specific parameter paths
-- **Enable parameter history** tracking for audit trails
-- **Use parameter policies** for automatic expiration
-- **Implement parameter rotation** for credentials
+On a container's first invocation, the Frigg handler bootstrap fetches the
+declared parameters (batched `GetParameters` with decryption) and writes them
+into `process.env` before your code runs. The result is cached per container
+with a TTL (default 300 seconds, configurable via `FRIGG_SSM_CACHE_TTL`;
+`0` caches for the container lifetime).
 
-### Parameter Naming Conventions
+**Precedence** (highest wins):
 
-```javascript
-// ✅ Good: Clear hierarchy and naming
-/${service}/${stage}/database/primary-url
-/${service}/${stage}/api-keys/salesforce/client-id
-/${service}/${stage}/features/enable-async-processing
+1. Real Lambda environment variables — a value set directly on a function's
+   configuration always wins, and the loader never touches it.
+2. Secrets Manager values injected via `SECRET_ARN` (`secretsToEnv`).
+3. SSM parameters.
 
-// ❌ Avoid: Flat structure and unclear names
-/${service}/${stage}/db-url
-/${service}/${stage}/sf-key  
-/${service}/${stage}/flag1
-```
+If a declared parameter is missing from Parameter Store, the cold start
+fails immediately with an error naming the missing key — a deliberate
+fail-fast instead of `undefined` surfacing somewhere downstream.
 
-## Examples
+### What cannot be offloaded
 
-### Complete Configuration Setup
+Framework-managed variables (`DATABASE_URL`, `DATABASE_*`, `KMS_KEY_ARN`,
+`AES_*`, `STAGE`, `FRIGG_*`, `SECRET_ARN`, `DB_TYPE`, and the AWS-reserved
+set) are rejected at build time: the database-migration handlers read them
+before the loader runs.
 
-```javascript
-// app-definition.js
-const appDefinition = {
-    name: 'integration-platform',
-    integrations: [
-        SalesforceIntegration,
-        HubspotIntegration
-    ],
-    ssm: { enable: true },
-    encryption: { fieldLevelEncryptionMethod: 'kms' },
-    vpc: { enable: true }
-};
+## Debugging and On-the-Fly Changes
 
-module.exports = appDefinition;
-```
-
-### Runtime Parameter Usage
-
-```javascript
-// Lambda function using parameters
-exports.handler = async (event) => {
-    // Get configuration from SSM
-    const databaseUrl = await getParameter('database/primary-url');
-    const salesforceKey = await getParameter('api-keys/salesforce/client-id');
-    const enableWebhooks = await getParameter('features/enable-webhooks');
-    
-    // Use parameters in your integration logic
-    const database = new Database(databaseUrl);
-    const salesforce = new SalesforceAPI(salesforceKey);
-    
-    if (enableWebhooks === 'true') {
-        // Feature flag enabled
-        await setupWebhooks();
-    }
-    
-    return { statusCode: 200 };
-};
-```
-
-## Deployment Considerations
-
-### Parameter Creation
-
-Parameters should be created during deployment or manually:
+**Inspect values** in the AWS console (Systems Manager → Parameter Store →
+filter by `/frigg/<service>/<stage>/`, toggle "Show decrypted value") or:
 
 ```bash
-# Create parameters using AWS CLI
-aws ssm put-parameter \
-    --name "/my-app/prod/database-url" \
-    --value "mongodb://prod-cluster.example.com" \
-    --type "SecureString"
-
-aws ssm put-parameter \
-    --name "/my-app/prod/api-keys/salesforce/client-id" \
-    --value "your-salesforce-client-id" \
-    --type "SecureString"
+aws ssm get-parameter --name /frigg/my-app/dev/HUBSPOT_CLIENT_SECRET --with-decryption
+aws ssm get-parameters-by-path --path /frigg/my-app/dev --with-decryption
 ```
 
-### Environment Isolation
+Parameters keep full version history, so "what was this value last Tuesday"
+is answerable — something Lambda env config never offered.
 
-Parameters are environment-specific by default:
-- **Development**: `/my-app/dev/*`
-- **Staging**: `/my-app/staging/*`  
-- **Production**: `/my-app/prod/*`
+**Change a value for all functions**: `aws ssm put-parameter --overwrite ...`
+(or edit in the console). Warm containers converge within the cache TTL
+(default 5 minutes); new containers pick it up immediately.
 
-### Version Requirements
+**Override one function instantly** (the classic debugging workflow): set the
+variable directly in that function's Lambda console configuration. Real env
+vars beat SSM, and saving the config recycles that function's containers, so
+the override applies immediately and only there.
 
-- **Framework Version**: Requires `@friggframework/devtools` v2.1.0+
-- **AWS Region**: Available in all AWS regions
-- **Lambda Runtime**: Compatible with Node.js 16.x, 18.x, 20.x
-- **Extension Version**: Uses AWS Parameters and Secrets Lambda Extension v11
+Both kinds of edits are temporary: the next `frigg deploy` re-pushes
+parameters from CI/`.env` values and resets function configs.
+
+## Local Development
+
+Nothing changes. In local mode (`frigg start`), offloaded keys fall back to
+plain `${env:KEY}` resolution from your `.env` — no SSM calls, no AWS
+dependency, and the runtime loader is inert because the SSM pointer
+variables are never set.
+
+## Configuration Reference
+
+```javascript
+ssm: {
+    enable: true,                 // required for any SSM feature
+    parameterPrefix: '/custom',   // optional; default /frigg/${service}/${stage}.
+                                  // Non-default prefixes without "frigg" require
+                                  // widening the generated deployment IAM policies.
+    kmsKeyArn: 'arn:aws:kms:...', // optional customer-managed key for SecureString;
+                                  // grants the Lambda role kms:Decrypt on it.
+                                  // Default: the AWS-managed aws/ssm key.
+    restrictIamToPrefix: true,    // optional; drop the legacy broad parameter/* read grant
+    parameters: { /* typed offload declarations, see above */ },
+},
+```
+
+### `frigg ssm push`
+
+```bash
+frigg ssm push --stage prod          # write offloaded values from env/.env to SSM
+frigg ssm push --stage prod --allow-empty   # permit empty values (default: error)
+```
+
+`frigg deploy` runs the push automatically before deploying whenever the
+offload set is non-empty. Use the standalone command to rotate a value
+without deploying (containers converge within the cache TTL) or to seed a
+new stage.
+
+Values are validated at push time: missing/empty values are an error, and
+values over 4KB (the standard-tier parameter limit) are rejected.
+
+## VPC Integration
+
+When the offload set is non-empty and `vpc.enable` is true, Frigg creates an
+SSM interface endpoint (`FriggSSMVPCEndpoint`, ~$7–22/month) so Lambdas in
+private subnets can reach Parameter Store without a NAT route. Without it,
+SSM calls from a VPC-enabled Lambda would hang.
+
+## Cost
+
+| Configuration | Parameter cost | Endpoint cost |
+|---------------|----------------|---------------|
+| Standard-tier parameters (≤4KB values) | $0 | — |
+| + VPC enabled with offload | $0 | ~$7–22/month (SSM interface endpoint) |
+
+API traffic is one batched fetch per container per TTL window — negligible
+against standard throughput limits.
+
+## Deployment Notes and Accepted Trade-offs
+
+- **Rollbacks**: parameters are pushed before the stack update. If the
+  deploy fails and CloudFormation rolls back the code, parameters keep their
+  new values — use parameter version history to revert manually if needed.
+- **Concurrent deploys** to one stage are last-writer-wins on parameters.
+- **Warm containers** keep values fetched at cold start until the TTL
+  expires or the container recycles.
+- The management UI's environment utilities use a separate
+  `/frigg/<environment>` namespace; it does not read or write this feature's
+  `/frigg/<service>/<stage>` parameters.
+
+## Version Requirements
+
+- `@friggframework/core` and `@friggframework/devtools` releases that
+  include ADR-027 (offload requires BOTH: devtools generates the pointers,
+  core fetches at runtime — upgrading devtools alone would silently drop
+  offloaded variables).
+- Works in all AWS regions; no Lambda layers or extensions required (the
+  loader uses `@aws-sdk/client-ssm` directly).

--- a/docs/reference/ssm-configuration.md
+++ b/docs/reference/ssm-configuration.md
@@ -118,6 +118,15 @@ If a declared parameter is missing from Parameter Store, INIT fails
 immediately with an error naming the missing key — a deliberate fail-fast
 instead of `undefined` surfacing somewhere downstream.
 
+> **Keep offloaded keys and Secrets Manager keys disjoint.** The ordering above
+> holds only when a key is offloaded to SSM *or* in the `SECRET_ARN` bundle, not
+> both. A key in both has undefined precedence: the INIT preload sets the SSM
+> value before modules load (so module-load reads see SSM), `secretsToEnv` then
+> overwrites it in the handler (Secrets Manager), and a later cache-TTL refresh
+> writes the SSM value back. Framework-managed secrets (`DATABASE_*`, etc.) are
+> already on the offload blocklist, so this only arises if an app marks one of
+> its own `SECRET_ARN` keys `'ssm'` — don't.
+
 ### What cannot be offloaded
 
 Framework-managed variables (`DATABASE_URL`, `DATABASE_*`, `KMS_KEY_ARN`,

--- a/docs/reference/ssm-configuration.md
+++ b/docs/reference/ssm-configuration.md
@@ -109,9 +109,10 @@ refreshes the preloaded keys per container on a TTL (default 300 seconds,
 **Precedence** (highest wins):
 
 1. Real Lambda environment variables — a value set directly on a function's
-   configuration always wins, and the loaders never touch it.
-2. INIT preload / handler loader SSM values.
-3. Secrets Manager values injected via `SECRET_ARN` (`secretsToEnv`).
+   configuration always wins, and the SSM loaders never touch it.
+2. Secrets Manager values injected via `SECRET_ARN` (`secretsToEnv`), which
+   runs first in the handler and overwrites, so it wins over SSM.
+3. INIT preload / handler loader SSM values.
 
 If a declared parameter is missing from Parameter Store, INIT fails
 immediately with an error naming the missing key — a deliberate fail-fast
@@ -175,8 +176,10 @@ ssm: {
 ### `frigg ssm push`
 
 ```bash
-frigg ssm push --stage prod          # write offloaded values from env/.env to SSM
-frigg ssm push --stage prod --allow-empty   # skip keys with empty values (warn instead of error)
+frigg ssm push --stage prod                 # write offloaded values from env/.env to SSM
+frigg ssm push --stage prod --allow-empty    # skip keys with no value (only for keys already in SSM)
+frigg ssm push --stage prod --tier advanced  # allow values up to 8KB (advanced tier, billed by AWS)
+frigg ssm push --stage prod --region eu-west-1  # target a specific region (default: AWS_REGION, else us-east-1)
 ```
 
 `frigg deploy` runs the push automatically before deploying whenever the
@@ -184,8 +187,13 @@ offload set is non-empty. Use the standalone command to rotate a value
 without deploying (containers converge within the cache TTL) or to seed a
 new stage.
 
-Values are validated at push time: missing/empty values are an error, and
-values over 4KB (the standard-tier parameter limit) are rejected.
+Values are validated at push time: missing/empty values are an error unless
+`--allow-empty`, which skips them — but only for keys whose parameter already
+exists (rotation); a skipped key with no parameter aborts the push, since it
+would fail every function at cold start. Values over 4KB (the standard-tier
+limit) require the advanced tier (up to 8KB, billed by AWS): set
+`ssm.parameters.<KEY>.tier: 'advanced'` in the app definition, or pass
+`--tier advanced`.
 
 ## VPC Integration
 

--- a/docs/reference/ssm-configuration.md
+++ b/docs/reference/ssm-configuration.md
@@ -158,7 +158,7 @@ ssm: {
 
 ```bash
 frigg ssm push --stage prod          # write offloaded values from env/.env to SSM
-frigg ssm push --stage prod --allow-empty   # permit empty values (default: error)
+frigg ssm push --stage prod --allow-empty   # skip keys with empty values (warn instead of error)
 ```
 
 `frigg deploy` runs the push automatically before deploying whenever the

--- a/package-lock.json
+++ b/package-lock.json
@@ -852,6 +852,31 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.1084.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1084.0.tgz",
+      "integrity": "sha512-LyRldNUFPS3ZDkY1D50WYBnXVf7f1hl7ifyshme5TSoWQ37jvAbeNtM92K+60VYz7WBDsqVWQ86PnUTofRmQOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.66",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@aws-sdk/client-sts": {
       "version": "3.1073.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1073.0.tgz",
@@ -881,17 +906,17 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.27.tgz",
-      "integrity": "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==",
+      "version": "3.975.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
+      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws-sdk/types": "^3.974.0",
+        "@aws-sdk/xml-builder": "^3.972.34",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.0",
-        "@smithy/signature-v4": "^5.6.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.2",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -930,15 +955,15 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.53.tgz",
-      "integrity": "sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -952,17 +977,17 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.55",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.55.tgz",
-      "integrity": "sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/fetch-http-handler": "^5.6.2",
-        "@smithy/node-http-handler": "^4.9.2",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -976,23 +1001,23 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.60",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.60.tgz",
-      "integrity": "sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/credential-provider-env": "^3.972.53",
-        "@aws-sdk/credential-provider-http": "^3.972.55",
-        "@aws-sdk/credential-provider-login": "^3.972.59",
-        "@aws-sdk/credential-provider-process": "^3.972.53",
-        "@aws-sdk/credential-provider-sso": "^3.972.59",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/credential-provider-imds": "^4.4.5",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-login": "^3.972.63",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1006,16 +1031,16 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.59.tgz",
-      "integrity": "sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1029,21 +1054,21 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.62",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.62.tgz",
-      "integrity": "sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
+      "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.53",
-        "@aws-sdk/credential-provider-http": "^3.972.55",
-        "@aws-sdk/credential-provider-ini": "^3.972.60",
-        "@aws-sdk/credential-provider-process": "^3.972.53",
-        "@aws-sdk/credential-provider-sso": "^3.972.59",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/credential-provider-imds": "^4.4.5",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-ini": "^3.973.1",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1057,15 +1082,15 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.53.tgz",
-      "integrity": "sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1079,17 +1104,17 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.59.tgz",
-      "integrity": "sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/token-providers": "3.1079.0",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/token-providers": "3.1083.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1103,16 +1128,16 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.59.tgz",
-      "integrity": "sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1294,18 +1319,18 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.27.tgz",
-      "integrity": "sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==",
+      "version": "3.997.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/fetch-http-handler": "^5.6.2",
-        "@smithy/node-http-handler": "^4.9.2",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1319,14 +1344,14 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
-      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+      "version": "3.996.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/signature-v4": "^5.6.1",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1340,16 +1365,16 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1079.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1079.0.tgz",
-      "integrity": "sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==",
+      "version": "3.1083.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1363,12 +1388,12 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
-      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
+      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1400,12 +1425,12 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
-      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2422,6 +2447,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2438,6 +2464,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2454,6 +2481,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2470,6 +2498,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2486,6 +2515,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2502,6 +2532,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2518,6 +2549,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2534,6 +2566,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2550,6 +2583,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2566,6 +2600,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2582,6 +2617,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2598,6 +2634,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2614,6 +2651,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2630,6 +2668,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2646,6 +2685,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2662,6 +2702,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2678,6 +2719,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2694,6 +2736,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2710,6 +2753,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2726,6 +2770,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2742,6 +2787,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2758,6 +2804,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2774,6 +2821,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2790,6 +2838,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2806,6 +2855,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2822,6 +2872,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9593,12 +9644,12 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
-      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.2.tgz",
+      "integrity": "sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9612,13 +9663,13 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz",
-      "integrity": "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.7.tgz",
+      "integrity": "sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9632,13 +9683,13 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz",
-      "integrity": "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.4.tgz",
+      "integrity": "sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9670,13 +9721,13 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
-      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.4.tgz",
+      "integrity": "sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9690,13 +9741,13 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
-      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.3.tgz",
+      "integrity": "sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9710,9 +9761,9 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/types": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
-      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.0.tgz",
+      "integrity": "sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -10534,7 +10585,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
       "version": "1.12.2",
@@ -10547,7 +10599,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.12.2",
@@ -10560,7 +10613,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.12.2",
@@ -10573,7 +10627,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
       "version": "1.12.2",
@@ -10586,7 +10641,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.12.2",
@@ -10599,7 +10655,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.12.2",
@@ -10612,7 +10669,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
       "version": "1.12.2",
@@ -10625,7 +10683,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
       "version": "1.12.2",
@@ -10638,7 +10697,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
       "version": "1.12.2",
@@ -10651,7 +10711,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
       "version": "1.12.2",
@@ -10664,7 +10725,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
       "version": "1.12.2",
@@ -10677,7 +10739,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
       "version": "1.12.2",
@@ -10690,7 +10753,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
       "version": "1.12.2",
@@ -10703,7 +10767,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
       "version": "1.12.2",
@@ -10716,7 +10781,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.12.2",
@@ -10729,7 +10795,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
       "version": "1.12.2",
@@ -10742,7 +10809,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-openharmony-arm64": {
       "version": "1.12.2",
@@ -10755,7 +10823,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
       "version": "1.12.2",
@@ -10766,6 +10835,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
@@ -10781,6 +10851,7 @@
       "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.2"
       },
@@ -10799,6 +10870,7 @@
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -10808,7 +10880,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
       "version": "1.12.2",
@@ -10821,7 +10894,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
       "version": "1.12.2",
@@ -10834,7 +10908,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.12.2",
@@ -10847,7 +10922,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -33706,6 +33782,7 @@
         "@aws-sdk/client-kms": "^3.588.0",
         "@aws-sdk/client-lambda": "^3.714.0",
         "@aws-sdk/client-sqs": "^3.588.0",
+        "@aws-sdk/client-ssm": "^3.588.0",
         "@hapi/boom": "^10.0.1",
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.20.5",
@@ -33799,6 +33876,7 @@
         "@aws-sdk/client-rds": "^3.906.0",
         "@aws-sdk/client-s3": "^3.917.0",
         "@aws-sdk/client-secrets-manager": "^3.906.0",
+        "@aws-sdk/client-ssm": "^3.906.0",
         "@aws-sdk/client-sts": "^3.835.0",
         "@babel/eslint-parser": "^7.18.9",
         "@babel/parser": "^7.25.3",

--- a/packages/core/core/CLAUDE.md
+++ b/packages/core/core/CLAUDE.md
@@ -131,6 +131,7 @@ class MyIntegration extends Delegate {
    ```javascript
    initDebugLog(eventName, event);           // Debug logging setup
    await secretsToEnv();                     // Secrets Manager injection
+   await parametersToEnv();                  // SSM Parameter Store fetch (only when SSM_PARAMETER_PREFIX + FRIGG_SSM_OFFLOADED_KEYS are set)
    context.callbackWaitsForEmptyEventLoop = false; // Connection pooling
    ```
 
@@ -164,6 +165,15 @@ class MyIntegration extends Delegate {
 - **Environment Variables**: Secrets automatically set as `process.env` variables
 - **Security**: No secrets logging or exposure in error messages
 - **Caching**: Secrets cached for Lambda container lifetime
+
+### SSM Parameter Store Loader (`parameters-to-env.js`)
+Offloads env vars that would otherwise exceed Lambda's 4KB env limit. Runs right after `secretsToEnv()` and is a no-op unless both `SSM_PARAMETER_PREFIX` and `FRIGG_SSM_OFFLOADED_KEYS` (comma-separated env var names) are set.
+
+- **Precedence**: real `process.env` > Secrets Manager > SSM. A key already present in `process.env` at load time is never fetched or overwritten (a documented local-debugging escape hatch); only keys the loader itself set are refreshed.
+- **Fetch**: `GetParametersCommand` with `WithDecryption: true`, batched in groups of 10 (the GetParameters max). Parameter name for key `K` is `${SSM_PARAMETER_PREFIX}/${K}`.
+- **TTL cache**: successful loads cache for `FRIGG_SSM_CACHE_TTL` seconds (default 300; `0` = forever). Concurrent callers share one in-flight promise. A failed initial load is never cached, so the next invocation retries; a failed TTL *refresh* keeps serving the stale values (warn + 30s backoff) instead of erroring a warm container. `ThrottlingException` is retried with short exponential backoff.
+- **Fail-fast**: throws listing every missing parameter name (and the prefix) if a required key is absent from SSM. Keys already satisfied by real `process.env` never trigger a failure.
+- **Security**: logs parameter names and versions only, never values.
 
 ## Database Connection Patterns
 

--- a/packages/core/core/create-handler.js
+++ b/packages/core/core/create-handler.js
@@ -4,6 +4,7 @@
 
 const { initDebugLog, flushDebugLog } = require('../logs');
 const { secretsToEnv } = require('./secrets-to-env');
+const { parametersToEnv } = require('./parameters-to-env');
 
 // Best-effort extraction of correlation identifiers from a Lambda event.
 // For SQS: pulls messageIds + parsed event/processId/integrationId from each
@@ -79,6 +80,9 @@ const createHandler = (optionByName = {}) => {
 
             // If enabled (i.e. if SECRET_ARN is set in process.env) Fetch secrets from AWS Secrets Manager, and set them as environment variables.
             await secretsToEnv();
+
+            // If enabled (i.e. if SSM_PARAMETER_PREFIX and FRIGG_SSM_OFFLOADED_KEYS are set) fetch offloaded params from SSM Parameter Store into process.env.
+            await parametersToEnv();
 
             // Lazy-required so DB-free handlers never load the Prisma client.
             if (shouldUseDatabase) {

--- a/packages/core/core/parameters-to-env.js
+++ b/packages/core/core/parameters-to-env.js
@@ -38,11 +38,11 @@ const parseKeys = (raw) =>
         .map((key) => key.trim())
         .filter(Boolean);
 
-const sendWithRetry = async (command) => {
+const sendWithRetry = async (ssmClient, command) => {
     let attempt = 0;
     for (;;) {
         try {
-            return await client.send(command);
+            return await ssmClient.send(command);
         } catch (err) {
             if (
                 err.name === 'ThrottlingException' &&
@@ -55,6 +55,47 @@ const sendWithRetry = async (command) => {
             throw err;
         }
     }
+};
+
+/**
+ * Fetch offloaded parameters and return a plain { key: value } map. Fetch-only:
+ * no process.env mutation, no caching, no ownership tracking. Shared by the
+ * runtime loader and the INIT-phase preload (ssm-preload.js). Throws (listing
+ * every missing name) if any requested key is absent from SSM.
+ */
+const fetchOffloadedParameters = async (prefix, keys, { region } = {}) => {
+    const { SSMClient, GetParametersCommand } = require('@aws-sdk/client-ssm');
+    const ssmClient = new SSMClient({
+        region: region || process.env.AWS_REGION,
+    });
+    const nameFor = (key) => `${prefix}/${key}`;
+
+    const found = new Map();
+    for (const batch of chunk(keys, BATCH_SIZE)) {
+        const { Parameters = [] } = await sendWithRetry(
+            ssmClient,
+            new GetParametersCommand({
+                Names: batch.map(nameFor),
+                WithDecryption: true,
+            })
+        );
+        for (const param of Parameters) {
+            found.set(param.Name, param);
+        }
+    }
+
+    const missing = keys.map(nameFor).filter((name) => !found.has(name));
+    if (missing.length > 0) {
+        throw new Error(
+            `missing SSM parameters under ${prefix}: ${missing.join(', ')}`
+        );
+    }
+
+    const values = {};
+    for (const key of keys) {
+        values[key] = found.get(nameFor(key)).Value;
+    }
+    return values;
 };
 
 const loadParameters = async (prefix, keys) => {
@@ -80,6 +121,7 @@ const loadParameters = async (prefix, keys) => {
     try {
         for (const batch of chunk(keysToFetch, BATCH_SIZE)) {
             const { Parameters = [] } = await sendWithRetry(
+                client,
                 new GetParametersCommand({
                     Names: batch.map(nameFor),
                     WithDecryption: true,
@@ -166,5 +208,6 @@ const _resetCache = () => {
 
 module.exports = {
     parametersToEnv,
+    fetchOffloadedParameters,
     _resetCache,
 };

--- a/packages/core/core/parameters-to-env.js
+++ b/packages/core/core/parameters-to-env.js
@@ -216,6 +216,31 @@ const adoptPreloadedKeys = (keys) => {
         ttlSeconds === 0 ? Infinity : Date.now() + ttlSeconds * 1000;
 };
 
+/**
+ * INIT-phase preload used by ssm-preload.mjs: fetch offloaded parameters and
+ * set them into process.env, then adopt the keys it set so the handler-time
+ * loader refreshes them on TTL. Real env wins — a key already present is never
+ * fetched or overwritten, so a console override keeps working even if that
+ * key's parameter is absent from SSM (fetching it would fail INIT). Returns the
+ * keys actually set (empty when every key was already in real env). Throws,
+ * listing the names, only for a genuinely-needed parameter that is missing.
+ */
+const preloadOffloadedParameters = async (prefix, keys, options = {}) => {
+    const keysToFetch = keys.filter((key) => process.env[key] === undefined);
+    if (keysToFetch.length === 0) {
+        return [];
+    }
+
+    const values = await fetchOffloadedParameters(prefix, keysToFetch, options);
+    const setKeys = [];
+    for (const [key, value] of Object.entries(values)) {
+        process.env[key] = value;
+        setKeys.push(key);
+    }
+    adoptPreloadedKeys(setKeys);
+    return setKeys;
+};
+
 const _resetCache = () => {
     client = null;
     cacheExpiresAt = null;
@@ -226,6 +251,7 @@ const _resetCache = () => {
 module.exports = {
     parametersToEnv,
     fetchOffloadedParameters,
+    preloadOffloadedParameters,
     adoptPreloadedKeys,
     _resetCache,
 };

--- a/packages/core/core/parameters-to-env.js
+++ b/packages/core/core/parameters-to-env.js
@@ -199,6 +199,23 @@ const parametersToEnv = async () => {
     return inflight;
 };
 
+/**
+ * Adopt keys the INIT preload (ssm-preload.mjs) already populated into
+ * process.env, so the handler-time loader treats them as its own: it seeds
+ * the cache TTL and marks the keys owned so the TTL-refresh path re-fetches
+ * them. The preload runs in-process (NODE_OPTIONS=--import), sharing this
+ * module singleton. Pass ONLY the keys the preload actually set (not keys
+ * already present as real env vars) so the real-env-wins rule is preserved.
+ */
+const adoptPreloadedKeys = (keys) => {
+    for (const key of keys) {
+        ownedKeys.add(key);
+    }
+    const ttlSeconds = getCacheTtlSeconds();
+    cacheExpiresAt =
+        ttlSeconds === 0 ? Infinity : Date.now() + ttlSeconds * 1000;
+};
+
 const _resetCache = () => {
     client = null;
     cacheExpiresAt = null;
@@ -209,5 +226,6 @@ const _resetCache = () => {
 module.exports = {
     parametersToEnv,
     fetchOffloadedParameters,
+    adoptPreloadedKeys,
     _resetCache,
 };

--- a/packages/core/core/parameters-to-env.js
+++ b/packages/core/core/parameters-to-env.js
@@ -1,0 +1,170 @@
+// Runtime loader that hydrates process.env from SSM Parameter Store. Used to
+// offload env vars that would otherwise blow past Lambda's 4KB env limit.
+// Real process.env always wins over SSM (a documented local-debugging escape
+// hatch); only keys this loader sets are ever refreshed.
+
+const DEFAULT_CACHE_TTL_SECONDS = 300;
+const BATCH_SIZE = 10;
+const THROTTLE_BACKOFF_MS = [100, 200, 400];
+const REFRESH_RETRY_MS = 30_000;
+
+let client = null;
+let cacheExpiresAt = null;
+let inflight = null;
+const ownedKeys = new Set();
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const chunk = (items, size) => {
+    const batches = [];
+    for (let i = 0; i < items.length; i += size) {
+        batches.push(items.slice(i, i + size));
+    }
+    return batches;
+};
+
+const getCacheTtlSeconds = () => {
+    const raw = process.env.FRIGG_SSM_CACHE_TTL;
+    if (raw === undefined || raw === '') {
+        return DEFAULT_CACHE_TTL_SECONDS;
+    }
+    const parsed = Number(raw);
+    return Number.isNaN(parsed) ? DEFAULT_CACHE_TTL_SECONDS : parsed;
+};
+
+const parseKeys = (raw) =>
+    raw
+        .split(',')
+        .map((key) => key.trim())
+        .filter(Boolean);
+
+const sendWithRetry = async (command) => {
+    let attempt = 0;
+    for (;;) {
+        try {
+            return await client.send(command);
+        } catch (err) {
+            if (
+                err.name === 'ThrottlingException' &&
+                attempt < THROTTLE_BACKOFF_MS.length
+            ) {
+                await sleep(THROTTLE_BACKOFF_MS[attempt]);
+                attempt += 1;
+                continue;
+            }
+            throw err;
+        }
+    }
+};
+
+const loadParameters = async (prefix, keys) => {
+    const { SSMClient, GetParametersCommand } = require('@aws-sdk/client-ssm');
+    if (!client) {
+        client = new SSMClient({ region: process.env.AWS_REGION });
+    }
+
+    // A key already living in process.env wins over SSM, except keys we set
+    // ourselves — those we refresh so later invocations pick up rotations.
+    const keysToFetch = keys.filter(
+        (key) => ownedKeys.has(key) || process.env[key] === undefined
+    );
+    const nameFor = (key) => `${prefix}/${key}`;
+
+    // A refresh means every key already has a served value; a warm container
+    // must keep serving stale values through an SSM blip instead of erroring.
+    const isRefresh =
+        keysToFetch.length > 0 &&
+        keysToFetch.every((key) => ownedKeys.has(key));
+
+    const found = new Map();
+    try {
+        for (const batch of chunk(keysToFetch, BATCH_SIZE)) {
+            const { Parameters = [] } = await sendWithRetry(
+                new GetParametersCommand({
+                    Names: batch.map(nameFor),
+                    WithDecryption: true,
+                })
+            );
+            for (const param of Parameters) {
+                found.set(param.Name, param);
+            }
+        }
+
+        const missing = keysToFetch
+            .map(nameFor)
+            .filter((name) => !found.has(name));
+        if (missing.length > 0) {
+            throw new Error(
+                `parametersToEnv: missing SSM parameters under ${prefix}: ${missing.join(
+                    ', '
+                )}`
+            );
+        }
+    } catch (err) {
+        if (!isRefresh) {
+            throw err;
+        }
+        console.warn(
+            `parametersToEnv: refresh failed, keeping cached values: ${err.message}`
+        );
+        cacheExpiresAt = Date.now() + REFRESH_RETRY_MS;
+        return;
+    }
+
+    const loaded = keysToFetch.map((key) => {
+        const param = found.get(nameFor(key));
+        process.env[key] = param.Value;
+        ownedKeys.add(key);
+        return `${param.Name} (v${param.Version})`;
+    });
+
+    const ttlSeconds = getCacheTtlSeconds();
+    cacheExpiresAt =
+        ttlSeconds === 0 ? Infinity : Date.now() + ttlSeconds * 1000;
+
+    if (loaded.length > 0) {
+        console.log('parametersToEnv: loaded', loaded);
+    }
+};
+
+/**
+ * Hydrate process.env from SSM Parameter Store.
+ *
+ * No-op unless both SSM_PARAMETER_PREFIX and FRIGG_SSM_OFFLOADED_KEYS are set.
+ * Results are cached for FRIGG_SSM_CACHE_TTL seconds (default 300; 0 = forever).
+ * A failed fetch is never cached, so the next invocation retries.
+ */
+const parametersToEnv = async () => {
+    const prefix = process.env.SSM_PARAMETER_PREFIX;
+    const rawKeys = process.env.FRIGG_SSM_OFFLOADED_KEYS;
+    if (!prefix || !rawKeys) {
+        return;
+    }
+    const keys = parseKeys(rawKeys);
+    if (keys.length === 0) {
+        return;
+    }
+
+    if (cacheExpiresAt !== null && Date.now() < cacheExpiresAt) {
+        return;
+    }
+
+    if (!inflight) {
+        inflight = loadParameters(prefix, keys).finally(() => {
+            inflight = null;
+        });
+    }
+    return inflight;
+};
+
+const _resetCache = () => {
+    client = null;
+    cacheExpiresAt = null;
+    inflight = null;
+    ownedKeys.clear();
+};
+
+module.exports = {
+    parametersToEnv,
+    _resetCache,
+};

--- a/packages/core/core/parameters-to-env.test.js
+++ b/packages/core/core/parameters-to-env.test.js
@@ -467,6 +467,89 @@ describe('parametersToEnv - SSM Parameter Store loader', () => {
         });
     });
 
+    describe('preloadOffloadedParameters (INIT preload)', () => {
+        const {
+            preloadOffloadedParameters,
+        } = require('./parameters-to-env');
+
+        it('fetches, sets, and returns keys not already in real env', async () => {
+            setParamStore({
+                '/frigg/app/A': { value: 'va' },
+                '/frigg/app/B': { value: 'vb' },
+            });
+
+            const setKeys = await preloadOffloadedParameters('/frigg/app', [
+                'A',
+                'B',
+            ]);
+
+            expect(setKeys.sort()).toEqual(['A', 'B']);
+            expect(process.env.A).toBe('va');
+            expect(process.env.B).toBe('vb');
+        });
+
+        it('never fetches or overwrites a key already in real env', async () => {
+            process.env.REAL_KEY = 'from-console';
+            setParamStore({
+                '/frigg/app/REAL_KEY': { value: 'from-ssm' },
+                '/frigg/app/OWNED': { value: 'ssm-owned' },
+            });
+
+            const setKeys = await preloadOffloadedParameters('/frigg/app', [
+                'REAL_KEY',
+                'OWNED',
+            ]);
+
+            expect(setKeys).toEqual(['OWNED']);
+            expect(process.env.REAL_KEY).toBe('from-console');
+            const call = ssmMock.commandCalls(GetParametersCommand)[0];
+            expect(call.args[0].input.Names).toEqual(['/frigg/app/OWNED']);
+        });
+
+        // Regression: a real-env override must work even when its SSM parameter
+        // is absent — the preload must not fetch (and fail INIT on) that key.
+        it('does not fetch or throw when every key is satisfied by real env, even if the parameter is absent', async () => {
+            process.env.REAL_KEY = 'from-console';
+            setParamStore({}); // REAL_KEY has no parameter in SSM
+
+            const setKeys = await preloadOffloadedParameters('/frigg/app', [
+                'REAL_KEY',
+            ]);
+
+            expect(setKeys).toEqual([]);
+            expect(process.env.REAL_KEY).toBe('from-console');
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(0);
+        });
+
+        it('fails fast when a genuinely-needed parameter is missing', async () => {
+            setParamStore({ '/frigg/app/PRESENT': { value: 'ok' } });
+
+            await expect(
+                preloadOffloadedParameters('/frigg/app', ['PRESENT', 'ABSENT'])
+            ).rejects.toThrow(/\/frigg\/app\/ABSENT/);
+        });
+
+        it('adopts set keys so the handler loader refreshes them on TTL', async () => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'OWNED';
+            process.env.FRIGG_SSM_CACHE_TTL = '60';
+            setParamStore({ '/frigg/app/OWNED': { value: 'v1', version: 1 } });
+
+            await preloadOffloadedParameters('/frigg/app', ['OWNED']);
+            expect(process.env.OWNED).toBe('v1');
+
+            // Within TTL the handler loader does not refetch (cache adopted).
+            await parametersToEnv();
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(1);
+
+            // After TTL it refreshes the adopted key.
+            setParamStore({ '/frigg/app/OWNED': { value: 'v2', version: 2 } });
+            clock += 61 * 1000;
+            await parametersToEnv();
+            expect(process.env.OWNED).toBe('v2');
+        });
+    });
+
     describe('adoptPreloadedKeys (INIT preload → handler-time TTL refresh)', () => {
         const { adoptPreloadedKeys } = require('./parameters-to-env');
 

--- a/packages/core/core/parameters-to-env.test.js
+++ b/packages/core/core/parameters-to-env.test.js
@@ -466,4 +466,46 @@ describe('parametersToEnv - SSM Parameter Store loader', () => {
             expect(process.env.A).toBeUndefined();
         });
     });
+
+    describe('adoptPreloadedKeys (INIT preload → handler-time TTL refresh)', () => {
+        const { adoptPreloadedKeys } = require('./parameters-to-env');
+
+        it('lets the TTL-refresh path re-fetch keys the preload set', async () => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'ADOPTED';
+            process.env.FRIGG_SSM_CACHE_TTL = '60';
+
+            // Simulate the preload: value already in env, adopted as owned.
+            process.env.ADOPTED = 'v1';
+            adoptPreloadedKeys(['ADOPTED']);
+
+            // Within TTL: no fetch.
+            await parametersToEnv();
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(0);
+
+            // After TTL: the adopted key IS refreshed (overwritten), unlike a
+            // real-env / console override which is never touched.
+            setParamStore({ '/frigg/app/ADOPTED': { value: 'v2', version: 2 } });
+            clock += 61 * 1000;
+            await parametersToEnv();
+
+            expect(process.env.ADOPTED).toBe('v2');
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(1);
+        });
+
+        it('does not refresh a key the preload left to real env (not adopted)', async () => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'REALENV';
+            process.env.FRIGG_SSM_CACHE_TTL = '60';
+
+            process.env.REALENV = 'from-console';
+            adoptPreloadedKeys([]); // preload set nothing (real env won)
+
+            clock += 61 * 1000;
+            await parametersToEnv();
+
+            expect(process.env.REALENV).toBe('from-console');
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(0);
+        });
+    });
 });

--- a/packages/core/core/parameters-to-env.test.js
+++ b/packages/core/core/parameters-to-env.test.js
@@ -1,0 +1,423 @@
+/**
+ * Tests for parametersToEnv - SSM Parameter Store runtime loader
+ *
+ * Uses aws-sdk-client-mock to stub the SSM client.
+ */
+
+const { mockClient } = require('aws-sdk-client-mock');
+const { SSMClient, GetParametersCommand } = require('@aws-sdk/client-ssm');
+const { parametersToEnv, _resetCache } = require('./parameters-to-env');
+
+describe('parametersToEnv - SSM Parameter Store loader', () => {
+    let ssmMock;
+    let clock;
+    const originalEnv = process.env;
+
+    // Builds a callsFake responder from a { paramName: {value, version} } store.
+    const setParamStore = (store) => {
+        ssmMock.on(GetParametersCommand).callsFake((input) => {
+            const Parameters = [];
+            const InvalidParameters = [];
+            for (const name of input.Names) {
+                const entry = store[name];
+                if (entry) {
+                    Parameters.push({
+                        Name: name,
+                        Value: entry.value,
+                        Version: entry.version ?? 1,
+                        Type: 'SecureString',
+                    });
+                } else {
+                    InvalidParameters.push(name);
+                }
+            }
+            return { Parameters, InvalidParameters };
+        });
+    };
+
+    beforeEach(() => {
+        ssmMock = mockClient(SSMClient);
+        process.env = { ...originalEnv };
+        delete process.env.SSM_PARAMETER_PREFIX;
+        delete process.env.FRIGG_SSM_OFFLOADED_KEYS;
+        delete process.env.FRIGG_SSM_CACHE_TTL;
+        process.env.AWS_REGION = 'us-east-1';
+        _resetCache();
+
+        clock = 1_000_000;
+        jest.spyOn(Date, 'now').mockImplementation(() => clock);
+    });
+
+    afterEach(() => {
+        ssmMock.reset();
+        process.env = originalEnv;
+        jest.restoreAllMocks();
+    });
+
+    describe('no-op guard', () => {
+        it('returns without any API call when neither env var is set', async () => {
+            await parametersToEnv();
+            expect(ssmMock.calls()).toHaveLength(0);
+        });
+
+        it('returns without any API call when only the prefix is set', async () => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            await parametersToEnv();
+            expect(ssmMock.calls()).toHaveLength(0);
+        });
+
+        it('returns without any API call when only the key list is set', async () => {
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'A,B';
+            await parametersToEnv();
+            expect(ssmMock.calls()).toHaveLength(0);
+        });
+
+        it('returns without any API call when the key list is empty', async () => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = '  , ,';
+            await parametersToEnv();
+            expect(ssmMock.calls()).toHaveLength(0);
+        });
+
+        it('does not log on the no-op path', async () => {
+            const logSpy = jest
+                .spyOn(console, 'log')
+                .mockImplementation(() => {});
+            await parametersToEnv();
+            expect(logSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('fetch and assignment', () => {
+        beforeEach(() => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'DATABASE_URL,API_TOKEN';
+        });
+
+        it('fetches declared keys and sets them as env vars', async () => {
+            setParamStore({
+                '/frigg/app/DATABASE_URL': { value: 'postgres://x' },
+                '/frigg/app/API_TOKEN': { value: 'tok_123' },
+            });
+
+            await parametersToEnv();
+
+            expect(process.env.DATABASE_URL).toBe('postgres://x');
+            expect(process.env.API_TOKEN).toBe('tok_123');
+        });
+
+        it('builds parameter names as prefix/key and requests decryption', async () => {
+            setParamStore({
+                '/frigg/app/DATABASE_URL': { value: 'postgres://x' },
+                '/frigg/app/API_TOKEN': { value: 'tok_123' },
+            });
+
+            await parametersToEnv();
+
+            const call = ssmMock.commandCalls(GetParametersCommand)[0];
+            expect(call.args[0].input.Names).toEqual([
+                '/frigg/app/DATABASE_URL',
+                '/frigg/app/API_TOKEN',
+            ]);
+            expect(call.args[0].input.WithDecryption).toBe(true);
+        });
+    });
+
+    describe('batching', () => {
+        it('splits more than 10 keys into multiple GetParameters calls', async () => {
+            const keys = Array.from({ length: 12 }, (_, i) => `K${i}`);
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = keys.join(',');
+
+            const store = {};
+            keys.forEach((k) => {
+                store[`/frigg/app/${k}`] = { value: `v-${k}` };
+            });
+            setParamStore(store);
+
+            await parametersToEnv();
+
+            const calls = ssmMock.commandCalls(GetParametersCommand);
+            expect(calls).toHaveLength(2);
+            expect(calls[0].args[0].input.Names).toHaveLength(10);
+            expect(calls[1].args[0].input.Names).toHaveLength(2);
+            keys.forEach((k) => {
+                expect(process.env[k]).toBe(`v-${k}`);
+            });
+        });
+    });
+
+    describe('precedence (real env wins)', () => {
+        it('never fetches or overwrites a key already present in process.env', async () => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'REAL_KEY,OWNED_KEY';
+            process.env.REAL_KEY = 'from-real-env';
+
+            setParamStore({
+                '/frigg/app/REAL_KEY': { value: 'from-ssm' },
+                '/frigg/app/OWNED_KEY': { value: 'ssm-owned' },
+            });
+
+            await parametersToEnv();
+
+            expect(process.env.REAL_KEY).toBe('from-real-env');
+            expect(process.env.OWNED_KEY).toBe('ssm-owned');
+
+            const call = ssmMock.commandCalls(GetParametersCommand)[0];
+            expect(call.args[0].input.Names).toEqual(['/frigg/app/OWNED_KEY']);
+        });
+    });
+
+    describe('TTL cache', () => {
+        beforeEach(() => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'OWNED_KEY';
+        });
+
+        it('does not refetch within the TTL window', async () => {
+            process.env.FRIGG_SSM_CACHE_TTL = '300';
+            setParamStore({ '/frigg/app/OWNED_KEY': { value: 'v1' } });
+
+            await parametersToEnv();
+            clock += 299 * 1000;
+            await parametersToEnv();
+
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(1);
+        });
+
+        it('caches forever when TTL is 0', async () => {
+            process.env.FRIGG_SSM_CACHE_TTL = '0';
+            setParamStore({ '/frigg/app/OWNED_KEY': { value: 'v1' } });
+
+            await parametersToEnv();
+            clock += 10 * 365 * 24 * 60 * 60 * 1000;
+            await parametersToEnv();
+
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(1);
+        });
+
+        it('refetches after the TTL expires and updates loader-owned keys only', async () => {
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'REAL_KEY,OWNED_KEY';
+            process.env.REAL_KEY = 'from-real-env';
+            process.env.FRIGG_SSM_CACHE_TTL = '60';
+
+            setParamStore({
+                '/frigg/app/OWNED_KEY': { value: 'v1', version: 1 },
+            });
+            await parametersToEnv();
+            expect(process.env.OWNED_KEY).toBe('v1');
+
+            setParamStore({
+                '/frigg/app/OWNED_KEY': { value: 'v2', version: 2 },
+            });
+            clock += 61 * 1000;
+            await parametersToEnv();
+
+            expect(process.env.OWNED_KEY).toBe('v2');
+            expect(process.env.REAL_KEY).toBe('from-real-env');
+
+            const calls = ssmMock.commandCalls(GetParametersCommand);
+            expect(calls).toHaveLength(2);
+            // refresh only fetches the loader-owned key, never the real-env key
+            expect(calls[1].args[0].input.Names).toEqual([
+                '/frigg/app/OWNED_KEY',
+            ]);
+        });
+
+        it('keeps stale values and does not throw when a TTL refresh fails', async () => {
+            process.env.FRIGG_SSM_CACHE_TTL = '60';
+            setParamStore({ '/frigg/app/OWNED_KEY': { value: 'v1' } });
+            await parametersToEnv();
+            expect(process.env.OWNED_KEY).toBe('v1');
+
+            clock += 61 * 1000;
+            ssmMock
+                .on(GetParametersCommand)
+                .rejects(new Error('ssm outage'));
+            const warnSpy = jest
+                .spyOn(console, 'warn')
+                .mockImplementation(() => {});
+
+            await expect(parametersToEnv()).resolves.toBeUndefined();
+            expect(process.env.OWNED_KEY).toBe('v1');
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('refresh failed')
+            );
+
+            // backs off instead of re-attempting on every invocation
+            const callsAfterFailure = ssmMock.commandCalls(
+                GetParametersCommand
+            ).length;
+            clock += 1000;
+            await parametersToEnv();
+            expect(
+                ssmMock.commandCalls(GetParametersCommand)
+            ).toHaveLength(callsAfterFailure);
+        });
+
+        it('still fails the initial load when SSM is unavailable', async () => {
+            ssmMock
+                .on(GetParametersCommand)
+                .rejects(new Error('ssm outage'));
+
+            await expect(parametersToEnv()).rejects.toThrow('ssm outage');
+        });
+
+        it('defaults the TTL to 300 seconds when unset', async () => {
+            setParamStore({ '/frigg/app/OWNED_KEY': { value: 'v1' } });
+
+            await parametersToEnv();
+            clock += 299 * 1000;
+            await parametersToEnv();
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(1);
+
+            clock += 2 * 1000;
+            await parametersToEnv();
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(2);
+        });
+    });
+
+    describe('concurrency', () => {
+        it('shares a single in-flight promise across concurrent callers', async () => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'OWNED_KEY';
+            setParamStore({ '/frigg/app/OWNED_KEY': { value: 'v1' } });
+
+            await Promise.all([parametersToEnv(), parametersToEnv()]);
+
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(1);
+        });
+    });
+
+    describe('fail-fast on missing parameters', () => {
+        it('throws listing every missing parameter name and the prefix', async () => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS =
+                'PRESENT,MISSING_ONE,MISSING_TWO';
+            setParamStore({ '/frigg/app/PRESENT': { value: 'ok' } });
+
+            await expect(parametersToEnv()).rejects.toThrow(
+                /\/frigg\/app\/MISSING_ONE/
+            );
+
+            _resetCache();
+            setParamStore({ '/frigg/app/PRESENT': { value: 'ok' } });
+            let error;
+            try {
+                await parametersToEnv();
+            } catch (err) {
+                error = err;
+            }
+            expect(error.message).toContain('/frigg/app/MISSING_ONE');
+            expect(error.message).toContain('/frigg/app/MISSING_TWO');
+            expect(error.message).toContain('/frigg/app');
+        });
+
+        it('does not fail for a key already satisfied by real env even if absent in SSM', async () => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'REAL_KEY,OWNED_KEY';
+            process.env.REAL_KEY = 'from-real-env';
+            setParamStore({ '/frigg/app/OWNED_KEY': { value: 'ssm-owned' } });
+
+            await expect(parametersToEnv()).resolves.not.toThrow();
+            expect(process.env.OWNED_KEY).toBe('ssm-owned');
+        });
+    });
+
+    describe('failure is not cached', () => {
+        it('retries on the next invocation after a failed fetch', async () => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'OWNED_KEY';
+
+            ssmMock
+                .on(GetParametersCommand)
+                .rejectsOnce(new Error('transient network error'))
+                .callsFake(() => ({
+                    Parameters: [
+                        {
+                            Name: '/frigg/app/OWNED_KEY',
+                            Value: 'recovered',
+                            Version: 1,
+                        },
+                    ],
+                    InvalidParameters: [],
+                }));
+
+            await expect(parametersToEnv()).rejects.toThrow(
+                'transient network error'
+            );
+
+            await parametersToEnv();
+            expect(process.env.OWNED_KEY).toBe('recovered');
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(2);
+        });
+    });
+
+    describe('throttling', () => {
+        beforeEach(() => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'OWNED_KEY';
+        });
+
+        it('retries a throttled batch and eventually succeeds', async () => {
+            const throttle = Object.assign(new Error('Rate exceeded'), {
+                name: 'ThrottlingException',
+            });
+            ssmMock
+                .on(GetParametersCommand)
+                .rejectsOnce(throttle)
+                .rejectsOnce(throttle)
+                .callsFake(() => ({
+                    Parameters: [
+                        {
+                            Name: '/frigg/app/OWNED_KEY',
+                            Value: 'v1',
+                            Version: 1,
+                        },
+                    ],
+                    InvalidParameters: [],
+                }));
+
+            await parametersToEnv();
+
+            expect(process.env.OWNED_KEY).toBe('v1');
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(3);
+        });
+
+        it('propagates non-throttling errors immediately without retry', async () => {
+            ssmMock.on(GetParametersCommand).rejects(new Error('AccessDenied'));
+
+            await expect(parametersToEnv()).rejects.toThrow('AccessDenied');
+            expect(ssmMock.commandCalls(GetParametersCommand)).toHaveLength(1);
+        });
+    });
+
+    describe('logging', () => {
+        it('logs parameter names and versions on success, never values', async () => {
+            process.env.SSM_PARAMETER_PREFIX = '/frigg/app';
+            process.env.FRIGG_SSM_OFFLOADED_KEYS = 'OWNED_KEY';
+            setParamStore({
+                '/frigg/app/OWNED_KEY': {
+                    value: 'super-secret-value',
+                    version: 7,
+                },
+            });
+
+            const logSpy = jest
+                .spyOn(console, 'log')
+                .mockImplementation(() => {});
+
+            await parametersToEnv();
+
+            expect(logSpy).toHaveBeenCalledWith(
+                'parametersToEnv: loaded',
+                expect.arrayContaining([
+                    expect.stringContaining('/frigg/app/OWNED_KEY'),
+                ])
+            );
+            const logged = JSON.stringify(logSpy.mock.calls);
+            expect(logged).toContain('7');
+            expect(logged).not.toContain('super-secret-value');
+        });
+    });
+});

--- a/packages/core/core/parameters-to-env.test.js
+++ b/packages/core/core/parameters-to-env.test.js
@@ -420,4 +420,50 @@ describe('parametersToEnv - SSM Parameter Store loader', () => {
             expect(logged).not.toContain('super-secret-value');
         });
     });
+
+    describe('fetchOffloadedParameters (shared with the INIT preload)', () => {
+        const { fetchOffloadedParameters } = require('./parameters-to-env');
+
+        it('returns a { key: value } map for the requested keys', async () => {
+            setParamStore({
+                '/frigg/app/A': { value: 'va' },
+                '/frigg/app/B': { value: 'vb' },
+            });
+
+            const values = await fetchOffloadedParameters('/frigg/app', [
+                'A',
+                'B',
+            ]);
+            expect(values).toEqual({ A: 'va', B: 'vb' });
+        });
+
+        it('batches more than 10 keys into multiple GetParameters calls', async () => {
+            const keys = Array.from({ length: 23 }, (_, i) => `K${i}`);
+            const store = {};
+            for (const k of keys) store[`/frigg/app/${k}`] = { value: k };
+            setParamStore(store);
+
+            const values = await fetchOffloadedParameters('/frigg/app', keys);
+            expect(Object.keys(values)).toHaveLength(23);
+            expect(
+                ssmMock.commandCalls(GetParametersCommand)
+            ).toHaveLength(3);
+        });
+
+        it('throws listing every missing parameter name', async () => {
+            setParamStore({ '/frigg/app/A': { value: 'va' } });
+
+            await expect(
+                fetchOffloadedParameters('/frigg/app', ['A', 'B', 'C'])
+            ).rejects.toThrow(/\/frigg\/app\/B.*\/frigg\/app\/C/s);
+        });
+
+        it('does not mutate process.env (fetch-only)', async () => {
+            setParamStore({ '/frigg/app/A': { value: 'va' } });
+            delete process.env.A;
+
+            await fetchOffloadedParameters('/frigg/app', ['A']);
+            expect(process.env.A).toBeUndefined();
+        });
+    });
 });

--- a/packages/core/core/ssm-preload.mjs
+++ b/packages/core/core/ssm-preload.mjs
@@ -25,15 +25,23 @@ if (prefix && rawKeys) {
         .filter(Boolean);
 
     if (keys.length > 0) {
-        const { fetchOffloadedParameters } = require('./parameters-to-env');
+        const {
+            fetchOffloadedParameters,
+            adoptPreloadedKeys,
+        } = require('./parameters-to-env');
         const values = await fetchOffloadedParameters(prefix, keys);
 
         // Real env vars win over SSM (console-override debugging escape hatch).
+        const setKeys = [];
         for (const [key, value] of Object.entries(values)) {
             if (process.env[key] === undefined) {
                 process.env[key] = value;
+                setKeys.push(key);
             }
         }
-        console.log(`frigg-ssm-preload: loaded ${keys.length} parameter(s) at INIT under ${prefix}`);
+        // Hand the keys we set to the handler-time loader (same in-process
+        // module singleton) so its TTL-refresh path re-fetches them.
+        adoptPreloadedKeys(setKeys);
+        console.log(`frigg-ssm-preload: loaded ${setKeys.length} parameter(s) at INIT under ${prefix}`);
     }
 }

--- a/packages/core/core/ssm-preload.mjs
+++ b/packages/core/core/ssm-preload.mjs
@@ -25,23 +25,10 @@ if (prefix && rawKeys) {
         .filter(Boolean);
 
     if (keys.length > 0) {
-        const {
-            fetchOffloadedParameters,
-            adoptPreloadedKeys,
-        } = require('./parameters-to-env');
-        const values = await fetchOffloadedParameters(prefix, keys);
-
-        // Real env vars win over SSM (console-override debugging escape hatch).
-        const setKeys = [];
-        for (const [key, value] of Object.entries(values)) {
-            if (process.env[key] === undefined) {
-                process.env[key] = value;
-                setKeys.push(key);
-            }
-        }
-        // Hand the keys we set to the handler-time loader (same in-process
-        // module singleton) so its TTL-refresh path re-fetches them.
-        adoptPreloadedKeys(setKeys);
+        // The fetch/real-env-wins/adopt logic lives in the CJS module (tested
+        // there); this preload is a thin INIT-phase shim over it.
+        const { preloadOffloadedParameters } = require('./parameters-to-env');
+        const setKeys = await preloadOffloadedParameters(prefix, keys);
         console.log(`frigg-ssm-preload: loaded ${setKeys.length} parameter(s) at INIT under ${prefix}`);
     }
 }

--- a/packages/core/core/ssm-preload.mjs
+++ b/packages/core/core/ssm-preload.mjs
@@ -1,0 +1,39 @@
+// INIT-phase SSM loader (ADR-027).
+//
+// Loaded via NODE_OPTIONS=--import BEFORE the Lambda handler and any api-module
+// is required, so SSM-offloaded values are present in process.env at
+// module-load time — when api-modules capture their OAuth client credentials
+// in a top-level `const Definition = { env: { client_secret: process.env.X } }`.
+// The runtime loader (parameters-to-env.js) runs inside the handler, which is
+// too late for those module-load reads; this preload closes that gap.
+//
+// Top-level await here is awaited by Node before the entry module loads, so the
+// fetch completes first. A fetch failure rejects the preload, failing Lambda
+// INIT loudly (fail-fast) rather than starting with undefined credentials.
+
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+const prefix = process.env.SSM_PARAMETER_PREFIX;
+const rawKeys = process.env.FRIGG_SSM_OFFLOADED_KEYS;
+
+if (prefix && rawKeys) {
+    const keys = rawKeys
+        .split(',')
+        .map((key) => key.trim())
+        .filter(Boolean);
+
+    if (keys.length > 0) {
+        const { fetchOffloadedParameters } = require('./parameters-to-env');
+        const values = await fetchOffloadedParameters(prefix, keys);
+
+        // Real env vars win over SSM (console-override debugging escape hatch).
+        for (const [key, value] of Object.entries(values)) {
+            if (process.env[key] === undefined) {
+                process.env[key] = value;
+            }
+        }
+        console.log(`frigg-ssm-preload: loaded ${keys.length} parameter(s) at INIT under ${prefix}`);
+    }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
         "@aws-sdk/client-sqs": "^3.588.0",
         "@aws-sdk/client-kms": "^3.588.0",
         "@aws-sdk/client-lambda": "^3.714.0",
+        "@aws-sdk/client-ssm": "^3.588.0",
         "@aws-sdk/client-apigatewaymanagementapi": "^3.588.0",
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.20.5",

--- a/packages/devtools/frigg-cli/__tests__/unit/commands/generate-iam.test.js
+++ b/packages/devtools/frigg-cli/__tests__/unit/commands/generate-iam.test.js
@@ -1,0 +1,97 @@
+/**
+ * Test suite for generate-iam command
+ *
+ * Drives generateIamCommand end-to-end (real getFeatureSummary +
+ * generateIAMCloudFormation) to verify appDefinition.ssm.kmsKeyArn
+ * actually reaches the generated CloudFormation template. A unit test
+ * that hand-supplies ssmKmsKeyArn straight to generateIAMCloudFormation
+ * would not catch a caller that forgets to thread it through.
+ */
+
+jest.mock('fs-extra');
+jest.mock('@friggframework/core', () => ({
+    findNearestBackendPackageJson: jest.fn()
+}));
+
+const path = require('path');
+const fs = require('fs-extra');
+const { findNearestBackendPackageJson } = require('@friggframework/core');
+const { generateIamCommand } = require('../../../generate-iam-command');
+
+describe('CLI Command: generate-iam', () => {
+    const mockBackendPath = '/mock/backend/package.json';
+    const mockBackendDir = '/mock/backend';
+    const mockAppDefinitionPath = path.join(mockBackendDir, 'index.js');
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+
+        jest.spyOn(process, 'exit').mockImplementation(() => {});
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        findNearestBackendPackageJson.mockReturnValue(mockBackendPath);
+
+        fs.existsSync = jest.fn().mockReturnValue(true);
+        fs.ensureDir = jest.fn().mockResolvedValue();
+        fs.writeFile = jest.fn().mockResolvedValue();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.dontMock(mockAppDefinitionPath);
+    });
+
+    it('scopes the SSM-mediated KMS grant to ssm.kmsKeyArn when configured', async () => {
+        const mockAppDefinition = {
+            name: 'test-app',
+            ssm: {
+                enable: true,
+                kmsKeyArn:
+                    'arn:aws:kms:us-east-1:123456789012:key/abcd-1234'
+            }
+        };
+
+        jest.doMock(
+            mockAppDefinitionPath,
+            () => ({ Definition: mockAppDefinition }),
+            { virtual: true }
+        );
+
+        await generateIamCommand({});
+
+        expect(fs.writeFile).toHaveBeenCalled();
+        const [, generatedYaml] = fs.writeFile.mock.calls[0];
+
+        expect(generatedYaml).toContain('FriggSSMParameterKMSEncryption');
+        expect(generatedYaml).toContain(
+            'arn:aws:kms:us-east-1:123456789012:key/abcd-1234'
+        );
+        expect(generatedYaml).not.toContain(
+            'arn:aws:kms:*:${AWS::AccountId}:key/*'
+        );
+    });
+
+    it('falls back to the account-wide KMS wildcard when ssm.kmsKeyArn is not set', async () => {
+        const mockAppDefinition = {
+            name: 'test-app',
+            ssm: { enable: true }
+        };
+
+        jest.doMock(
+            mockAppDefinitionPath,
+            () => ({ Definition: mockAppDefinition }),
+            { virtual: true }
+        );
+
+        await generateIamCommand({});
+
+        expect(fs.writeFile).toHaveBeenCalled();
+        const [, generatedYaml] = fs.writeFile.mock.calls[0];
+
+        expect(generatedYaml).toContain(
+            'arn:aws:kms:*:${AWS::AccountId}:key/*'
+        );
+    });
+});

--- a/packages/devtools/frigg-cli/deploy-command/index.js
+++ b/packages/devtools/frigg-cli/deploy-command/index.js
@@ -293,7 +293,18 @@ async function pushOffloadedParametersOrAbort(appDefinition, options) {
         console.log(`   ✓ ${pushed.length} parameter(s) up to date`);
     } catch (error) {
         console.error(`\n✗ SSM parameter push failed: ${error.message}`);
-        console.error('   Deployment aborted — no resources were changed.');
+        const pushedBeforeFailure = error.pushed || [];
+        if (pushedBeforeFailure.length === 0) {
+            console.error('   Deployment aborted — no parameters were changed.');
+        } else {
+            const names = pushedBeforeFailure.map((p) => p.name).join(', ');
+            console.error(
+                `   Deployment aborted, but ${pushedBeforeFailure.length} parameter(s) were already pushed and are now live in Parameter Store: ${names}`
+            );
+            console.error(
+                '   Those values will take effect on old Lambda code at its next SSM cache TTL refresh. Redeploy soon so the running code matches.'
+            );
+        }
         process.exit(1);
     }
 }

--- a/packages/devtools/frigg-cli/deploy-command/index.js
+++ b/packages/devtools/frigg-cli/deploy-command/index.js
@@ -267,11 +267,44 @@ async function runPostDeploymentHealthCheck(stackName, options) {
     }
 }
 
+/**
+ * Push SSM-offloaded parameters before deploying so they exist before new
+ * code cold-starts (ADR-027). A push failure aborts the deploy: shipping
+ * code whose parameters are missing would fail every cold start anyway.
+ */
+async function pushOffloadedParametersOrAbort(appDefinition, options) {
+    const {
+        getOffloadedKeys,
+    } = require('../../infrastructure/domains/parameters/offload-utils');
+    if (!appDefinition || getOffloadedKeys(appDefinition).length === 0) {
+        return;
+    }
+
+    require('dotenv').config();
+    const { pushOffloadedParameters } = require('../ssm-command');
+
+    console.log('🔒 Pushing SSM-offloaded parameters before deploy...');
+    try {
+        const { pushed } = await pushOffloadedParameters(
+            appDefinition,
+            options.stage,
+            options
+        );
+        console.log(`   ✓ ${pushed.length} parameter(s) up to date`);
+    } catch (error) {
+        console.error(`\n✗ SSM parameter push failed: ${error.message}`);
+        console.error('   Deployment aborted — no resources were changed.');
+        process.exit(1);
+    }
+}
+
 async function deployCommand(options) {
     console.log('Deploying the serverless application...');
 
     const appDefinition = loadAppDefinition();
     const environment = validateAndBuildEnvironment(appDefinition, options);
+
+    await pushOffloadedParametersOrAbort(appDefinition, options);
 
     // Execute deployment
     const exitCode = await executeServerlessDeployment(environment, options);

--- a/packages/devtools/frigg-cli/generate-command/index.js
+++ b/packages/devtools/frigg-cli/generate-command/index.js
@@ -120,7 +120,8 @@ async function generateCommand(options = {}) {
                     appName,
                     features,
                     userPrefix: options.user || 'frigg-deployment-user',
-                    stackName: options.stackName || 'frigg-deployment-iam'
+                    stackName: options.stackName || 'frigg-deployment-iam',
+                    ssmKmsKeyArn: appDefinition.ssm?.kmsKeyArn
                 });
                 fileExtension = 'yaml';
                 deploymentInstructions = generateCloudFormationInstructions(options);

--- a/packages/devtools/frigg-cli/generate-iam-command.js
+++ b/packages/devtools/frigg-cli/generate-iam-command.js
@@ -64,7 +64,8 @@ async function generateIamCommand(options = {}) {
             appName: summary.appName,
             features: summary.features,
             userPrefix: deploymentUserName,
-            stackName
+            stackName,
+            ssmKmsKeyArn: summary.ssmKmsKeyArn
         });
 
         // Determine output file path

--- a/packages/devtools/frigg-cli/index.js
+++ b/packages/devtools/frigg-cli/index.js
@@ -179,8 +179,9 @@ ssmProgram
     .command('push')
     .description('Push SSM-offloaded environment values to Parameter Store')
     .option('-s, --stage <stage>', 'deployment stage', 'dev')
+    .option('-r, --region <region>', 'AWS region (defaults to AWS_REGION env var or us-east-1)')
     .option('--allow-empty', 'skip (instead of fail on) keys with missing or empty values')
-    .option('--tier <tier>', 'parameter tier: standard (4KB values) or advanced (8KB, billed)', 'standard')
+    .option('--tier <tier>', 'override tier for all keys: standard (4KB values) or advanced (8KB, billed)')
     .action(ssmPushCommand);
 
 // Auth command group for testing API module authentication

--- a/packages/devtools/frigg-cli/index.js
+++ b/packages/devtools/frigg-cli/index.js
@@ -220,4 +220,4 @@ authProgram
 
 program.parse(process.argv);
 
-module.exports = { initCommand, installCommand, startCommand, buildCommand, deployCommand, generateIamCommand, uiCommand, dbSetupCommand, doctorCommand, repairCommand, authCommand };
+module.exports = { initCommand, installCommand, startCommand, buildCommand, deployCommand, generateIamCommand, uiCommand, dbSetupCommand, doctorCommand, repairCommand, authCommand, ssmPushCommand };

--- a/packages/devtools/frigg-cli/index.js
+++ b/packages/devtools/frigg-cli/index.js
@@ -86,6 +86,7 @@ const { dbSetupCommand } = require('./db-setup-command');
 const { doctorCommand } = require('./doctor-command');
 const { repairCommand } = require('./repair-command');
 const { authCommand } = require('./auth-command');
+const { ssmPushCommand } = require('./ssm-command');
 
 const program = new Command();
 
@@ -168,6 +169,19 @@ program
     .option('-y, --yes', 'skip confirmation prompts')
     .option('-v, --verbose', 'enable verbose output')
     .action(repairCommand);
+
+// SSM command group for the parameter offload feature (ADR-027)
+const ssmProgram = program
+    .command('ssm')
+    .description('Manage SSM Parameter Store offloaded configuration');
+
+ssmProgram
+    .command('push')
+    .description('Push SSM-offloaded environment values to Parameter Store')
+    .option('-s, --stage <stage>', 'deployment stage', 'dev')
+    .option('--allow-empty', 'skip (instead of fail on) keys with missing or empty values')
+    .option('--tier <tier>', 'parameter tier: standard (4KB values) or advanced (8KB, billed)', 'standard')
+    .action(ssmPushCommand);
 
 // Auth command group for testing API module authentication
 const authProgram = program

--- a/packages/devtools/frigg-cli/ssm-command/index.js
+++ b/packages/devtools/frigg-cli/ssm-command/index.js
@@ -163,20 +163,58 @@ async function pushOffloadedParameters(appDefinition, stage, options = {}) {
         options
     );
 
-    for (const key of skipped) {
-        console.warn(
-            `⚠️  Skipping ${key}: no value in the environment (--allow-empty)`
+    if (specs.length === 0 && skipped.length === 0) {
+        return { pushed: [], skipped };
+    }
+
+    const {
+        SSMClient,
+        PutParameterCommand,
+        GetParametersCommand,
+    } = require('@aws-sdk/client-ssm');
+    const client = new SSMClient({
+        region: resolvePushRegion(options),
+    });
+
+    // --allow-empty only rotates keys that already exist. A skipped key still
+    // ships in FRIGG_SSM_OFFLOADED_KEYS, so if its parameter does not exist the
+    // runtime fails fast at cold start on every function — a green deploy that
+    // bricks the fleet. Verify existence and abort instead.
+    if (skipped.length > 0) {
+        const prefix = resolveParameterPrefix(appDefinition, stage);
+        const names = skipped.map((key) => `${prefix}/${key}`);
+        const existing = new Set();
+        for (let i = 0; i < names.length; i += 10) {
+            const { Parameters = [] } = await client.send(
+                new GetParametersCommand({ Names: names.slice(i, i + 10) })
+            );
+            for (const param of Parameters) {
+                existing.add(param.Name);
+            }
+        }
+        const orphaned = skipped.filter(
+            (key) => !existing.has(`${prefix}/${key}`)
         );
+        if (orphaned.length > 0) {
+            throw new Error(
+                `--allow-empty skipped ${orphaned.join(
+                    ', '
+                )}, but no such parameter exists in Parameter Store. --allow-empty ` +
+                    `only rotates keys that already have a value; a skipped key with no ` +
+                    `parameter stays in FRIGG_SSM_OFFLOADED_KEYS and fails every function ` +
+                    `at cold start. Set a value and push without --allow-empty.`
+            );
+        }
+        for (const key of skipped) {
+            console.warn(
+                `⚠️  Skipping ${key}: no value in the environment; keeping the existing Parameter Store value (--allow-empty)`
+            );
+        }
     }
 
     if (specs.length === 0) {
         return { pushed: [], skipped };
     }
-
-    const { SSMClient, PutParameterCommand } = require('@aws-sdk/client-ssm');
-    const client = new SSMClient({
-        region: resolvePushRegion(options),
-    });
 
     const pushed = [];
     for (const spec of specs) {

--- a/packages/devtools/frigg-cli/ssm-command/index.js
+++ b/packages/devtools/frigg-cli/ssm-command/index.js
@@ -21,9 +21,28 @@ const TIER_LIMITS = {
 };
 
 /**
+ * Resolve the tier for a single offloaded key. An explicit `--tier` CLI
+ * option overrides every key; otherwise each key uses its own
+ * ssm.parameters[KEY].tier, defaulting to 'standard'.
+ */
+function resolveKeyTier(appDefinition, key, options = {}) {
+    const raw =
+        options.tier ||
+        appDefinition.ssm?.parameters?.[key]?.tier ||
+        'standard';
+    const tier = String(raw).toLowerCase();
+    if (!TIER_LIMITS[tier]) {
+        throw new Error(
+            `Unknown parameter tier '${raw}' for ${key}. Use 'standard' or 'advanced'.`
+        );
+    }
+    return tier;
+}
+
+/**
  * Build the PutParameter specs for every offloaded key, reading values
  * from process.env. Throws on invalid config, missing values (unless
- * allowEmpty), or oversized values.
+ * allowEmpty), or values that exceed their own tier limit.
  */
 function collectParameterSpecs(appDefinition, stage, options = {}) {
     const { errors: configErrors } = validateOffloadConfig(appDefinition);
@@ -38,14 +57,6 @@ function collectParameterSpecs(appDefinition, stage, options = {}) {
     const keys = getOffloadedKeys(appDefinition);
     if (keys.length === 0) {
         return { specs: [], skipped: [] };
-    }
-
-    const tier = (options.tier || 'standard').toLowerCase();
-    const maxBytes = TIER_LIMITS[tier];
-    if (!maxBytes) {
-        throw new Error(
-            `Unknown parameter tier '${options.tier}'. Use 'standard' or 'advanced'.`
-        );
     }
 
     const prefix = resolveParameterPrefix(appDefinition, stage);
@@ -66,9 +77,13 @@ function collectParameterSpecs(appDefinition, stage, options = {}) {
             continue;
         }
 
+        const tier = resolveKeyTier(appDefinition, key, options);
+        const maxBytes = TIER_LIMITS[tier];
         const bytes = Buffer.byteLength(value, 'utf8');
         if (bytes > maxBytes) {
-            oversized.push(`${key} (${bytes} bytes)`);
+            oversized.push(
+                `${key} (${bytes} bytes > ${tier} tier limit ${maxBytes})`
+            );
             continue;
         }
 
@@ -90,18 +105,24 @@ function collectParameterSpecs(appDefinition, stage, options = {}) {
     }
 
     if (oversized.length > 0) {
-        const hint =
-            tier === 'standard'
-                ? ` Values over ${TIER_LIMITS.standard} bytes need --tier advanced (up to ${TIER_LIMITS.advanced} bytes, billed by AWS).`
-                : ` The advanced tier caps values at ${TIER_LIMITS.advanced} bytes.`;
         throw new Error(
-            `Offloaded values exceed the ${tier} parameter tier limit: ${oversized.join(
+            `Offloaded values exceed their parameter tier limit: ${oversized.join(
                 ', '
-            )}.${hint}`
+            )}. Values over ${TIER_LIMITS.standard} bytes need the advanced tier (up to ${TIER_LIMITS.advanced} bytes, billed by AWS): set ssm.parameters.<KEY>.tier: 'advanced' in the app definition, or pass --tier advanced to 'frigg ssm push'.`
         );
     }
 
     return { specs, skipped };
+}
+
+/**
+ * Resolve the region parameters are pushed to. An explicit `--region`
+ * option wins; otherwise fall back to AWS_REGION and finally to the same
+ * default the composed stack uses ('us-east-1'), so pushes and cold-start
+ * reads always target the same region.
+ */
+function resolvePushRegion(options = {}) {
+    return options.region || process.env.AWS_REGION || 'us-east-1';
 }
 
 /**
@@ -127,7 +148,7 @@ async function pushOffloadedParameters(appDefinition, stage, options = {}) {
 
     const { SSMClient, PutParameterCommand } = require('@aws-sdk/client-ssm');
     const client = new SSMClient({
-        region: process.env.AWS_REGION || options.region,
+        region: resolvePushRegion(options),
     });
 
     const pushed = [];
@@ -212,4 +233,5 @@ module.exports = {
     ssmPushCommand,
     pushOffloadedParameters,
     collectParameterSpecs,
+    resolvePushRegion,
 };

--- a/packages/devtools/frigg-cli/ssm-command/index.js
+++ b/packages/devtools/frigg-cli/ssm-command/index.js
@@ -1,0 +1,215 @@
+/**
+ * frigg ssm push
+ *
+ * Writes SSM-offloaded environment values (see ADR-027) from the CLI
+ * process environment into Parameter Store. Runs automatically before
+ * `frigg deploy` so parameters exist before new code cold-starts; also
+ * available standalone to rotate values without deploying.
+ */
+
+const path = require('path');
+const dotenv = require('dotenv');
+const {
+    getOffloadedKeys,
+    resolveParameterPrefix,
+    validateOffloadConfig,
+} = require('../../infrastructure/domains/parameters/offload-utils');
+
+const TIER_LIMITS = {
+    standard: 4096,
+    advanced: 8192,
+};
+
+/**
+ * Build the PutParameter specs for every offloaded key, reading values
+ * from process.env. Throws on invalid config, missing values (unless
+ * allowEmpty), or oversized values.
+ */
+function collectParameterSpecs(appDefinition, stage, options = {}) {
+    const { errors: configErrors } = validateOffloadConfig(appDefinition);
+    if (configErrors.length > 0) {
+        throw new Error(
+            `Invalid SSM offload configuration:\n  - ${configErrors.join(
+                '\n  - '
+            )}`
+        );
+    }
+
+    const keys = getOffloadedKeys(appDefinition);
+    if (keys.length === 0) {
+        return { specs: [], skipped: [] };
+    }
+
+    const tier = (options.tier || 'standard').toLowerCase();
+    const maxBytes = TIER_LIMITS[tier];
+    if (!maxBytes) {
+        throw new Error(
+            `Unknown parameter tier '${options.tier}'. Use 'standard' or 'advanced'.`
+        );
+    }
+
+    const prefix = resolveParameterPrefix(appDefinition, stage);
+    const specs = [];
+    const skipped = [];
+    const missing = [];
+    const oversized = [];
+
+    for (const key of keys) {
+        const value = process.env[key];
+
+        if (value === undefined || value === '') {
+            if (options.allowEmpty) {
+                skipped.push(key);
+            } else {
+                missing.push(key);
+            }
+            continue;
+        }
+
+        const bytes = Buffer.byteLength(value, 'utf8');
+        if (bytes > maxBytes) {
+            oversized.push(`${key} (${bytes} bytes)`);
+            continue;
+        }
+
+        specs.push({
+            key,
+            name: `${prefix}/${key}`,
+            value,
+            type: appDefinition.ssm?.parameters?.[key]?.type || 'String',
+            tier,
+        });
+    }
+
+    if (missing.length > 0) {
+        throw new Error(
+            `Missing or empty values for offloaded keys: ${missing.join(
+                ', '
+            )}. Set them in the environment (or .env) before pushing, or pass --allow-empty to skip them.`
+        );
+    }
+
+    if (oversized.length > 0) {
+        const hint =
+            tier === 'standard'
+                ? ` Values over ${TIER_LIMITS.standard} bytes need --tier advanced (up to ${TIER_LIMITS.advanced} bytes, billed by AWS).`
+                : ` The advanced tier caps values at ${TIER_LIMITS.advanced} bytes.`;
+        throw new Error(
+            `Offloaded values exceed the ${tier} parameter tier limit: ${oversized.join(
+                ', '
+            )}.${hint}`
+        );
+    }
+
+    return { specs, skipped };
+}
+
+/**
+ * Push all offloaded parameters for an app definition. Silent no-op when
+ * the offload set is empty. Returns { pushed, skipped }.
+ */
+async function pushOffloadedParameters(appDefinition, stage, options = {}) {
+    const { specs, skipped } = collectParameterSpecs(
+        appDefinition,
+        stage,
+        options
+    );
+
+    for (const key of skipped) {
+        console.warn(
+            `⚠️  Skipping ${key}: no value in the environment (--allow-empty)`
+        );
+    }
+
+    if (specs.length === 0) {
+        return { pushed: [], skipped };
+    }
+
+    const { SSMClient, PutParameterCommand } = require('@aws-sdk/client-ssm');
+    const client = new SSMClient({
+        region: process.env.AWS_REGION || options.region,
+    });
+
+    const pushed = [];
+    for (const spec of specs) {
+        const input = {
+            Name: spec.name,
+            Value: spec.value,
+            Type: spec.type,
+            Overwrite: true,
+        };
+        if (spec.tier === 'advanced') {
+            input.Tier = 'Advanced';
+        }
+        if (spec.type === 'SecureString' && appDefinition.ssm?.kmsKeyArn) {
+            input.KeyId = appDefinition.ssm.kmsKeyArn;
+        }
+
+        try {
+            const result = await client.send(new PutParameterCommand(input));
+            pushed.push({ name: spec.name, version: result.Version });
+            console.log(
+                `   ✅ ${spec.name} (${spec.type}, v${result.Version})`
+            );
+        } catch (error) {
+            throw new Error(
+                `Failed to push parameter ${spec.name} (${spec.key}): ${error.message}`
+            );
+        }
+    }
+
+    return { pushed, skipped };
+}
+
+function loadAppDefinition() {
+    const appDefPath = path.join(process.cwd(), 'index.js');
+    const { Definition } = require(appDefPath);
+    return Definition;
+}
+
+/**
+ * `frigg ssm push` command action.
+ */
+async function ssmPushCommand(options) {
+    dotenv.config();
+
+    let appDefinition;
+    try {
+        appDefinition = loadAppDefinition();
+    } catch (error) {
+        console.error(
+            `✗ Could not load the app definition from ${process.cwd()}/index.js: ${error.message}`
+        );
+        process.exit(1);
+    }
+
+    const keys = getOffloadedKeys(appDefinition);
+    if (keys.length === 0) {
+        console.log(
+            'No environment variables are marked for SSM offload — nothing to push.'
+        );
+        return;
+    }
+
+    console.log(
+        `🔒 Pushing ${keys.length} offloaded parameter(s) for stage '${options.stage}'...`
+    );
+
+    try {
+        const { pushed } = await pushOffloadedParameters(
+            appDefinition,
+            options.stage,
+            options
+        );
+        console.log(`✓ Pushed ${pushed.length} parameter(s)`);
+    } catch (error) {
+        console.error(`✗ ${error.message}`);
+        process.exit(1);
+    }
+}
+
+module.exports = {
+    ssmPushCommand,
+    pushOffloadedParameters,
+    collectParameterSpecs,
+};

--- a/packages/devtools/frigg-cli/ssm-command/index.js
+++ b/packages/devtools/frigg-cli/ssm-command/index.js
@@ -20,6 +20,33 @@ const TIER_LIMITS = {
     advanced: 8192,
 };
 
+const THROTTLE_BACKOFF_MS = [100, 200, 400];
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Send a PutParameterCommand, retrying ThrottlingException with short
+ * exponential backoff (mirrors sendWithRetry in core/parameters-to-env.js).
+ */
+async function putParameterWithRetry(client, PutParameterCommand, input) {
+    let attempt = 0;
+    for (;;) {
+        try {
+            return await client.send(new PutParameterCommand(input));
+        } catch (error) {
+            if (
+                error.name === 'ThrottlingException' &&
+                attempt < THROTTLE_BACKOFF_MS.length
+            ) {
+                await sleep(THROTTLE_BACKOFF_MS[attempt]);
+                attempt += 1;
+                continue;
+            }
+            throw error;
+        }
+    }
+}
+
 /**
  * Resolve the tier for a single offloaded key. An explicit `--tier` CLI
  * option overrides every key; otherwise each key uses its own
@@ -167,15 +194,21 @@ async function pushOffloadedParameters(appDefinition, stage, options = {}) {
         }
 
         try {
-            const result = await client.send(new PutParameterCommand(input));
+            const result = await putParameterWithRetry(
+                client,
+                PutParameterCommand,
+                input
+            );
             pushed.push({ name: spec.name, version: result.Version });
             console.log(
                 `   ✅ ${spec.name} (${spec.type}, v${result.Version})`
             );
         } catch (error) {
-            throw new Error(
+            const failure = new Error(
                 `Failed to push parameter ${spec.name} (${spec.key}): ${error.message}`
             );
+            failure.pushed = pushed;
+            throw failure;
         }
     }
 

--- a/packages/devtools/frigg-cli/ssm-command/index.test.js
+++ b/packages/devtools/frigg-cli/ssm-command/index.test.js
@@ -1,6 +1,6 @@
 const { mockClient } = require('aws-sdk-client-mock');
 const { SSMClient, PutParameterCommand } = require('@aws-sdk/client-ssm');
-const { pushOffloadedParameters } = require('./index');
+const { pushOffloadedParameters, resolvePushRegion } = require('./index');
 
 describe('ssm-command pushOffloadedParameters', () => {
     let ssmMock;
@@ -137,6 +137,62 @@ describe('ssm-command pushOffloadedParameters', () => {
         ).rejects.toThrow(/8192|8 ?KB/i);
     });
 
+    describe('per-key tier resolution', () => {
+        const withKeyTier = {
+            ...appDefinition,
+            ssm: {
+                ...appDefinition.ssm,
+                parameters: {
+                    MY_SECRET: { type: 'SecureString' },
+                    MY_CONFIG: { tier: 'advanced' },
+                },
+            },
+        };
+
+        it('accepts a large value when the key is configured advanced in the app definition', async () => {
+            process.env.MY_CONFIG = 'x'.repeat(4097);
+
+            await pushOffloadedParameters(withKeyTier, 'dev');
+
+            const config = ssmMock
+                .commandCalls(PutParameterCommand)
+                .map((c) => c.args[0].input)
+                .find((i) => i.Name.endsWith('/MY_CONFIG'));
+            expect(config.Tier).toBe('Advanced');
+        });
+
+        it('validates each key against its own configured tier', async () => {
+            // MY_CONFIG (advanced) tolerates 5000 bytes; MY_SECRET (standard) does not
+            process.env.MY_CONFIG = 'x'.repeat(5000);
+            process.env.MY_SECRET = 'y'.repeat(5000);
+
+            await expect(
+                pushOffloadedParameters(withKeyTier, 'dev')
+            ).rejects.toThrow(/MY_SECRET/);
+            expect(ssmMock.commandCalls(PutParameterCommand)).toHaveLength(0);
+        });
+
+        it('does not tag standard-tier keys with an Advanced tier', async () => {
+            await pushOffloadedParameters(withKeyTier, 'dev');
+
+            const secret = ssmMock
+                .commandCalls(PutParameterCommand)
+                .map((c) => c.args[0].input)
+                .find((i) => i.Name.endsWith('/MY_SECRET'));
+            expect(secret.Tier).toBeUndefined();
+        });
+
+        it('lets the --tier CLI option override per-key config for all keys', async () => {
+            process.env.MY_CONFIG = 'x'.repeat(4097);
+
+            await expect(
+                pushOffloadedParameters(withKeyTier, 'dev', {
+                    tier: 'standard',
+                })
+            ).rejects.toThrow(/advanced/i);
+        });
+    });
+
     it('throws on invalid offload config (markers without ssm.enable)', async () => {
         await expect(
             pushOffloadedParameters(
@@ -174,5 +230,24 @@ describe('ssm-command pushOffloadedParameters', () => {
                 '/team/x/MY_CONFIG',
             ])
         );
+    });
+
+    describe('resolvePushRegion', () => {
+        it('prefers an explicit --region option over the environment', () => {
+            process.env.AWS_REGION = 'us-west-2';
+            expect(resolvePushRegion({ region: 'eu-central-1' })).toBe(
+                'eu-central-1'
+            );
+        });
+
+        it('falls back to AWS_REGION when no option is given', () => {
+            process.env.AWS_REGION = 'us-west-2';
+            expect(resolvePushRegion({})).toBe('us-west-2');
+        });
+
+        it('defaults to us-east-1 when neither option nor AWS_REGION is set', () => {
+            delete process.env.AWS_REGION;
+            expect(resolvePushRegion({})).toBe('us-east-1');
+        });
     });
 });

--- a/packages/devtools/frigg-cli/ssm-command/index.test.js
+++ b/packages/devtools/frigg-cli/ssm-command/index.test.js
@@ -214,6 +214,54 @@ describe('ssm-command pushOffloadedParameters', () => {
         ).rejects.toThrow(/MY_SECRET/);
     });
 
+    it('retries a throttled PutParameter and succeeds', async () => {
+        const throttle = Object.assign(new Error('Rate exceeded'), {
+            name: 'ThrottlingException',
+        });
+        ssmMock
+            .on(PutParameterCommand, {
+                Name: '/frigg/my-app/dev/MY_SECRET',
+            })
+            .rejectsOnce(throttle)
+            .resolves({ Version: 2 });
+
+        const result = await pushOffloadedParameters(appDefinition, 'dev');
+
+        expect(result.pushed).toHaveLength(2);
+        const secretCalls = ssmMock
+            .commandCalls(PutParameterCommand)
+            .filter(
+                (c) => c.args[0].input.Name === '/frigg/my-app/dev/MY_SECRET'
+            );
+        expect(secretCalls).toHaveLength(2);
+    });
+
+    it('exposes keys pushed so far on a mid-batch failure', async () => {
+        // MY_CONFIG (sorted before MY_SECRET) succeeds; MY_SECRET fails.
+        ssmMock
+            .on(PutParameterCommand, {
+                Name: '/frigg/my-app/dev/MY_CONFIG',
+            })
+            .resolves({ Version: 1 });
+        ssmMock
+            .on(PutParameterCommand, {
+                Name: '/frigg/my-app/dev/MY_SECRET',
+            })
+            .rejects(new Error('boom'));
+
+        let caught;
+        try {
+            await pushOffloadedParameters(appDefinition, 'dev');
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toBeDefined();
+        expect(caught.pushed).toEqual([
+            { name: '/frigg/my-app/dev/MY_CONFIG', version: 1 },
+        ]);
+    });
+
     it('honors a custom parameterPrefix', async () => {
         const custom = {
             ...appDefinition,

--- a/packages/devtools/frigg-cli/ssm-command/index.test.js
+++ b/packages/devtools/frigg-cli/ssm-command/index.test.js
@@ -1,5 +1,9 @@
 const { mockClient } = require('aws-sdk-client-mock');
-const { SSMClient, PutParameterCommand } = require('@aws-sdk/client-ssm');
+const {
+    SSMClient,
+    PutParameterCommand,
+    GetParametersCommand,
+} = require('@aws-sdk/client-ssm');
 const { pushOffloadedParameters, resolvePushRegion } = require('./index');
 
 describe('ssm-command pushOffloadedParameters', () => {
@@ -95,14 +99,27 @@ describe('ssm-command pushOffloadedParameters', () => {
         expect(ssmMock.commandCalls(PutParameterCommand)).toHaveLength(0);
     });
 
-    it('skips missing values with allowEmpty instead of throwing', async () => {
+    it('skips missing values with allowEmpty when the parameter already exists', async () => {
         delete process.env.MY_SECRET;
+        ssmMock.on(GetParametersCommand).resolves({
+            Parameters: [{ Name: '/frigg/my-app/dev/MY_SECRET' }],
+        });
 
         const result = await pushOffloadedParameters(appDefinition, 'dev', {
             allowEmpty: true,
         });
         expect(result.skipped).toEqual(['MY_SECRET']);
         expect(ssmMock.commandCalls(PutParameterCommand)).toHaveLength(1);
+    });
+
+    it('aborts when allowEmpty skips a key that does not exist in Parameter Store', async () => {
+        delete process.env.MY_SECRET;
+        ssmMock.on(GetParametersCommand).resolves({ Parameters: [] });
+
+        await expect(
+            pushOffloadedParameters(appDefinition, 'dev', { allowEmpty: true })
+        ).rejects.toThrow(/MY_SECRET.*no such parameter|--allow-empty/s);
+        expect(ssmMock.commandCalls(PutParameterCommand)).toHaveLength(0);
     });
 
     it('rejects values over the standard tier limit and suggests advanced', async () => {

--- a/packages/devtools/frigg-cli/ssm-command/index.test.js
+++ b/packages/devtools/frigg-cli/ssm-command/index.test.js
@@ -1,0 +1,178 @@
+const { mockClient } = require('aws-sdk-client-mock');
+const { SSMClient, PutParameterCommand } = require('@aws-sdk/client-ssm');
+const { pushOffloadedParameters } = require('./index');
+
+describe('ssm-command pushOffloadedParameters', () => {
+    let ssmMock;
+    const originalEnv = process.env;
+
+    const appDefinition = {
+        name: 'my-app',
+        ssm: {
+            enable: true,
+            parameters: {
+                MY_SECRET: { type: 'SecureString' },
+            },
+        },
+        environment: {
+            MY_CONFIG: 'ssm',
+            PLAIN: true,
+        },
+    };
+
+    beforeEach(() => {
+        ssmMock = mockClient(SSMClient);
+        ssmMock.on(PutParameterCommand).resolves({ Version: 1 });
+        process.env = {
+            ...originalEnv,
+            MY_SECRET: 'shh',
+            MY_CONFIG: 'value-1',
+        };
+    });
+
+    afterEach(() => {
+        ssmMock.restore();
+        process.env = originalEnv;
+    });
+
+    it('pushes each offloaded key with resolved name, type, and overwrite', async () => {
+        const result = await pushOffloadedParameters(appDefinition, 'prod');
+
+        const calls = ssmMock.commandCalls(PutParameterCommand);
+        expect(calls).toHaveLength(2);
+
+        const byName = Object.fromEntries(
+            calls.map((c) => [c.args[0].input.Name, c.args[0].input])
+        );
+        expect(byName['/frigg/my-app/prod/MY_SECRET']).toMatchObject({
+            Value: 'shh',
+            Type: 'SecureString',
+            Overwrite: true,
+        });
+        expect(byName['/frigg/my-app/prod/MY_CONFIG']).toMatchObject({
+            Value: 'value-1',
+            Type: 'String',
+            Overwrite: true,
+        });
+        expect(result.pushed).toHaveLength(2);
+    });
+
+    it('passes KeyId for SecureString when ssm.kmsKeyArn is set', async () => {
+        const withKey = {
+            ...appDefinition,
+            ssm: {
+                ...appDefinition.ssm,
+                kmsKeyArn: 'arn:aws:kms:us-east-1:1:key/k',
+            },
+        };
+        await pushOffloadedParameters(withKey, 'dev');
+
+        const inputs = ssmMock
+            .commandCalls(PutParameterCommand)
+            .map((c) => c.args[0].input);
+        const secure = inputs.find((i) => i.Type === 'SecureString');
+        const plain = inputs.find((i) => i.Type === 'String');
+        expect(secure.KeyId).toBe('arn:aws:kms:us-east-1:1:key/k');
+        expect(plain.KeyId).toBeUndefined();
+    });
+
+    it('is a silent no-op when nothing is offloaded', async () => {
+        const result = await pushOffloadedParameters(
+            { name: 'x', environment: { PLAIN: true } },
+            'dev'
+        );
+        expect(result.pushed).toHaveLength(0);
+        expect(ssmMock.commandCalls(PutParameterCommand)).toHaveLength(0);
+    });
+
+    it('throws listing keys with missing or empty values', async () => {
+        delete process.env.MY_SECRET;
+        process.env.MY_CONFIG = '';
+
+        await expect(
+            pushOffloadedParameters(appDefinition, 'dev')
+        ).rejects.toThrow(/MY_SECRET.*MY_CONFIG|MY_CONFIG.*MY_SECRET/s);
+        expect(ssmMock.commandCalls(PutParameterCommand)).toHaveLength(0);
+    });
+
+    it('skips missing values with allowEmpty instead of throwing', async () => {
+        delete process.env.MY_SECRET;
+
+        const result = await pushOffloadedParameters(appDefinition, 'dev', {
+            allowEmpty: true,
+        });
+        expect(result.skipped).toEqual(['MY_SECRET']);
+        expect(ssmMock.commandCalls(PutParameterCommand)).toHaveLength(1);
+    });
+
+    it('rejects values over the standard tier limit and suggests advanced', async () => {
+        process.env.MY_CONFIG = 'x'.repeat(4097);
+
+        await expect(
+            pushOffloadedParameters(appDefinition, 'dev')
+        ).rejects.toThrow(/advanced/i);
+    });
+
+    it('accepts large values with the advanced tier', async () => {
+        process.env.MY_CONFIG = 'x'.repeat(4097);
+
+        await pushOffloadedParameters(appDefinition, 'dev', {
+            tier: 'advanced',
+        });
+        const inputs = ssmMock
+            .commandCalls(PutParameterCommand)
+            .map((c) => c.args[0].input);
+        expect(
+            inputs.find((i) => i.Name.endsWith('/MY_CONFIG')).Tier
+        ).toBe('Advanced');
+    });
+
+    it('rejects values over the advanced tier limit', async () => {
+        process.env.MY_CONFIG = 'x'.repeat(8193);
+
+        await expect(
+            pushOffloadedParameters(appDefinition, 'dev', {
+                tier: 'advanced',
+            })
+        ).rejects.toThrow(/8192|8 ?KB/i);
+    });
+
+    it('throws on invalid offload config (markers without ssm.enable)', async () => {
+        await expect(
+            pushOffloadedParameters(
+                { name: 'x', environment: { FOO: 'ssm' } },
+                'dev'
+            )
+        ).rejects.toThrow(/ssm\.enable/);
+    });
+
+    it('wraps AWS errors with the parameter name', async () => {
+        ssmMock
+            .on(PutParameterCommand, {
+                Name: '/frigg/my-app/dev/MY_SECRET',
+            })
+            .rejects(new Error('boom'));
+
+        await expect(
+            pushOffloadedParameters(appDefinition, 'dev')
+        ).rejects.toThrow(/MY_SECRET/);
+    });
+
+    it('honors a custom parameterPrefix', async () => {
+        const custom = {
+            ...appDefinition,
+            ssm: { ...appDefinition.ssm, parameterPrefix: '/team/x' },
+        };
+        await pushOffloadedParameters(custom, 'dev');
+
+        const names = ssmMock
+            .commandCalls(PutParameterCommand)
+            .map((c) => c.args[0].input.Name);
+        expect(names).toEqual(
+            expect.arrayContaining([
+                '/team/x/MY_SECRET',
+                '/team/x/MY_CONFIG',
+            ])
+        );
+    });
+});

--- a/packages/devtools/infrastructure/__tests__/helpers/test-utils.js
+++ b/packages/devtools/infrastructure/__tests__/helpers/test-utils.js
@@ -166,12 +166,10 @@ function verifyKmsConfiguration(config) {
  * @param {Object} config - Serverless configuration
  */
 function verifySsmConfiguration(config) {
-    expect(config.provider.layers).toEqual([
-        'arn:aws:lambda:${self:provider.region}:177933569100:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11'
-    ]);
-    expect(config.provider.environment.SSM_PARAMETER_PREFIX).toBe('/${self:service}/${self:provider.stage}');
+    // The framework does NOT use the AWS Parameters-and-Secrets extension layer
+    expect(config.provider.layers).toBeUndefined();
 
-    // Verify SSM IAM permissions
+    // Verify SSM IAM permissions (broad read grant added whenever SSM is enabled)
     const ssmPermission = config.provider.iamRoleStatements.find(
         statement => statement.Action.includes('ssm:GetParameter')
     );

--- a/packages/devtools/infrastructure/__tests__/scoped-environment.test.js
+++ b/packages/devtools/infrastructure/__tests__/scoped-environment.test.js
@@ -1,0 +1,126 @@
+/**
+ * End-to-end composer tests for per-function environment scoping
+ * (lambda.scopedEnvironment, ADR-027).
+ */
+
+const { composeServerlessDefinition } = require('../infrastructure-composer');
+
+jest.mock('../domains/shared/resource-discovery', () => {
+    const originalModule = jest.requireActual(
+        '../domains/shared/resource-discovery'
+    );
+    return {
+        ...originalModule,
+        gatherDiscoveredResources: jest.fn().mockResolvedValue({
+            defaultVpcId: 'vpc-123456',
+            defaultSecurityGroupId: 'sg-123456',
+            privateSubnetId1: 'subnet-123456',
+            privateSubnetId2: 'subnet-789012',
+            defaultKmsKeyId:
+                'arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012',
+            auroraClusterEndpoint:
+                'test-cluster.cluster-abc123.us-east-1.rds.amazonaws.com',
+            auroraPort: 5432,
+        }),
+    };
+});
+
+const buildApp = (overrides = {}) => ({
+    name: 'scoped-test-app',
+    provider: 'aws',
+    usePrismaLambdaLayer: false,
+    encryption: { fieldLevelEncryptionMethod: 'aes' },
+    vpc: { enable: false },
+    database: { postgres: { enable: true } },
+    adminScripts: [{ Definition: { name: 'fixThings' } }],
+    integrations: [
+        { Definition: { name: 'hubspot', webhooks: true } },
+        { Definition: { name: 'slack' } },
+    ],
+    ...overrides,
+});
+
+const SCOPED_VARS = [
+    'HUBSPOT_QUEUE_URL',
+    'SLACK_QUEUE_URL',
+    'SCHEDULER_ROLE_ARN',
+    'SCHEDULE_GROUP_NAME',
+    'S3_BUCKET_NAME',
+    'MIGRATION_STATUS_BUCKET',
+    'DB_MIGRATION_QUEUE_URL',
+    'ADMIN_SCRIPT_QUEUE_URL',
+];
+
+describe('lambda.scopedEnvironment composer e2e', () => {
+    beforeEach(() => {
+        process.argv = ['node', 'test'];
+        delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+    });
+
+    afterEach(() => {
+        delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+    });
+
+    it('removes scoped vars from provider.environment and lands them on exact consumer sets', async () => {
+        const definition = await composeServerlessDefinition(
+            buildApp({ lambda: { scopedEnvironment: true } })
+        );
+
+        for (const key of SCOPED_VARS) {
+            expect(definition.provider.environment[key]).toBeUndefined();
+        }
+        // DB_TYPE deliberately stays global
+        expect(definition.provider.environment.DB_TYPE).toBe('postgresql');
+
+        const env = (fnName) => definition.functions[fnName].environment || {};
+
+        // auth + admin functions can reach every integration queue
+        for (const fnName of [
+            'auth',
+            'adminScriptRouter',
+            'adminScriptExecutor',
+        ]) {
+            expect(env(fnName).HUBSPOT_QUEUE_URL).toBeDefined();
+            expect(env(fnName).SLACK_QUEUE_URL).toBeDefined();
+        }
+
+        // owning integration set, cross-integration isolation
+        expect(env('hubspot').HUBSPOT_QUEUE_URL).toBeDefined();
+        expect(env('hubspotWebhook').HUBSPOT_QUEUE_URL).toBeDefined();
+        expect(env('hubspotQueueWorker').HUBSPOT_QUEUE_URL).toBeDefined();
+        expect(env('hubspotQueueWorker').SLACK_QUEUE_URL).toBeUndefined();
+        expect(env('slackQueueWorker').HUBSPOT_QUEUE_URL).toBeUndefined();
+
+        // scheduler vars on integration functions and the executor, but the
+        // router keeps its own admin-scheduler role reference untouched
+        expect(env('hubspot').SCHEDULER_ROLE_ARN).toEqual({
+            'Fn::GetAtt': ['SchedulerExecutionRole', 'Arn'],
+        });
+        expect(env('adminScriptExecutor').SCHEDULER_ROLE_ARN).toEqual({
+            'Fn::GetAtt': ['SchedulerExecutionRole', 'Arn'],
+        });
+
+        // migration vars only on the migration functions
+        expect(env('dbMigrationRouter').DB_MIGRATION_QUEUE_URL).toBeDefined();
+        expect(env('dbMigrationWorker').S3_BUCKET_NAME).toBeDefined();
+
+        // base functions that consume none of this carry none of it
+        for (const fnName of ['user', 'health']) {
+            for (const key of SCOPED_VARS) {
+                expect(env(fnName)[key]).toBeUndefined();
+            }
+        }
+    });
+
+    it('keeps full broadcast when the flag is off, byte-identical to omitting the lambda key', async () => {
+        const withoutKey = await composeServerlessDefinition(buildApp());
+        const withFlagOff = await composeServerlessDefinition(
+            buildApp({ lambda: { scopedEnvironment: false } })
+        );
+
+        expect(withFlagOff).toEqual(withoutKey);
+        for (const key of SCOPED_VARS) {
+            expect(withoutKey.provider.environment[key]).toBeDefined();
+        }
+    });
+});

--- a/packages/devtools/infrastructure/__tests__/ssm-preload-node-options.test.js
+++ b/packages/devtools/infrastructure/__tests__/ssm-preload-node-options.test.js
@@ -1,0 +1,79 @@
+/**
+ * The SSM INIT preload (NODE_OPTIONS=--import) must be scoped to skipEsbuild
+ * functions only. esbuild-bundled functions (e.g. defaultWebsocket) do not
+ * package the preload .mjs, and a missing --import target fatally aborts Node
+ * startup — so a global NODE_OPTIONS would brick them (ADR-027 review finding).
+ */
+
+const { composeServerlessDefinition } = require('../infrastructure-composer');
+
+jest.mock('../domains/shared/resource-discovery', () => {
+    const original = jest.requireActual('../domains/shared/resource-discovery');
+    return {
+        ...original,
+        gatherDiscoveredResources: jest.fn().mockResolvedValue({
+            defaultVpcId: 'vpc-123456',
+            defaultSecurityGroupId: 'sg-123456',
+            privateSubnetId1: 'subnet-1',
+            privateSubnetId2: 'subnet-2',
+            defaultKmsKeyId:
+                'arn:aws:kms:us-east-1:123456789012:key/abc-123',
+            auroraClusterEndpoint: 'c.cluster-x.us-east-1.rds.amazonaws.com',
+            auroraPort: 5432,
+        }),
+    };
+});
+
+const buildApp = (overrides = {}) => ({
+    name: 'preload-test',
+    provider: 'aws',
+    usePrismaLambdaLayer: false,
+    encryption: { fieldLevelEncryptionMethod: 'aes' },
+    vpc: { enable: false },
+    database: { postgres: { enable: true } },
+    websockets: { enable: true },
+    integrations: [{ Definition: { name: 'hubspot' } }],
+    ...overrides,
+});
+
+const IMPORT_FRAGMENT = '--import file:///var/task/node_modules/@friggframework/core/core/ssm-preload.mjs';
+
+describe('SSM preload NODE_OPTIONS scoping', () => {
+    beforeEach(() => {
+        process.argv = ['node', 'test'];
+        delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+    });
+
+    it('sets NODE_OPTIONS --import on skipEsbuild functions and NOT on esbuild-bundled ones when offload is active', async () => {
+        const definition = await composeServerlessDefinition(
+            buildApp({
+                ssm: { enable: true },
+                environment: { HUBSPOT_SECRET: 'ssm' },
+            })
+        );
+        const fns = definition.functions;
+
+        // skipEsbuild handlers (auth/user/health + integration) package the
+        // preload → they get the flag.
+        expect(fns.auth.skipEsbuild).toBe(true);
+        expect(fns.auth.environment.NODE_OPTIONS).toBe(IMPORT_FRAGMENT);
+        expect(fns.hubspot.environment.NODE_OPTIONS).toBe(IMPORT_FRAGMENT);
+
+        // defaultWebsocket is esbuild-bundled (no skipEsbuild) → MUST NOT get it.
+        expect(fns.defaultWebsocket.skipEsbuild).toBeFalsy();
+        expect(fns.defaultWebsocket.environment?.NODE_OPTIONS).toBeUndefined();
+
+        // Never global.
+        expect(definition.provider.environment.NODE_OPTIONS).toBeUndefined();
+    });
+
+    it('sets no NODE_OPTIONS anywhere when offload is inactive', async () => {
+        const definition = await composeServerlessDefinition(
+            buildApp({ ssm: { enable: true } }) // enabled, but no 'ssm' keys
+        );
+        for (const fn of Object.values(definition.functions)) {
+            expect(fn.environment?.NODE_OPTIONS).toBeUndefined();
+        }
+        expect(definition.provider.environment.NODE_OPTIONS).toBeUndefined();
+    });
+});

--- a/packages/devtools/infrastructure/domains/admin-scripts/admin-script-builder.js
+++ b/packages/devtools/infrastructure/domains/admin-scripts/admin-script-builder.js
@@ -14,6 +14,7 @@
  */
 
 const { InfrastructureBuilder, ValidationResult } = require('../shared/base-builder');
+const { isScopedEnvironmentActive } = require('../shared/function-environments');
 
 class AdminScriptBuilder extends InfrastructureBuilder {
     constructor() {
@@ -67,7 +68,7 @@ class AdminScriptBuilder extends InfrastructureBuilder {
         };
 
         // Create admin script queue
-        this.createAdminScriptQueue(result);
+        this.createAdminScriptQueue(result, appDefinition);
 
         // Create Lambda function for script execution
         this.createScriptExecutorFunction(appDefinition, result, usePrismaLayer);
@@ -90,7 +91,7 @@ class AdminScriptBuilder extends InfrastructureBuilder {
         return result;
     }
 
-    createAdminScriptQueue(result) {
+    createAdminScriptQueue(result, appDefinition) {
         result.resources.AdminScriptQueue = {
             Type: 'AWS::SQS::Queue',
             Properties: {
@@ -106,7 +107,20 @@ class AdminScriptBuilder extends InfrastructureBuilder {
             },
         };
 
-        result.environment.ADMIN_SCRIPT_QUEUE_URL = { Ref: 'AdminScriptQueue' };
+        if (isScopedEnvironmentActive(appDefinition)) {
+            // Only the admin functions read this queue URL
+            result.functionEnvironments = result.functionEnvironments || {};
+            for (const fnName of ['adminScriptRouter', 'adminScriptExecutor']) {
+                result.functionEnvironments[fnName] = {
+                    ...result.functionEnvironments[fnName],
+                    ADMIN_SCRIPT_QUEUE_URL: { Ref: 'AdminScriptQueue' },
+                };
+            }
+        } else {
+            result.environment.ADMIN_SCRIPT_QUEUE_URL = {
+                Ref: 'AdminScriptQueue',
+            };
+        }
 
         // The router enqueues async executions and scripts enqueue continuations
         // via queueScript()/queueScriptBatch(). The base role's wildcard does not

--- a/packages/devtools/infrastructure/domains/admin-scripts/admin-script-builder.test.js
+++ b/packages/devtools/infrastructure/domains/admin-scripts/admin-script-builder.test.js
@@ -625,4 +625,49 @@ describe('AdminScriptBuilder', () => {
             expect(adminScriptBuilder.getName()).toBe('AdminScriptBuilder');
         });
     });
+
+    describe('scoped environment (lambda.scopedEnvironment)', () => {
+        const originalSkipDiscovery = process.env.FRIGG_SKIP_AWS_DISCOVERY;
+
+        beforeEach(() => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+        });
+
+        afterEach(() => {
+            if (originalSkipDiscovery === undefined) {
+                delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            } else {
+                process.env.FRIGG_SKIP_AWS_DISCOVERY = originalSkipDiscovery;
+            }
+        });
+
+        it('scopes ADMIN_SCRIPT_QUEUE_URL to the admin functions only', async () => {
+            const result = await adminScriptBuilder.build(
+                {
+                    lambda: { scopedEnvironment: true },
+                    adminScripts: [{ Definition: { name: 'fix-things' } }],
+                },
+                {}
+            );
+
+            expect(result.environment.ADMIN_SCRIPT_QUEUE_URL).toBeUndefined();
+            for (const fnName of ['adminScriptRouter', 'adminScriptExecutor']) {
+                expect(
+                    result.functionEnvironments[fnName].ADMIN_SCRIPT_QUEUE_URL
+                ).toEqual({ Ref: 'AdminScriptQueue' });
+            }
+        });
+
+        it('broadcasts app-wide when the flag is off', async () => {
+            const result = await adminScriptBuilder.build(
+                { adminScripts: [{ Definition: { name: 'fix-things' } }] },
+                {}
+            );
+
+            expect(result.environment.ADMIN_SCRIPT_QUEUE_URL).toEqual({
+                Ref: 'AdminScriptQueue',
+            });
+            expect(result.functionEnvironments).toBeUndefined();
+        });
+    });
 });

--- a/packages/devtools/infrastructure/domains/database/migration-builder.js
+++ b/packages/devtools/infrastructure/domains/database/migration-builder.js
@@ -673,9 +673,29 @@ class MigrationBuilder extends InfrastructureBuilder {
                                   .replace(/\//g, ':');
 
         // Add environment variables (using external resource names/URLs)
-        result.environment.S3_BUCKET_NAME = bucketName;
-        result.environment.MIGRATION_STATUS_BUCKET = bucketName;
-        result.environment.DB_MIGRATION_QUEUE_URL = queueUrl;
+        const migrationEnvironment = {
+            S3_BUCKET_NAME: bucketName,
+            MIGRATION_STATUS_BUCKET: bucketName,
+            DB_MIGRATION_QUEUE_URL: queueUrl,
+        };
+
+        if (isScopedEnvironmentActive(appDefinition)) {
+            // Only the migration functions read these
+            result.functionEnvironments = result.functionEnvironments || {};
+            for (const fnName of ['dbMigrationRouter', 'dbMigrationWorker']) {
+                result.functionEnvironments[fnName] = {
+                    ...result.functionEnvironments[fnName],
+                    ...migrationEnvironment,
+                };
+            }
+        } else {
+            Object.assign(result.environment, migrationEnvironment);
+        }
+
+        // Hardcode DB_TYPE for PostgreSQL-only migrations. Stays app-wide
+        // even when scoping: it is tiny and broadly consumed, and scoping it
+        // would push every function through the app-definition fallback in
+        // core's getDatabaseType() at cold start.
         result.environment.DB_TYPE = 'postgresql';
 
         console.log('  ✓ Added S3_BUCKET_NAME, DB_MIGRATION_QUEUE_URL, and DB_TYPE environment variables');

--- a/packages/devtools/infrastructure/domains/database/migration-builder.js
+++ b/packages/devtools/infrastructure/domains/database/migration-builder.js
@@ -14,6 +14,7 @@
  */
 
 const { InfrastructureBuilder, ValidationResult } = require('../shared/base-builder');
+const { isScopedEnvironmentActive } = require('../shared/function-environments');
 const { MigrationResourceResolver } = require('./migration-resolver');
 const { createEmptyDiscoveryResult, ResourceOwnership } = require('../shared/types');
 
@@ -564,14 +565,30 @@ class MigrationBuilder extends InfrastructureBuilder {
 
         console.log('  ✓ Created DbMigrationQueue resource');
 
-        // Add S3 bucket name to environment (for migration Lambda functions)
-        result.environment.S3_BUCKET_NAME = { Ref: 'FriggMigrationStatusBucket' };
-        result.environment.MIGRATION_STATUS_BUCKET = { Ref: 'FriggMigrationStatusBucket' };
+        const migrationEnvironment = {
+            // S3 bucket for migration Lambda functions
+            S3_BUCKET_NAME: { Ref: 'FriggMigrationStatusBucket' },
+            MIGRATION_STATUS_BUCKET: { Ref: 'FriggMigrationStatusBucket' },
+            DB_MIGRATION_QUEUE_URL: { Ref: 'DbMigrationQueue' },
+        };
 
-        // Add queue URL to environment
-        result.environment.DB_MIGRATION_QUEUE_URL = { Ref: 'DbMigrationQueue' };
+        if (isScopedEnvironmentActive(appDefinition)) {
+            // Only the migration functions read these
+            result.functionEnvironments = result.functionEnvironments || {};
+            for (const fnName of ['dbMigrationRouter', 'dbMigrationWorker']) {
+                result.functionEnvironments[fnName] = {
+                    ...result.functionEnvironments[fnName],
+                    ...migrationEnvironment,
+                };
+            }
+        } else {
+            Object.assign(result.environment, migrationEnvironment);
+        }
 
-        // Hardcode DB_TYPE for PostgreSQL-only migrations
+        // Hardcode DB_TYPE for PostgreSQL-only migrations. Stays app-wide
+        // even when scoping: it is tiny and broadly consumed, and scoping it
+        // would push every function through the app-definition fallback in
+        // core's getDatabaseType() at cold start.
         result.environment.DB_TYPE = 'postgresql';
 
         console.log('  ✓ Added S3_BUCKET_NAME, DB_MIGRATION_QUEUE_URL, and DB_TYPE environment variables');

--- a/packages/devtools/infrastructure/domains/database/migration-builder.test.js
+++ b/packages/devtools/infrastructure/domains/database/migration-builder.test.js
@@ -318,5 +318,45 @@ describe('MigrationBuilder', () => {
             );
         });
     });
+
+    describe('scoped environment (lambda.scopedEnvironment)', () => {
+        beforeEach(() => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+        });
+
+        it('scopes migration vars to the migration functions, keeping DB_TYPE global', async () => {
+            const result = await builder.build(
+                { lambda: { scopedEnvironment: true } },
+                {}
+            );
+
+            expect(result.environment.S3_BUCKET_NAME).toBeUndefined();
+            expect(result.environment.MIGRATION_STATUS_BUCKET).toBeUndefined();
+            expect(result.environment.DB_MIGRATION_QUEUE_URL).toBeUndefined();
+            expect(result.environment.DB_TYPE).toBe('postgresql');
+
+            for (const fnName of ['dbMigrationRouter', 'dbMigrationWorker']) {
+                expect(result.functionEnvironments[fnName]).toMatchObject({
+                    S3_BUCKET_NAME: { Ref: 'FriggMigrationStatusBucket' },
+                    MIGRATION_STATUS_BUCKET: {
+                        Ref: 'FriggMigrationStatusBucket',
+                    },
+                    DB_MIGRATION_QUEUE_URL: { Ref: 'DbMigrationQueue' },
+                });
+            }
+        });
+
+        it('broadcasts app-wide when the flag is off', async () => {
+            const result = await builder.build({}, {});
+
+            expect(result.environment.S3_BUCKET_NAME).toEqual({
+                Ref: 'FriggMigrationStatusBucket',
+            });
+            expect(result.environment.DB_MIGRATION_QUEUE_URL).toEqual({
+                Ref: 'DbMigrationQueue',
+            });
+            expect(result.functionEnvironments).toBeUndefined();
+        });
+    });
 });
 

--- a/packages/devtools/infrastructure/domains/database/migration-builder.test.js
+++ b/packages/devtools/infrastructure/domains/database/migration-builder.test.js
@@ -358,5 +358,66 @@ describe('MigrationBuilder', () => {
             expect(result.functionEnvironments).toBeUndefined();
         });
     });
+
+    describe('scoped environment (external migration resources)', () => {
+        // managementMode='managed' + vpcIsolation='shared' resolves both
+        // resources to EXTERNAL when discovered, driving the external path.
+        const externalDiscovery = {
+            migrationStatusBucket: 'external-migration-bucket',
+            migrationQueueUrl:
+                'https://sqs.us-east-1.amazonaws.com/123456789012/external-migration-queue',
+        };
+
+        beforeEach(() => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+        });
+
+        it('scopes external migration vars to the migration functions, keeping DB_TYPE global', async () => {
+            const result = await builder.build(
+                {
+                    managementMode: 'managed',
+                    vpcIsolation: 'shared',
+                    lambda: { scopedEnvironment: true },
+                },
+                externalDiscovery
+            );
+
+            expect(result.environment.S3_BUCKET_NAME).toBeUndefined();
+            expect(result.environment.MIGRATION_STATUS_BUCKET).toBeUndefined();
+            expect(result.environment.DB_MIGRATION_QUEUE_URL).toBeUndefined();
+            expect(result.environment.DB_TYPE).toBe('postgresql');
+
+            for (const fnName of ['dbMigrationRouter', 'dbMigrationWorker']) {
+                expect(result.functionEnvironments[fnName]).toMatchObject({
+                    S3_BUCKET_NAME: externalDiscovery.migrationStatusBucket,
+                    MIGRATION_STATUS_BUCKET:
+                        externalDiscovery.migrationStatusBucket,
+                    DB_MIGRATION_QUEUE_URL: externalDiscovery.migrationQueueUrl,
+                });
+            }
+        });
+
+        it('broadcasts external migration vars app-wide when the flag is off', async () => {
+            const result = await builder.build(
+                {
+                    managementMode: 'managed',
+                    vpcIsolation: 'shared',
+                },
+                externalDiscovery
+            );
+
+            expect(result.environment.S3_BUCKET_NAME).toBe(
+                externalDiscovery.migrationStatusBucket
+            );
+            expect(result.environment.MIGRATION_STATUS_BUCKET).toBe(
+                externalDiscovery.migrationStatusBucket
+            );
+            expect(result.environment.DB_MIGRATION_QUEUE_URL).toBe(
+                externalDiscovery.migrationQueueUrl
+            );
+            expect(result.environment.DB_TYPE).toBe('postgresql');
+            expect(result.functionEnvironments).toBeUndefined();
+        });
+    });
 });
 

--- a/packages/devtools/infrastructure/domains/integration/integration-builder.js
+++ b/packages/devtools/infrastructure/domains/integration/integration-builder.js
@@ -24,6 +24,11 @@ const {
     createEmptyDiscoveryResult,
     ResourceOwnership,
 } = require('../shared/types');
+const {
+    isScopedEnvironmentActive,
+    getIntegrationFunctionNames,
+    getAdminFunctionNames,
+} = require('../shared/function-environments');
 
 class IntegrationBuilder extends InfrastructureBuilder {
     constructor() {
@@ -218,13 +223,18 @@ class IntegrationBuilder extends InfrastructureBuilder {
                 console.log(
                     `      ✓ Creating ${integrationName}Queue in stack`
                 );
-                this.createIntegrationQueue(integrationName, result);
+                this.createIntegrationQueue(
+                    integrationName,
+                    result,
+                    appDefinition
+                );
             } else {
                 console.log(`      ✓ Using external ${integrationName}Queue`);
                 this.useExternalIntegrationQueue(
                     integrationName,
                     queueDecision,
-                    result
+                    result,
+                    appDefinition
                 );
             }
         }
@@ -544,7 +554,7 @@ class IntegrationBuilder extends InfrastructureBuilder {
     /**
      * Create integration-specific SQS queue CloudFormation resource
      */
-    createIntegrationQueue(integrationName, result) {
+    createIntegrationQueue(integrationName, result, appDefinition) {
         const queueReference = `${this.capitalizeFirst(integrationName)}Queue`;
         const queueName = `\${self:service}--\${self:provider.stage}-${queueReference}`;
 
@@ -564,9 +574,12 @@ class IntegrationBuilder extends InfrastructureBuilder {
         };
 
         // Add queue URL to environment
-        result.environment[`${integrationName.toUpperCase()}_QUEUE_URL`] = {
-            Ref: queueReference,
-        };
+        this.setQueueUrlEnvironment(
+            integrationName,
+            { Ref: queueReference },
+            result,
+            appDefinition
+        );
 
         // Add queue name to custom section
         result.custom[queueReference] = queueName;
@@ -577,12 +590,55 @@ class IntegrationBuilder extends InfrastructureBuilder {
     /**
      * Use external integration queue
      */
-    useExternalIntegrationQueue(integrationName, decision, result) {
+    useExternalIntegrationQueue(
+        integrationName,
+        decision,
+        result,
+        appDefinition
+    ) {
         // Add queue URL to environment for Lambda functions
-        result.environment[`${integrationName.toUpperCase()}_QUEUE_URL`] =
-            decision.physicalId;
+        this.setQueueUrlEnvironment(
+            integrationName,
+            decision.physicalId,
+            result,
+            appDefinition
+        );
 
         console.log(`  ✓ Using external queue: ${decision.physicalId}`);
+    }
+
+    /**
+     * Broadcast the queue URL app-wide, or — with lambda.scopedEnvironment —
+     * scope it to the functions that can actually enqueue: the shared auth
+     * router (dispatches integration actions synchronously), the admin-script
+     * functions (instantiate arbitrary integrations), and the owning
+     * integration's own functions.
+     */
+    setQueueUrlEnvironment(integrationName, value, result, appDefinition) {
+        const key = `${integrationName.toUpperCase()}_QUEUE_URL`;
+
+        if (!isScopedEnvironmentActive(appDefinition)) {
+            result.environment[key] = value;
+            return;
+        }
+
+        const integration = appDefinition.integrations.find(
+            (entry) => entry.Definition.name === integrationName
+        );
+        const targets = [
+            'auth',
+            ...getAdminFunctionNames(appDefinition),
+            ...getIntegrationFunctionNames(integration),
+        ];
+
+        result.functionEnvironments = result.functionEnvironments || {};
+        for (const fnName of targets) {
+            result.functionEnvironments[fnName] = {
+                ...result.functionEnvironments[fnName],
+                [key]: value,
+            };
+        }
+        console.log(`  ✓ Scoped ${key} to: ${targets.join(', ')}`);
     }
 
     /**

--- a/packages/devtools/infrastructure/domains/integration/integration-builder.test.js
+++ b/packages/devtools/infrastructure/domains/integration/integration-builder.test.js
@@ -935,5 +935,100 @@ describe('IntegrationBuilder', () => {
             );
         });
     });
+
+    describe('scoped environment (lambda.scopedEnvironment)', () => {
+        const originalSkipDiscovery = process.env.FRIGG_SKIP_AWS_DISCOVERY;
+
+        beforeEach(() => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+        });
+
+        afterEach(() => {
+            if (originalSkipDiscovery === undefined) {
+                delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            } else {
+                process.env.FRIGG_SKIP_AWS_DISCOVERY = originalSkipDiscovery;
+            }
+        });
+
+        const scopedApp = {
+            lambda: { scopedEnvironment: true },
+            adminScripts: [{ Definition: { name: 'fix-things' } }],
+            integrations: [
+                { Definition: { name: 'hubspot', webhooks: true } },
+                { Definition: { name: 'slack' } },
+            ],
+        };
+
+        it('scopes queue URLs to auth, admin functions, and the owning integration only', async () => {
+            const result = await integrationBuilder.build(scopedApp, {});
+
+            expect(result.environment.HUBSPOT_QUEUE_URL).toBeUndefined();
+            expect(result.environment.SLACK_QUEUE_URL).toBeUndefined();
+
+            const scoped = result.functionEnvironments;
+            // auth and admin functions can enqueue to any integration
+            expect(scoped.auth).toEqual({
+                HUBSPOT_QUEUE_URL: { Ref: 'HubspotQueue' },
+                SLACK_QUEUE_URL: { Ref: 'SlackQueue' },
+            });
+            expect(scoped.adminScriptRouter.HUBSPOT_QUEUE_URL).toBeDefined();
+            expect(scoped.adminScriptExecutor.SLACK_QUEUE_URL).toBeDefined();
+
+            // owning integration's full function set
+            expect(scoped.hubspot.HUBSPOT_QUEUE_URL).toBeDefined();
+            expect(scoped.hubspotWebhook.HUBSPOT_QUEUE_URL).toBeDefined();
+            expect(scoped.hubspotQueueWorker.HUBSPOT_QUEUE_URL).toBeDefined();
+
+            // cross-integration isolation
+            expect(scoped.hubspotQueueWorker.SLACK_QUEUE_URL).toBeUndefined();
+            expect(scoped.slackQueueWorker.HUBSPOT_QUEUE_URL).toBeUndefined();
+        });
+
+        it('targets extension handler functions too', async () => {
+            const withExtension = {
+                lambda: { scopedEnvironment: true },
+                integrations: [
+                    {
+                        Definition: {
+                            name: 'hubspot',
+                            extensions: {
+                                'my-ext': {
+                                    extension: {
+                                        routes: [{ path: '/x', method: 'GET' }],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                ],
+            };
+            const result = await integrationBuilder.build(withExtension, {});
+
+            expect(
+                result.functionEnvironments.hubspot__myext.HUBSPOT_QUEUE_URL
+            ).toBeDefined();
+        });
+
+        it('broadcasts app-wide when the flag is off', async () => {
+            const result = await integrationBuilder.build(
+                { integrations: scopedApp.integrations },
+                {}
+            );
+
+            expect(result.environment.HUBSPOT_QUEUE_URL).toEqual({
+                Ref: 'HubspotQueue',
+            });
+            expect(result.functionEnvironments).toBeUndefined();
+        });
+
+        it('broadcasts in local mode even with the flag on', async () => {
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = 'true';
+            const result = await integrationBuilder.build(scopedApp, {});
+
+            expect(result.environment.HUBSPOT_QUEUE_URL).toBeDefined();
+            expect(result.functionEnvironments).toBeUndefined();
+        });
+    });
 });
 

--- a/packages/devtools/infrastructure/domains/networking/vpc-builder.js
+++ b/packages/devtools/infrastructure/domains/networking/vpc-builder.js
@@ -22,6 +22,7 @@ const { InfrastructureBuilder, ValidationResult } = require('../shared/base-buil
 const VpcResourceResolver = require('./vpc-resolver');
 const { createEmptyDiscoveryResult } = require('../shared/types/discovery-result');
 const { ResourceOwnership } = require('../shared/types/resource-ownership');
+const { isSsmOffloadActive } = require('../parameters/offload-utils');
 
 class VpcBuilder extends InfrastructureBuilder {
     constructor() {
@@ -177,6 +178,9 @@ class VpcBuilder extends InfrastructureBuilder {
                 } else if (logicalId === 'FriggSQSVPCEndpoint' || logicalId === 'VPCEndpointSQS') {
                     resourceType = 'AWS::EC2::VPCEndpoint';
                     physicalId = flatDiscovery.sqsVpcEndpointId;
+                } else if (logicalId === 'FriggSSMVPCEndpoint' || logicalId === 'VPCEndpointSSM') {
+                    resourceType = 'AWS::EC2::VPCEndpoint';
+                    physicalId = flatDiscovery.ssmVpcEndpointId;
                 } else if (logicalId === 'FriggNATRoute' || logicalId === 'FriggPrivateRoute') {
                     resourceType = 'AWS::EC2::Route';
                     physicalId = flatDiscovery.natRoute;
@@ -294,6 +298,15 @@ class VpcBuilder extends InfrastructureBuilder {
                     resourceType: 'AWS::EC2::VPCEndpoint',
                     source: 'aws-discovery',
                     properties: { ServiceName: 'sqs' }
+                });
+            }
+
+            if (flatDiscovery.ssmVpcEndpointId && typeof flatDiscovery.ssmVpcEndpointId === 'string') {
+                discovery.external.push({
+                    physicalId: flatDiscovery.ssmVpcEndpointId,
+                    resourceType: 'AWS::EC2::VPCEndpoint',
+                    source: 'aws-discovery',
+                    properties: { ServiceName: 'ssm' }
                 });
             }
         }
@@ -1005,7 +1018,7 @@ class VpcBuilder extends InfrastructureBuilder {
         }
 
         // Create security group for interface endpoints if needed
-        const needsInterfaceEndpoints = endpointsToCreate.some(type => ['kms', 'secretsManager', 'sqs'].includes(type));
+        const needsInterfaceEndpoints = endpointsToCreate.some(type => ['kms', 'secretsManager', 'sqs', 'ssm'].includes(type));
         if (needsInterfaceEndpoints) {
             // Determine source security group for ingress rule
             let sourceSgId;
@@ -1072,6 +1085,20 @@ class VpcBuilder extends InfrastructureBuilder {
                 Properties: {
                     VpcId: vpcId,
                     ServiceName: 'com.amazonaws.${self:provider.region}.sqs',
+                    VpcEndpointType: 'Interface',
+                    SubnetIds: result.vpcConfig.subnetIds,
+                    SecurityGroupIds: [{ Ref: 'FriggVPCEndpointSecurityGroup' }],
+                    PrivateDnsEnabled: true,
+                },
+            };
+        }
+
+        if (endpointsToCreate.includes('ssm')) {
+            result.resources.FriggSSMVPCEndpoint = {
+                Type: 'AWS::EC2::VPCEndpoint',
+                Properties: {
+                    VpcId: vpcId,
+                    ServiceName: 'com.amazonaws.${self:provider.region}.ssm',
                     VpcEndpointType: 'Interface',
                     SubnetIds: result.vpcConfig.subnetIds,
                     SecurityGroupIds: [{ Ref: 'FriggVPCEndpointSecurityGroup' }],
@@ -1157,7 +1184,8 @@ class VpcBuilder extends InfrastructureBuilder {
             dynamodb: existingLogicalIds.includes('VPCEndpointDynamoDB') ? 'VPCEndpointDynamoDB' : 'FriggDynamoDBVPCEndpoint',
             kms: existingLogicalIds.includes('VPCEndpointKMS') ? 'VPCEndpointKMS' : 'FriggKMSVPCEndpoint',
             secretsManager: existingLogicalIds.includes('VPCEndpointSecretsManager') ? 'VPCEndpointSecretsManager' : 'FriggSecretsManagerVPCEndpoint',
-            sqs: existingLogicalIds.includes('VPCEndpointSQS') ? 'VPCEndpointSQS' : 'FriggSQSVPCEndpoint'
+            sqs: existingLogicalIds.includes('VPCEndpointSQS') ? 'VPCEndpointSQS' : 'FriggSQSVPCEndpoint',
+            ssm: existingLogicalIds.includes('VPCEndpointSSM') ? 'VPCEndpointSSM' : 'FriggSSMVPCEndpoint'
         };
 
         Object.entries(decisions).forEach(([type, decision]) => {
@@ -1186,11 +1214,12 @@ class VpcBuilder extends InfrastructureBuilder {
                         }
                     };
                 } else {
-                    // Interface endpoints (KMS, Secrets Manager, SQS)
+                    // Interface endpoints (KMS, Secrets Manager, SQS, SSM)
                     const serviceMap = {
                         kms: 'kms',
                         secretsManager: 'secretsmanager',
-                        sqs: 'sqs'
+                        sqs: 'sqs',
+                        ssm: 'ssm'
                     };
                     
                     result.resources[logicalId] = {
@@ -1209,7 +1238,7 @@ class VpcBuilder extends InfrastructureBuilder {
         });
 
         // If any interface endpoints exist, ensure security group is in template
-        const hasInterfaceEndpoints = ['kms', 'secretsManager', 'sqs'].some(
+        const hasInterfaceEndpoints = ['kms', 'secretsManager', 'sqs', 'ssm'].some(
             type => decisions[type]?.ownership === ResourceOwnership.STACK && decisions[type]?.physicalId
         );
 
@@ -1887,7 +1916,10 @@ class VpcBuilder extends InfrastructureBuilder {
             kms: discoveredResources.kmsVpcEndpointId && typeof discoveredResources.kmsVpcEndpointId === 'string',
             secretsManager: discoveredResources.secretsManagerVpcEndpointId && typeof discoveredResources.secretsManagerVpcEndpointId === 'string',
             sqs: discoveredResources.sqsVpcEndpointId && typeof discoveredResources.sqsVpcEndpointId === 'string',
+            ssm: discoveredResources.ssmVpcEndpointId && typeof discoveredResources.ssmVpcEndpointId === 'string',
         };
+
+        const needsSsm = isSsmOffloadActive(appDefinition);
 
         // Build list of what needs creation (not stack-managed, not existing elsewhere)
         const missing = [];
@@ -1897,6 +1929,7 @@ class VpcBuilder extends InfrastructureBuilder {
         if (!stackManagedEndpoints.secretsManager && !existingEndpoints.secretsManager) missing.push('Secrets Manager');
         // SQS endpoint needed for job queues and async processing
         if (!stackManagedEndpoints.sqs && !existingEndpoints.sqs) missing.push('SQS');
+        if (!stackManagedEndpoints.ssm && !existingEndpoints.ssm && needsSsm) missing.push('SSM');
 
         // Log reused stack-managed endpoints
         const reused = [];
@@ -1905,6 +1938,7 @@ class VpcBuilder extends InfrastructureBuilder {
         if (stackManagedEndpoints.kms) reused.push('KMS');
         if (stackManagedEndpoints.secretsManager) reused.push('Secrets Manager');
         if (stackManagedEndpoints.sqs) reused.push('SQS');
+        if (stackManagedEndpoints.ssm) reused.push('SSM');
 
         if (reused.length > 0) {
             console.log(`  ✓ Reusing stack-managed VPC endpoints: ${reused.join(', ')}`);
@@ -1968,11 +2002,12 @@ class VpcBuilder extends InfrastructureBuilder {
             };
         }
 
-        // VPC Endpoint Security Group (only if KMS, Secrets Manager, or SQS are not stack-managed and missing)
+        // VPC Endpoint Security Group (only if KMS, Secrets Manager, SQS, or SSM are not stack-managed and missing)
         const needsSecurityGroup =
             (!stackManagedEndpoints.kms && !existingEndpoints.kms && appDefinition.encryption?.fieldLevelEncryptionMethod === 'kms') ||
             (!stackManagedEndpoints.secretsManager && !existingEndpoints.secretsManager) ||
-            (!stackManagedEndpoints.sqs && !existingEndpoints.sqs);
+            (!stackManagedEndpoints.sqs && !existingEndpoints.sqs) ||
+            (!stackManagedEndpoints.ssm && !existingEndpoints.ssm && needsSsm);
 
         if (needsSecurityGroup) {
             result.resources.FriggVPCEndpointSecurityGroup = {
@@ -2035,6 +2070,21 @@ class VpcBuilder extends InfrastructureBuilder {
                 Properties: {
                     VpcId: vpcId,
                     ServiceName: 'com.amazonaws.${self:provider.region}.sqs',
+                    VpcEndpointType: 'Interface',
+                    SubnetIds: result.vpcConfig.subnetIds,
+                    SecurityGroupIds: [{ Ref: 'FriggVPCEndpointSecurityGroup' }],
+                    PrivateDnsEnabled: true,
+                },
+            };
+        }
+
+        // SSM Interface Endpoint (only if not stack-managed, missing, AND SSM offload is active)
+        if (!stackManagedEndpoints.ssm && !existingEndpoints.ssm && needsSsm) {
+            result.resources.FriggSSMVPCEndpoint = {
+                Type: 'AWS::EC2::VPCEndpoint',
+                Properties: {
+                    VpcId: vpcId,
+                    ServiceName: 'com.amazonaws.${self:provider.region}.ssm',
                     VpcEndpointType: 'Interface',
                     SubnetIds: result.vpcConfig.subnetIds,
                     SecurityGroupIds: [{ Ref: 'FriggVPCEndpointSecurityGroup' }],

--- a/packages/devtools/infrastructure/domains/networking/vpc-builder.test.js
+++ b/packages/devtools/infrastructure/domains/networking/vpc-builder.test.js
@@ -990,6 +990,47 @@ describe('VpcBuilder', () => {
         });
     });
 
+    describe('SSM VPC Endpoint', () => {
+        const originalSkipDiscovery = process.env.FRIGG_SKIP_AWS_DISCOVERY;
+
+        afterEach(() => {
+            if (originalSkipDiscovery === undefined) {
+                delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            } else {
+                process.env.FRIGG_SKIP_AWS_DISCOVERY = originalSkipDiscovery;
+            }
+        });
+
+        it('should create SSM endpoint when offload is active and VPC is enabled', async () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            const appDefinition = {
+                vpc: { enable: true, management: 'create-new' },
+                ssm: { enable: true },
+                environment: { FOO: 'ssm' },
+            };
+
+            const result = await vpcBuilder.build(appDefinition, {});
+
+            expect(result.resources.FriggSSMVPCEndpoint).toBeDefined();
+            expect(result.resources.FriggSSMVPCEndpoint.Type).toBe('AWS::EC2::VPCEndpoint');
+            expect(result.resources.FriggSSMVPCEndpoint.Properties.VpcEndpointType).toBe('Interface');
+            expect(result.resources.FriggSSMVPCEndpoint.Properties.ServiceName).toBe('com.amazonaws.${self:provider.region}.ssm');
+            expect(result.resources.FriggSSMVPCEndpoint.Properties.PrivateDnsEnabled).toBe(true);
+        });
+
+        it('should not create SSM endpoint when offload is not active', async () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            const appDefinition = {
+                vpc: { enable: true, management: 'create-new' },
+                ssm: { enable: true },
+            };
+
+            const result = await vpcBuilder.build(appDefinition, {});
+
+            expect(result.resources.FriggSSMVPCEndpoint).toBeUndefined();
+        });
+    });
+
     describe('Self-healing', () => {
         it('should create missing subnets when selfHeal is enabled', async () => {
             const appDefinition = {

--- a/packages/devtools/infrastructure/domains/networking/vpc-discovery.js
+++ b/packages/devtools/infrastructure/domains/networking/vpc-discovery.js
@@ -123,6 +123,10 @@ class VpcDiscovery {
                 const sqsEndpoint = rawResources.vpcEndpoints.find(
                     ep => ep.ServiceName && ep.ServiceName.includes('.sqs')
                 );
+                // endsWith avoids matching sibling services like `.ssmmessages`
+                const ssmEndpoint = rawResources.vpcEndpoints.find(
+                    ep => ep.ServiceName && ep.ServiceName.endsWith('.ssm')
+                );
 
                 if (s3Endpoint) {
                     result.s3VpcEndpointId = s3Endpoint.VpcEndpointId;
@@ -139,6 +143,9 @@ class VpcDiscovery {
                 if (sqsEndpoint) {
                     result.sqsVpcEndpointId = sqsEndpoint.VpcEndpointId;
                 }
+                if (ssmEndpoint) {
+                    result.ssmVpcEndpointId = ssmEndpoint.VpcEndpointId;
+                }
             }
 
             console.log(`  ✓ Found VPC: ${result.defaultVpcId}`);
@@ -151,8 +158,8 @@ class VpcDiscovery {
             if (result.existingNatGatewayId) {
                 console.log(`  ✓ Found NAT Gateway: ${result.existingNatGatewayId}`);
             }
-            if (result.s3VpcEndpointId || result.dynamodbVpcEndpointId || result.kmsVpcEndpointId || result.secretsManagerVpcEndpointId || result.sqsVpcEndpointId) {
-                console.log(`  ✓ Found VPC Endpoints: S3=${result.s3VpcEndpointId ? 'Yes' : 'No'}, DynamoDB=${result.dynamodbVpcEndpointId ? 'Yes' : 'No'}, KMS=${result.kmsVpcEndpointId ? 'Yes' : 'No'}, SecretsManager=${result.secretsManagerVpcEndpointId ? 'Yes' : 'No'}, SQS=${result.sqsVpcEndpointId ? 'Yes' : 'No'}`);
+            if (result.s3VpcEndpointId || result.dynamodbVpcEndpointId || result.kmsVpcEndpointId || result.secretsManagerVpcEndpointId || result.sqsVpcEndpointId || result.ssmVpcEndpointId) {
+                console.log(`  ✓ Found VPC Endpoints: S3=${result.s3VpcEndpointId ? 'Yes' : 'No'}, DynamoDB=${result.dynamodbVpcEndpointId ? 'Yes' : 'No'}, KMS=${result.kmsVpcEndpointId ? 'Yes' : 'No'}, SecretsManager=${result.secretsManagerVpcEndpointId ? 'Yes' : 'No'}, SQS=${result.sqsVpcEndpointId ? 'Yes' : 'No'}, SSM=${result.ssmVpcEndpointId ? 'Yes' : 'No'}`);
             }
 
             return result;

--- a/packages/devtools/infrastructure/domains/networking/vpc-discovery.test.js
+++ b/packages/devtools/infrastructure/domains/networking/vpc-discovery.test.js
@@ -253,7 +253,7 @@ describe('VpcDiscovery', () => {
             expect(mockProvider.discoverVpc).toHaveBeenCalledWith(config);
         });
 
-        it('should discover all VPC endpoints (S3, DynamoDB, KMS, Secrets Manager)', async () => {
+        it('should discover all VPC endpoints (S3, DynamoDB, KMS, Secrets Manager, SQS, SSM)', async () => {
             mockProvider.discoverVpc.mockResolvedValue({
                 vpcId: 'vpc-123',
                 vpcCidr: '10.0.0.0/16',
@@ -283,6 +283,22 @@ describe('VpcDiscovery', () => {
                         ServiceName: 'com.amazonaws.us-east-1.secretsmanager',
                         State: 'available',
                     },
+                    {
+                        VpcEndpointId: 'vpce-sqs-def',
+                        ServiceName: 'com.amazonaws.us-east-1.sqs',
+                        State: 'available',
+                    },
+                    // ssmmessages must NOT be mistaken for the ssm endpoint
+                    {
+                        VpcEndpointId: 'vpce-ssmmessages-000',
+                        ServiceName: 'com.amazonaws.us-east-1.ssmmessages',
+                        State: 'available',
+                    },
+                    {
+                        VpcEndpointId: 'vpce-ssm-ghi',
+                        ServiceName: 'com.amazonaws.us-east-1.ssm',
+                        State: 'available',
+                    },
                 ],
             });
 
@@ -292,6 +308,8 @@ describe('VpcDiscovery', () => {
             expect(result.dynamodbVpcEndpointId).toBe('vpce-ddb-456');
             expect(result.kmsVpcEndpointId).toBe('vpce-kms-789');
             expect(result.secretsManagerVpcEndpointId).toBe('vpce-sm-abc');
+            expect(result.sqsVpcEndpointId).toBe('vpce-sqs-def');
+            expect(result.ssmVpcEndpointId).toBe('vpce-ssm-ghi');
         });
 
         it('should handle partial VPC endpoint discovery', async () => {

--- a/packages/devtools/infrastructure/domains/networking/vpc-resolver.js
+++ b/packages/devtools/infrastructure/domains/networking/vpc-resolver.js
@@ -13,6 +13,7 @@
 
 const BaseResourceResolver = require('../shared/base-resolver');
 const { ResourceOwnership } = require('../shared/types');
+const { isSsmOffloadActive } = require('../parameters/offload-utils');
 
 class VpcResourceResolver extends BaseResourceResolver {
     /**
@@ -381,13 +382,17 @@ class VpcResourceResolver extends BaseResourceResolver {
                 dynamodb: { ownership: null, reason: 'VPC Endpoints disabled' },
                 kms: { ownership: null, reason: 'VPC Endpoints disabled' },
                 secretsManager: { ownership: null, reason: 'VPC Endpoints disabled' },
-                sqs: { ownership: null, reason: 'VPC Endpoints disabled' }
+                sqs: { ownership: null, reason: 'VPC Endpoints disabled' },
+                ssm: { ownership: null, reason: 'VPC Endpoints disabled' }
             };
         }
 
         // KMS endpoint only needed if encryption method is KMS
         const encryptionMethod = appDefinition.encryption?.fieldLevelEncryptionMethod;
         const needsKms = encryptionMethod === 'kms';
+
+        // SSM endpoint only needed when parameter offload is active
+        const needsSsm = isSsmOffloadActive(appDefinition);
 
         // DynamoDB endpoint only needed if using DynamoDB (not MongoDB or PostgreSQL)
         // Currently framework only supports MongoDB (via Prisma) and PostgreSQL (via Aurora)
@@ -403,7 +408,10 @@ class VpcResourceResolver extends BaseResourceResolver {
                 ? this._resolveEndpoint('FriggKMSVPCEndpoint', 'kms', userIntent, appDefinition, discovery)
                 : { ownership: null, reason: 'KMS endpoint not needed (encryption method is not KMS)' },
             secretsManager: this._resolveEndpoint('FriggSecretsManagerVPCEndpoint', 'secretsManager', userIntent, appDefinition, discovery),
-            sqs: this._resolveEndpoint('FriggSQSVPCEndpoint', 'sqs', userIntent, appDefinition, discovery)
+            sqs: this._resolveEndpoint('FriggSQSVPCEndpoint', 'sqs', userIntent, appDefinition, discovery),
+            ssm: needsSsm
+                ? this._resolveEndpoint('FriggSSMVPCEndpoint', 'ssm', userIntent, appDefinition, discovery)
+                : { ownership: null, reason: 'SSM endpoint not needed (SSM offload not active)' }
         };
 
         return endpoints;
@@ -421,7 +429,8 @@ class VpcResourceResolver extends BaseResourceResolver {
             'FriggDynamoDBVPCEndpoint': 'VPCEndpointDynamoDB',
             'FriggKMSVPCEndpoint': 'VPCEndpointKMS',
             'FriggSecretsManagerVPCEndpoint': 'VPCEndpointSecretsManager',
-            'FriggSQSVPCEndpoint': 'VPCEndpointSQS'
+            'FriggSQSVPCEndpoint': 'VPCEndpointSQS',
+            'FriggSSMVPCEndpoint': 'VPCEndpointSSM'
         };
         const oldLogicalId = oldLogicalIdMap[logicalId];
 

--- a/packages/devtools/infrastructure/domains/networking/vpc-resolver.test.js
+++ b/packages/devtools/infrastructure/domains/networking/vpc-resolver.test.js
@@ -567,6 +567,46 @@ describe('VpcResourceResolver', () => {
             expect(decisions.kms.ownership).toBeNull();
             expect(decisions.secretsManager.ownership).toBeNull();
             expect(decisions.sqs.ownership).toBeNull();
+            expect(decisions.ssm.ownership).toBeNull();
+        });
+
+        describe('SSM endpoint', () => {
+            const originalSkipDiscovery = process.env.FRIGG_SKIP_AWS_DISCOVERY;
+
+            afterEach(() => {
+                if (originalSkipDiscovery === undefined) {
+                    delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+                } else {
+                    process.env.FRIGG_SKIP_AWS_DISCOVERY = originalSkipDiscovery;
+                }
+            });
+
+            it('should create SSM endpoint when offload is active', () => {
+                delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+                const appDefinition = {
+                    vpc: { ownership: { vpcEndpoints: 'auto' } },
+                    ssm: { enable: true },
+                    environment: { FOO: 'ssm' }
+                };
+                const discovery = { stackManaged: [], external: [], fromCloudFormation: false };
+
+                const decisions = resolver.resolveVpcEndpoints(appDefinition, discovery);
+
+                expect(decisions.ssm.ownership).toBe('stack');
+            });
+
+            it('should not create SSM endpoint when offload is not active', () => {
+                delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+                const appDefinition = {
+                    vpc: { ownership: { vpcEndpoints: 'auto' } },
+                    ssm: { enable: true }
+                };
+                const discovery = { stackManaged: [], external: [], fromCloudFormation: false };
+
+                const decisions = resolver.resolveVpcEndpoints(appDefinition, discovery);
+
+                expect(decisions.ssm.ownership).toBeNull();
+            });
         });
 
         it('should resolve to EXTERNAL with user-provided endpoint IDs', () => {

--- a/packages/devtools/infrastructure/domains/parameters/offload-utils.js
+++ b/packages/devtools/infrastructure/domains/parameters/offload-utils.js
@@ -94,7 +94,7 @@ function getOffloadedKeys(appDefinition = {}) {
         keys.add(key);
     }
 
-    return [...keys].sort();
+    return [...keys].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 }
 
 /**

--- a/packages/devtools/infrastructure/domains/parameters/offload-utils.js
+++ b/packages/devtools/infrastructure/domains/parameters/offload-utils.js
@@ -99,6 +99,21 @@ function getParameterPrefix(appDefinition = {}) {
 }
 
 /**
+ * Resolve the parameter prefix to a concrete path outside a serverless
+ * build (e.g. in the CLI), substituting the serverless variables the
+ * default prefix uses.
+ *
+ * @param {Object} appDefinition
+ * @param {string} stage
+ * @returns {string}
+ */
+function resolveParameterPrefix(appDefinition = {}, stage) {
+    return getParameterPrefix(appDefinition)
+        .replaceAll('${self:service}', appDefinition.name)
+        .replaceAll('${self:provider.stage}', stage);
+}
+
+/**
  * Whether the offload feature is active for this build: SSM enabled, at
  * least one key marked, and not running in local mode.
  *
@@ -152,6 +167,7 @@ function validateOffloadConfig(appDefinition = {}) {
 module.exports = {
     getOffloadedKeys,
     getParameterPrefix,
+    resolveParameterPrefix,
     isSsmOffloadActive,
     validateOffloadConfig,
     FRAMEWORK_ENV_BLOCKLIST,

--- a/packages/devtools/infrastructure/domains/parameters/offload-utils.js
+++ b/packages/devtools/infrastructure/domains/parameters/offload-utils.js
@@ -16,6 +16,19 @@ const ENV_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
 const DEFAULT_PARAMETER_PREFIX =
     '/frigg/${self:service}/${self:provider.stage}';
 
+// INIT-phase preload shipped in @friggframework/core, present at this path in
+// every skipEsbuild handler (which packages the full node_modules tree).
+// LAMBDA_TASK_ROOT = /var/task.
+const SSM_PRELOAD_PATH =
+    '/var/task/node_modules/@friggframework/core/core/ssm-preload.mjs';
+
+// NODE_OPTIONS value that loads the INIT preload. Set ONLY on skipEsbuild
+// functions (esbuild-bundled functions do not package the .mjs, and a missing
+// --import target is a fatal Node startup error). No `${env:NODE_OPTIONS}`
+// prefix: that source resolves the deploy host's shell at package time, which
+// would leak an unrelated value into every Lambda.
+const SSM_PRELOAD_NODE_OPTIONS = `--import file://${SSM_PRELOAD_PATH}`;
+
 // Keys the framework itself sets (from discovered resources or the base
 // template) or that the loader/bypass handlers depend on before SSM values
 // are available. Never offloadable.
@@ -172,4 +185,6 @@ module.exports = {
     validateOffloadConfig,
     FRAMEWORK_ENV_BLOCKLIST,
     DEFAULT_PARAMETER_PREFIX,
+    SSM_PRELOAD_PATH,
+    SSM_PRELOAD_NODE_OPTIONS,
 };

--- a/packages/devtools/infrastructure/domains/parameters/offload-utils.js
+++ b/packages/devtools/infrastructure/domains/parameters/offload-utils.js
@@ -1,0 +1,159 @@
+/**
+ * SSM Offload Utilities
+ *
+ * Shared helpers for the SSM Parameter Store offload feature. A variable is
+ * "offloaded" when its value lives in Parameter Store and is fetched by the
+ * runtime at cold start instead of being baked into the Lambda environment
+ * (which counts against the hard 4KB env-var limit).
+ *
+ * Consumed by the SsmBuilder, the environment builder, and the
+ * `frigg ssm push` CLI command so they all agree on the offload key set and
+ * parameter naming.
+ */
+
+const ENV_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+
+const DEFAULT_PARAMETER_PREFIX =
+    '/frigg/${self:service}/${self:provider.stage}';
+
+// Keys the framework itself sets (from discovered resources or the base
+// template) or that the loader/bypass handlers depend on before SSM values
+// are available. Never offloadable.
+const FRAMEWORK_ENV_BLOCKLIST = new Set([
+    'STAGE',
+    'FRIGG_STACK',
+    'FRIGG_STAGE',
+    'FRIGG_REGION',
+    'KMS_KEY_ARN',
+    'AES_KEY',
+    'AES_KEY_ID',
+    'DATABASE_URL',
+    'DATABASE_HOST',
+    'DATABASE_PORT',
+    'DATABASE_USER',
+    'DATABASE_PASSWORD',
+    'DATABASE_SECRET_ARN',
+    'DB_TYPE',
+    'MONGO_URI',
+    'SECRET_ARN',
+    'SSM_PARAMETER_PREFIX',
+    'FRIGG_SSM_OFFLOADED_KEYS',
+    'FRIGG_SSM_CACHE_TTL',
+    'WORKER_FUNCTION_NAME',
+    // Reserved AWS Lambda runtime variables
+    '_HANDLER',
+    '_X_AMZN_TRACE_ID',
+    'AWS_DEFAULT_REGION',
+    'AWS_EXECUTION_ENV',
+    'AWS_REGION',
+    'AWS_LAMBDA_FUNCTION_NAME',
+    'AWS_LAMBDA_FUNCTION_MEMORY_SIZE',
+    'AWS_LAMBDA_FUNCTION_VERSION',
+    'AWS_LAMBDA_INITIALIZATION_TYPE',
+    'AWS_LAMBDA_LOG_GROUP_NAME',
+    'AWS_LAMBDA_LOG_STREAM_NAME',
+    'AWS_ACCESS_KEY',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+]);
+
+/**
+ * Union of keys marked for SSM offload, sorted for deterministic output.
+ * Sources: appDefinition.environment values === 'ssm' and
+ * appDefinition.ssm.parameters keys. Does NOT filter invalid/blocklisted
+ * keys — use validateOffloadConfig() to surface those as errors instead of
+ * silently dropping them.
+ *
+ * @param {Object} appDefinition
+ * @returns {string[]}
+ */
+function getOffloadedKeys(appDefinition = {}) {
+    const keys = new Set();
+
+    for (const [key, value] of Object.entries(
+        appDefinition.environment || {}
+    )) {
+        if (value === 'ssm') keys.add(key);
+    }
+
+    for (const key of Object.keys(appDefinition.ssm?.parameters || {})) {
+        keys.add(key);
+    }
+
+    return [...keys].sort();
+}
+
+/**
+ * Parameter path prefix under which offloaded values are stored. The default
+ * uses serverless variables resolved at package time and stays inside the
+ * *frigg* scope of the generated deployment IAM policies.
+ *
+ * @param {Object} appDefinition
+ * @returns {string}
+ */
+function getParameterPrefix(appDefinition = {}) {
+    const prefix =
+        appDefinition.ssm?.parameterPrefix || DEFAULT_PARAMETER_PREFIX;
+    return prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+}
+
+/**
+ * Whether the offload feature is active for this build: SSM enabled, at
+ * least one key marked, and not running in local mode.
+ *
+ * @param {Object} appDefinition
+ * @returns {boolean}
+ */
+function isSsmOffloadActive(appDefinition = {}) {
+    if (process.env.FRIGG_SKIP_AWS_DISCOVERY === 'true') return false;
+    if (appDefinition.ssm?.enable !== true) return false;
+    return getOffloadedKeys(appDefinition).length > 0;
+}
+
+/**
+ * Validate the offload configuration. Returns errors (not warnings) for
+ * misconfigurations that would silently lose variables at runtime.
+ *
+ * @param {Object} appDefinition
+ * @returns {{errors: string[]}}
+ */
+function validateOffloadConfig(appDefinition = {}) {
+    const errors = [];
+    const offloadedKeys = getOffloadedKeys(appDefinition);
+
+    if (offloadedKeys.length === 0) {
+        return { errors };
+    }
+
+    if (appDefinition.ssm?.enable !== true) {
+        errors.push(
+            `Environment keys are marked for SSM offload (${offloadedKeys.join(
+                ', '
+            )}) but ssm.enable is not true. Set ssm: { enable: true } in the app definition.`
+        );
+    }
+
+    for (const key of offloadedKeys) {
+        if (FRAMEWORK_ENV_BLOCKLIST.has(key)) {
+            errors.push(
+                `${key} is a framework-managed environment variable and cannot be offloaded to SSM.`
+            );
+        } else if (!ENV_NAME_PATTERN.test(key)) {
+            errors.push(
+                `'${key}' is not a valid environment variable name (expected ${ENV_NAME_PATTERN}); it cannot be offloaded to SSM.`
+            );
+        }
+    }
+
+    return { errors };
+}
+
+module.exports = {
+    getOffloadedKeys,
+    getParameterPrefix,
+    isSsmOffloadActive,
+    validateOffloadConfig,
+    FRAMEWORK_ENV_BLOCKLIST,
+    DEFAULT_PARAMETER_PREFIX,
+};

--- a/packages/devtools/infrastructure/domains/parameters/offload-utils.test.js
+++ b/packages/devtools/infrastructure/domains/parameters/offload-utils.test.js
@@ -1,0 +1,159 @@
+const {
+    getOffloadedKeys,
+    getParameterPrefix,
+    isSsmOffloadActive,
+    validateOffloadConfig,
+    FRAMEWORK_ENV_BLOCKLIST,
+} = require('./offload-utils');
+
+describe('offload-utils', () => {
+    const originalSkipDiscovery = process.env.FRIGG_SKIP_AWS_DISCOVERY;
+
+    afterEach(() => {
+        if (originalSkipDiscovery === undefined) {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+        } else {
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = originalSkipDiscovery;
+        }
+    });
+
+    describe('getOffloadedKeys', () => {
+        it('returns empty array when nothing is marked', () => {
+            expect(getOffloadedKeys({})).toEqual([]);
+            expect(
+                getOffloadedKeys({ environment: { MY_VAR: true } })
+            ).toEqual([]);
+        });
+
+        it("collects environment keys marked 'ssm'", () => {
+            const keys = getOffloadedKeys({
+                environment: { B_VAR: 'ssm', A_VAR: 'ssm', PLAIN: true },
+            });
+            expect(keys).toEqual(['A_VAR', 'B_VAR']);
+        });
+
+        it('collects ssm.parameters keys', () => {
+            const keys = getOffloadedKeys({
+                ssm: {
+                    enable: true,
+                    parameters: { MY_SECRET: { type: 'SecureString' } },
+                },
+            });
+            expect(keys).toEqual(['MY_SECRET']);
+        });
+
+        it('unions and dedupes both sources, sorted', () => {
+            const keys = getOffloadedKeys({
+                environment: { SHARED: 'ssm', ENV_ONLY: 'ssm' },
+                ssm: {
+                    enable: true,
+                    parameters: {
+                        SHARED: { type: 'SecureString' },
+                        PARAM_ONLY: { type: 'String' },
+                    },
+                },
+            });
+            expect(keys).toEqual(['ENV_ONLY', 'PARAM_ONLY', 'SHARED']);
+        });
+    });
+
+    describe('getParameterPrefix', () => {
+        it('defaults to the frigg-scoped serverless-variable path', () => {
+            expect(getParameterPrefix({})).toBe(
+                '/frigg/${self:service}/${self:provider.stage}'
+            );
+        });
+
+        it('honors ssm.parameterPrefix override', () => {
+            expect(
+                getParameterPrefix({ ssm: { parameterPrefix: '/custom/x' } })
+            ).toBe('/custom/x');
+        });
+
+        it('strips a trailing slash from the override', () => {
+            expect(
+                getParameterPrefix({ ssm: { parameterPrefix: '/custom/x/' } })
+            ).toBe('/custom/x');
+        });
+    });
+
+    describe('isSsmOffloadActive', () => {
+        const offloadApp = {
+            ssm: { enable: true },
+            environment: { MY_SECRET: 'ssm' },
+        };
+
+        it('is true when ssm enabled and offload set non-empty', () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            expect(isSsmOffloadActive(offloadApp)).toBe(true);
+        });
+
+        it('is false without ssm.enable', () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            expect(
+                isSsmOffloadActive({ environment: { MY_SECRET: 'ssm' } })
+            ).toBe(false);
+        });
+
+        it('is false when nothing is offloaded', () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            expect(isSsmOffloadActive({ ssm: { enable: true } })).toBe(false);
+        });
+
+        it('is false in local mode (FRIGG_SKIP_AWS_DISCOVERY)', () => {
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = 'true';
+            expect(isSsmOffloadActive(offloadApp)).toBe(false);
+        });
+    });
+
+    describe('validateOffloadConfig', () => {
+        it('passes for a clean offload config', () => {
+            const { errors } = validateOffloadConfig({
+                ssm: { enable: true },
+                environment: { MY_SECRET: 'ssm' },
+            });
+            expect(errors).toEqual([]);
+        });
+
+        it('errors when offload markers exist without ssm.enable', () => {
+            const { errors } = validateOffloadConfig({
+                environment: { MY_SECRET: 'ssm' },
+            });
+            expect(errors.join(' ')).toMatch(/ssm\.enable/);
+        });
+
+        it('errors on framework-managed (blocklisted) keys', () => {
+            const { errors } = validateOffloadConfig({
+                ssm: { enable: true },
+                environment: { DATABASE_URL: 'ssm' },
+            });
+            expect(errors.join(' ')).toMatch(/DATABASE_URL/);
+        });
+
+        it('errors on keys that are not valid env var names', () => {
+            const { errors } = validateOffloadConfig({
+                ssm: {
+                    enable: true,
+                    parameters: { 'api-keys/foo': { type: 'String' } },
+                },
+            });
+            expect(errors.join(' ')).toMatch(/api-keys\/foo/);
+        });
+    });
+
+    it('blocklist covers the framework-managed keys', () => {
+        for (const key of [
+            'STAGE',
+            'FRIGG_STACK',
+            'KMS_KEY_ARN',
+            'DATABASE_URL',
+            'DATABASE_SECRET_ARN',
+            'SECRET_ARN',
+            'SSM_PARAMETER_PREFIX',
+            'FRIGG_SSM_OFFLOADED_KEYS',
+            'AWS_REGION',
+        ]) {
+            expect(FRAMEWORK_ENV_BLOCKLIST.has(key)).toBe(true);
+        }
+    });
+});

--- a/packages/devtools/infrastructure/domains/parameters/offload-utils.test.js
+++ b/packages/devtools/infrastructure/domains/parameters/offload-utils.test.js
@@ -77,6 +77,40 @@ describe('offload-utils', () => {
         });
     });
 
+    describe('resolveParameterPrefix', () => {
+        const { resolveParameterPrefix } = require('./offload-utils');
+
+        it('resolves the default prefix with service and stage', () => {
+            expect(
+                resolveParameterPrefix({ name: 'my-app' }, 'prod')
+            ).toBe('/frigg/my-app/prod');
+        });
+
+        it('resolves serverless tokens inside a custom prefix', () => {
+            expect(
+                resolveParameterPrefix(
+                    {
+                        name: 'my-app',
+                        ssm: {
+                            parameterPrefix:
+                                '/x/${self:service}/${self:provider.stage}',
+                        },
+                    },
+                    'dev'
+                )
+            ).toBe('/x/my-app/dev');
+        });
+
+        it('passes literal custom prefixes through', () => {
+            expect(
+                resolveParameterPrefix(
+                    { name: 'my-app', ssm: { parameterPrefix: '/plain/path' } },
+                    'dev'
+                )
+            ).toBe('/plain/path');
+        });
+    });
+
     describe('isSsmOffloadActive', () => {
         const offloadApp = {
             ssm: { enable: true },

--- a/packages/devtools/infrastructure/domains/parameters/ssm-builder.js
+++ b/packages/devtools/infrastructure/domains/parameters/ssm-builder.js
@@ -9,6 +9,12 @@
  */
 
 const { InfrastructureBuilder, ValidationResult } = require('../shared/base-builder');
+const {
+    getOffloadedKeys,
+    getParameterPrefix,
+    isSsmOffloadActive,
+    validateOffloadConfig,
+} = require('./offload-utils');
 
 class SsmBuilder extends InfrastructureBuilder {
     constructor() {
@@ -41,6 +47,10 @@ class SsmBuilder extends InfrastructureBuilder {
             }
         }
 
+        for (const error of validateOffloadConfig(appDefinition).errors) {
+            result.addError(error);
+        }
+
         return result;
     }
 
@@ -55,20 +65,56 @@ class SsmBuilder extends InfrastructureBuilder {
             environment: {},
         };
 
-        // Add IAM permissions for SSM Parameter Store
-        result.iamStatements.push({
-            Effect: 'Allow',
-            Action: [
-                'ssm:GetParameter',
-                'ssm:GetParameters',
-                'ssm:GetParametersByPath',
-            ],
-            Resource: {
-                'Fn::Sub': 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*',
-            },
-        });
+        const ssmActions = [
+            'ssm:GetParameter',
+            'ssm:GetParameters',
+            'ssm:GetParametersByPath',
+        ];
 
-        console.log('  ✅ SSM Parameter Store IAM permissions added');
+        const offloadActive = isSsmOffloadActive(appDefinition);
+
+        // Broad read grant, unless the app opts into prefix-only access while
+        // offload is active.
+        if (!(appDefinition.ssm.restrictIamToPrefix === true && offloadActive)) {
+            result.iamStatements.push({
+                Effect: 'Allow',
+                Action: ssmActions,
+                Resource: {
+                    'Fn::Sub': 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*',
+                },
+            });
+            console.log('  ✅ SSM Parameter Store IAM permissions added');
+        }
+
+        if (offloadActive) {
+            const prefix = getParameterPrefix(appDefinition);
+            const offloadedKeys = getOffloadedKeys(appDefinition);
+
+            result.environment.SSM_PARAMETER_PREFIX = prefix;
+            result.environment.FRIGG_SSM_OFFLOADED_KEYS = offloadedKeys.join(',');
+
+            // Prefix-scoped read grant. Built as a plain serverless string (not
+            // Fn::Sub) because the prefix contains serverless variables like
+            // ${self:service} that Fn::Sub would reject as bad substitution keys.
+            result.iamStatements.push({
+                Effect: 'Allow',
+                Action: ssmActions,
+                Resource: `arn:aws:ssm:\${self:provider.region}:\${aws:accountId}:parameter${prefix}/*`,
+            });
+            console.log(
+                `  ✅ SSM offload enabled for ${offloadedKeys.length} variable(s) under ${prefix}`
+            );
+
+            if (appDefinition.ssm.kmsKeyArn) {
+                result.iamStatements.push({
+                    Effect: 'Allow',
+                    Action: ['kms:Decrypt'],
+                    Resource: appDefinition.ssm.kmsKeyArn,
+                });
+                console.log('  ✅ KMS decrypt permission added for offloaded parameters');
+            }
+        }
+
         console.log(`[${this.name}] ✅ SSM configuration completed`);
 
         return result;

--- a/packages/devtools/infrastructure/domains/parameters/ssm-builder.js
+++ b/packages/devtools/infrastructure/domains/parameters/ssm-builder.js
@@ -16,6 +16,11 @@ const {
     validateOffloadConfig,
 } = require('./offload-utils');
 
+// INIT-phase preload shipped in @friggframework/core, packaged into every
+// skipEsbuild handler at this stable path (LAMBDA_TASK_ROOT = /var/task).
+const SSM_PRELOAD_PATH =
+    '/var/task/node_modules/@friggframework/core/core/ssm-preload.mjs';
+
 class SsmBuilder extends InfrastructureBuilder {
     constructor() {
         super();
@@ -92,6 +97,16 @@ class SsmBuilder extends InfrastructureBuilder {
 
             result.environment.SSM_PARAMETER_PREFIX = prefix;
             result.environment.FRIGG_SSM_OFFLOADED_KEYS = offloadedKeys.join(',');
+
+            // Populate offloaded values into process.env during Lambda INIT,
+            // BEFORE app modules load. api-modules capture OAuth client
+            // credentials at module-require time (top-level Definition.env), so
+            // the handler-time loader (parametersToEnv) is too late for them.
+            // NODE_OPTIONS=--import runs this ESM preload (top-level await) before
+            // the entry module. Shipped in @friggframework/core (packaged into
+            // every skipEsbuild handler at a stable path). Appended to any
+            // app-provided NODE_OPTIONS.
+            result.environment.NODE_OPTIONS = `\${env:NODE_OPTIONS, ''} --import file://${SSM_PRELOAD_PATH}`;
 
             // Prefix-scoped read grant. Built as a plain serverless string (not
             // Fn::Sub) because the prefix contains serverless variables like

--- a/packages/devtools/infrastructure/domains/parameters/ssm-builder.js
+++ b/packages/devtools/infrastructure/domains/parameters/ssm-builder.js
@@ -16,11 +16,6 @@ const {
     validateOffloadConfig,
 } = require('./offload-utils');
 
-// INIT-phase preload shipped in @friggframework/core, packaged into every
-// skipEsbuild handler at this stable path (LAMBDA_TASK_ROOT = /var/task).
-const SSM_PRELOAD_PATH =
-    '/var/task/node_modules/@friggframework/core/core/ssm-preload.mjs';
-
 class SsmBuilder extends InfrastructureBuilder {
     constructor() {
         super();
@@ -98,15 +93,12 @@ class SsmBuilder extends InfrastructureBuilder {
             result.environment.SSM_PARAMETER_PREFIX = prefix;
             result.environment.FRIGG_SSM_OFFLOADED_KEYS = offloadedKeys.join(',');
 
-            // Populate offloaded values into process.env during Lambda INIT,
-            // BEFORE app modules load. api-modules capture OAuth client
-            // credentials at module-require time (top-level Definition.env), so
-            // the handler-time loader (parametersToEnv) is too late for them.
-            // NODE_OPTIONS=--import runs this ESM preload (top-level await) before
-            // the entry module. Shipped in @friggframework/core (packaged into
-            // every skipEsbuild handler at a stable path). Appended to any
-            // app-provided NODE_OPTIONS.
-            result.environment.NODE_OPTIONS = `\${env:NODE_OPTIONS, ''} --import file://${SSM_PRELOAD_PATH}`;
+            // The INIT-phase preload (NODE_OPTIONS=--import) that populates
+            // process.env before app modules load is set per-function on
+            // skipEsbuild handlers only — see infrastructure-composer.js. It
+            // cannot go here (provider.environment is global) because a missing
+            // --import target fatally aborts Node startup, and esbuild-bundled
+            // functions do not package the preload file.
 
             // Prefix-scoped read grant. Built as a plain serverless string (not
             // Fn::Sub) because the prefix contains serverless variables like

--- a/packages/devtools/infrastructure/domains/parameters/ssm-builder.test.js
+++ b/packages/devtools/infrastructure/domains/parameters/ssm-builder.test.js
@@ -72,7 +72,7 @@ describe('SsmBuilder', () => {
                 ssm: {
                     enable: true,
                     parameters: {
-                        DATABASE_URL: '/my-app/database-url',
+                        SERVICE_TOKEN: '/my-app/service-token',
                         API_KEY: '/my-app/api-key',
                     },
                 },
@@ -118,6 +118,42 @@ describe('SsmBuilder', () => {
 
             expect(result.valid).toBe(false);
             expect(result.errors.some(e => e.includes('ssm.parameters must be an object'))).toBe(true);
+        });
+
+        it('should error when keys are marked for offload but ssm.enable is not true', () => {
+            const appDefinition = {
+                ssm: { enable: false },
+                environment: { FOO: 'ssm' },
+            };
+
+            const result = ssmBuilder.validate(appDefinition);
+
+            expect(result.valid).toBe(false);
+            expect(result.errors.some(e => e.includes('ssm.enable is not true'))).toBe(true);
+        });
+
+        it('should error when a blocklisted key is marked for offload', () => {
+            const appDefinition = {
+                ssm: { enable: true },
+                environment: { DATABASE_URL: 'ssm' },
+            };
+
+            const result = ssmBuilder.validate(appDefinition);
+
+            expect(result.valid).toBe(false);
+            expect(result.errors.some(e => e.includes('DATABASE_URL'))).toBe(true);
+        });
+
+        it('should error when an invalid env name is marked for offload', () => {
+            const appDefinition = {
+                ssm: { enable: true },
+                environment: { 'bad-name': 'ssm' },
+            };
+
+            const result = ssmBuilder.validate(appDefinition);
+
+            expect(result.valid).toBe(false);
+            expect(result.errors.some(e => e.includes('bad-name'))).toBe(true);
         });
     });
 
@@ -169,6 +205,114 @@ describe('SsmBuilder', () => {
             const result2 = await ssmBuilder.build(appDefinition, { someResource: 'value' });
 
             expect(result1.iamStatements).toEqual(result2.iamStatements);
+        });
+
+        it('should return empty environment when no keys are offloaded', async () => {
+            const appDefinition = {
+                ssm: { enable: true },
+            };
+
+            const result = await ssmBuilder.build(appDefinition, {});
+
+            expect(result.environment).toEqual({});
+            expect(result.iamStatements).toHaveLength(1);
+        });
+    });
+
+    describe('build() - offload active', () => {
+        it('should add prefix and offloaded keys env vars', async () => {
+            const appDefinition = {
+                ssm: { enable: true },
+                environment: { FOO: 'ssm', BAR: 'ssm' },
+            };
+
+            const result = await ssmBuilder.build(appDefinition, {});
+
+            expect(result.environment.SSM_PARAMETER_PREFIX).toBe(
+                '/frigg/${self:service}/${self:provider.stage}'
+            );
+            expect(result.environment.FRIGG_SSM_OFFLOADED_KEYS).toBe('BAR,FOO');
+        });
+
+        it('should add a prefix-scoped read statement while retaining the broad grant by default', async () => {
+            const appDefinition = {
+                ssm: { enable: true },
+                environment: { FOO: 'ssm' },
+            };
+
+            const result = await ssmBuilder.build(appDefinition, {});
+
+            const broad = result.iamStatements.find(
+                s => s.Resource && s.Resource['Fn::Sub'] === 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
+            );
+            expect(broad).toBeDefined();
+
+            const scoped = result.iamStatements.find(
+                s => s.Resource === 'arn:aws:ssm:${self:provider.region}:${aws:accountId}:parameter/frigg/${self:service}/${self:provider.stage}/*'
+            );
+            expect(scoped).toBeDefined();
+            expect(scoped.Action).toEqual([
+                'ssm:GetParameter',
+                'ssm:GetParameters',
+                'ssm:GetParametersByPath',
+            ]);
+        });
+
+        it('should drop the broad grant when restrictIamToPrefix is set', async () => {
+            const appDefinition = {
+                ssm: { enable: true, restrictIamToPrefix: true },
+                environment: { FOO: 'ssm' },
+            };
+
+            const result = await ssmBuilder.build(appDefinition, {});
+
+            const broad = result.iamStatements.find(
+                s => s.Resource && s.Resource['Fn::Sub']
+            );
+            expect(broad).toBeUndefined();
+
+            const scoped = result.iamStatements.find(
+                s => s.Resource === 'arn:aws:ssm:${self:provider.region}:${aws:accountId}:parameter/frigg/${self:service}/${self:provider.stage}/*'
+            );
+            expect(scoped).toBeDefined();
+        });
+
+        it('should add kms:Decrypt when kmsKeyArn is set', async () => {
+            const appDefinition = {
+                ssm: {
+                    enable: true,
+                    kmsKeyArn: 'arn:aws:kms:us-east-1:123456789012:key/abc-123',
+                },
+                environment: { FOO: 'ssm' },
+            };
+
+            const result = await ssmBuilder.build(appDefinition, {});
+
+            const decrypt = result.iamStatements.find(
+                s => Array.isArray(s.Action) && s.Action.includes('kms:Decrypt')
+            );
+            expect(decrypt).toEqual({
+                Effect: 'Allow',
+                Action: ['kms:Decrypt'],
+                Resource: 'arn:aws:kms:us-east-1:123456789012:key/abc-123',
+            });
+        });
+
+        it('should honor a custom parameterPrefix', async () => {
+            const appDefinition = {
+                ssm: { enable: true, parameterPrefix: '/custom/${self:provider.stage}' },
+                environment: { FOO: 'ssm' },
+            };
+
+            const result = await ssmBuilder.build(appDefinition, {});
+
+            expect(result.environment.SSM_PARAMETER_PREFIX).toBe(
+                '/custom/${self:provider.stage}'
+            );
+            const scoped = result.iamStatements.find(
+                s => s.Resource === 'arn:aws:ssm:${self:provider.region}:${aws:accountId}:parameter/custom/${self:provider.stage}/*'
+            );
+            expect(scoped).toBeDefined();
         });
     });
 

--- a/packages/devtools/infrastructure/domains/parameters/ssm-builder.test.js
+++ b/packages/devtools/infrastructure/domains/parameters/ssm-builder.test.js
@@ -234,6 +234,29 @@ describe('SsmBuilder', () => {
             expect(result.environment.FRIGG_SSM_OFFLOADED_KEYS).toBe('BAR,FOO');
         });
 
+        it('sets NODE_OPTIONS to --import the INIT preload (appended to any app value)', async () => {
+            const appDefinition = {
+                ssm: { enable: true },
+                environment: { FOO: 'ssm' },
+            };
+
+            const result = await ssmBuilder.build(appDefinition, {});
+
+            expect(result.environment.NODE_OPTIONS).toContain('--import');
+            expect(result.environment.NODE_OPTIONS).toContain(
+                '@friggframework/core/core/ssm-preload.mjs'
+            );
+            // Appends to any app-provided NODE_OPTIONS rather than clobbering it.
+            expect(result.environment.NODE_OPTIONS).toContain(
+                "${env:NODE_OPTIONS, ''}"
+            );
+        });
+
+        it('does not set NODE_OPTIONS when no keys are offloaded', async () => {
+            const result = await ssmBuilder.build({ ssm: { enable: true } }, {});
+            expect(result.environment.NODE_OPTIONS).toBeUndefined();
+        });
+
         it('should add a prefix-scoped read statement while retaining the broad grant by default', async () => {
             const appDefinition = {
                 ssm: { enable: true },

--- a/packages/devtools/infrastructure/domains/parameters/ssm-builder.test.js
+++ b/packages/devtools/infrastructure/domains/parameters/ssm-builder.test.js
@@ -234,7 +234,7 @@ describe('SsmBuilder', () => {
             expect(result.environment.FRIGG_SSM_OFFLOADED_KEYS).toBe('BAR,FOO');
         });
 
-        it('sets NODE_OPTIONS to --import the INIT preload (appended to any app value)', async () => {
+        it('does not set NODE_OPTIONS globally (the composer scopes it to skipEsbuild functions)', async () => {
             const appDefinition = {
                 ssm: { enable: true },
                 environment: { FOO: 'ssm' },
@@ -242,18 +242,8 @@ describe('SsmBuilder', () => {
 
             const result = await ssmBuilder.build(appDefinition, {});
 
-            expect(result.environment.NODE_OPTIONS).toContain('--import');
-            expect(result.environment.NODE_OPTIONS).toContain(
-                '@friggframework/core/core/ssm-preload.mjs'
-            );
-            // Appends to any app-provided NODE_OPTIONS rather than clobbering it.
-            expect(result.environment.NODE_OPTIONS).toContain(
-                "${env:NODE_OPTIONS, ''}"
-            );
-        });
-
-        it('does not set NODE_OPTIONS when no keys are offloaded', async () => {
-            const result = await ssmBuilder.build({ ssm: { enable: true } }, {});
+            // NODE_OPTIONS=--import would fatally abort esbuild-bundled functions
+            // that lack the preload file, so it must never be provider-global.
             expect(result.environment.NODE_OPTIONS).toBeUndefined();
         });
 

--- a/packages/devtools/infrastructure/domains/scheduler/scheduler-builder.js
+++ b/packages/devtools/infrastructure/domains/scheduler/scheduler-builder.js
@@ -13,6 +13,11 @@
  */
 
 const { InfrastructureBuilder, ValidationResult } = require('../shared/base-builder');
+const {
+    isScopedEnvironmentActive,
+    getIntegrationFunctionNames,
+    getAdminFunctionNames,
+} = require('../shared/function-environments');
 
 class SchedulerBuilder extends InfrastructureBuilder {
     constructor() {
@@ -70,7 +75,7 @@ class SchedulerBuilder extends InfrastructureBuilder {
         this.addSchedulerIamStatements(result);
 
         // Add environment variables
-        this.addEnvironmentVariables(result);
+        this.addEnvironmentVariables(result, appDefinition);
 
         console.log(`[${this.name}] ✅ Scheduler configuration completed`);
         return result;
@@ -196,15 +201,46 @@ class SchedulerBuilder extends InfrastructureBuilder {
     /**
      * Add environment variables for scheduler configuration
      */
-    addEnvironmentVariables(result) {
-        result.environment.SCHEDULER_ROLE_ARN = {
-            'Fn::GetAtt': ['SchedulerExecutionRole', 'Arn'],
-        };
-        result.environment.SCHEDULE_GROUP_NAME = {
-            Ref: 'FriggScheduleGroup',
+    addEnvironmentVariables(result, appDefinition = {}) {
+        const environment = {
+            SCHEDULER_ROLE_ARN: {
+                'Fn::GetAtt': ['SchedulerExecutionRole', 'Arn'],
+            },
+            SCHEDULE_GROUP_NAME: {
+                Ref: 'FriggScheduleGroup',
+            },
         };
 
-        console.log('  ✓ Added scheduler environment variables');
+        if (!isScopedEnvironmentActive(appDefinition)) {
+            Object.assign(result.environment, environment);
+            console.log('  ✓ Added scheduler environment variables');
+            return;
+        }
+
+        // Consumers: auth (runs integration actions), the executor (runs
+        // admin scripts that instantiate integrations), and every
+        // integration function. NOT adminScriptRouter — it carries its own
+        // admin-scheduler role, set directly by the admin-script builder.
+        const targets = [
+            'auth',
+            ...getAdminFunctionNames(appDefinition).filter(
+                (fnName) => fnName !== 'adminScriptRouter'
+            ),
+            ...(appDefinition.integrations || []).flatMap(
+                getIntegrationFunctionNames
+            ),
+        ];
+
+        result.functionEnvironments = result.functionEnvironments || {};
+        for (const fnName of targets) {
+            result.functionEnvironments[fnName] = {
+                ...result.functionEnvironments[fnName],
+                ...environment,
+            };
+        }
+        console.log(
+            `  ✓ Scoped scheduler environment variables to: ${targets.join(', ')}`
+        );
     }
 }
 

--- a/packages/devtools/infrastructure/domains/scheduler/scheduler-builder.test.js
+++ b/packages/devtools/infrastructure/domains/scheduler/scheduler-builder.test.js
@@ -1,0 +1,118 @@
+/**
+ * Tests for Scheduler Builder
+ */
+
+const { SchedulerBuilder } = require('./scheduler-builder');
+
+describe('SchedulerBuilder', () => {
+    let schedulerBuilder;
+    const originalSkipDiscovery = process.env.FRIGG_SKIP_AWS_DISCOVERY;
+
+    beforeEach(() => {
+        schedulerBuilder = new SchedulerBuilder();
+        delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+    });
+
+    afterEach(() => {
+        if (originalSkipDiscovery === undefined) {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+        } else {
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = originalSkipDiscovery;
+        }
+    });
+
+    describe('shouldExecute()', () => {
+        it('runs when explicitly enabled', () => {
+            expect(
+                schedulerBuilder.shouldExecute({ scheduler: { enable: true } })
+            ).toBe(true);
+        });
+
+        it('runs when any integration has webhooks', () => {
+            expect(
+                schedulerBuilder.shouldExecute({
+                    integrations: [
+                        { Definition: { name: 'a', webhooks: true } },
+                    ],
+                })
+            ).toBe(true);
+        });
+
+        it('skips otherwise', () => {
+            expect(
+                schedulerBuilder.shouldExecute({
+                    integrations: [{ Definition: { name: 'a' } }],
+                })
+            ).toBe(false);
+        });
+    });
+
+    describe('build() environment', () => {
+        const scheduledApp = (extra = {}) => ({
+            scheduler: { enable: true },
+            integrations: [
+                { Definition: { name: 'hubspot', webhooks: true } },
+                { Definition: { name: 'slack' } },
+            ],
+            ...extra,
+        });
+
+        it('broadcasts scheduler vars app-wide by default', async () => {
+            const result = await schedulerBuilder.build(scheduledApp(), {});
+
+            expect(result.environment.SCHEDULER_ROLE_ARN).toEqual({
+                'Fn::GetAtt': ['SchedulerExecutionRole', 'Arn'],
+            });
+            expect(result.environment.SCHEDULE_GROUP_NAME).toEqual({
+                Ref: 'FriggScheduleGroup',
+            });
+            expect(result.functionEnvironments).toBeUndefined();
+        });
+
+        it('scopes scheduler vars to auth, adminScriptExecutor, and integration functions with lambda.scopedEnvironment', async () => {
+            const result = await schedulerBuilder.build(
+                scheduledApp({
+                    lambda: { scopedEnvironment: true },
+                    adminScripts: [{ Definition: { name: 'fix-things' } }],
+                }),
+                {}
+            );
+
+            expect(result.environment.SCHEDULER_ROLE_ARN).toBeUndefined();
+            expect(result.environment.SCHEDULE_GROUP_NAME).toBeUndefined();
+
+            const scoped = result.functionEnvironments;
+            for (const fnName of [
+                'auth',
+                'adminScriptExecutor',
+                'hubspot',
+                'hubspotWebhook',
+                'hubspotQueueWorker',
+                'slack',
+                'slackQueueWorker',
+            ]) {
+                expect(scoped[fnName].SCHEDULER_ROLE_ARN).toEqual({
+                    'Fn::GetAtt': ['SchedulerExecutionRole', 'Arn'],
+                });
+                expect(scoped[fnName].SCHEDULE_GROUP_NAME).toEqual({
+                    Ref: 'FriggScheduleGroup',
+                });
+            }
+
+            // the router keeps its own admin-scheduler role, set directly by
+            // the admin-script builder — never targeted here
+            expect(scoped.adminScriptRouter).toBeUndefined();
+        });
+
+        it('keeps broadcasting in local mode even with the flag on', async () => {
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = 'true';
+            const result = await schedulerBuilder.build(
+                scheduledApp({ lambda: { scopedEnvironment: true } }),
+                {}
+            );
+
+            expect(result.environment.SCHEDULER_ROLE_ARN).toBeDefined();
+            expect(result.functionEnvironments).toBeUndefined();
+        });
+    });
+});

--- a/packages/devtools/infrastructure/domains/security/iam-generator.js
+++ b/packages/devtools/infrastructure/domains/security/iam-generator.js
@@ -804,6 +804,7 @@ function getFeatureSummary(appDefinition) {
         features,
         integrationCount,
         appName: appDefinition.name || 'Unnamed Frigg App',
+        ssmKmsKeyArn: appDefinition.ssm?.kmsKeyArn,
     };
 }
 

--- a/packages/devtools/infrastructure/domains/security/iam-generator.js
+++ b/packages/devtools/infrastructure/domains/security/iam-generator.js
@@ -667,6 +667,9 @@ function generateIAMCloudFormation(options = {}) {
                                 'ssm:GetParameter',
                                 'ssm:GetParameters',
                                 'ssm:GetParametersByPath',
+                                'ssm:PutParameter',
+                                'ssm:DeleteParameter',
+                                'ssm:AddTagsToResource',
                             ],
                             Resource: [
                                 {

--- a/packages/devtools/infrastructure/domains/security/iam-generator.js
+++ b/packages/devtools/infrastructure/domains/security/iam-generator.js
@@ -7,6 +7,7 @@ const path = require('path');
  * @param {Object} [options.features={}] - Enabled features { vpc, kms, ssm, websockets }
  * @param {string} [options.userPrefix='frigg-deployment-user'] - IAM user name prefix
  * @param {string} [options.stackName='frigg-deployment-iam'] - CloudFormation stack name
+ * @param {string} [options.ssmKmsKeyArn] - Customer-managed KMS key ARN for SecureString offload (appDefinition.ssm.kmsKeyArn)
  * @returns {string} CloudFormation YAML template
  */
 function generateIAMCloudFormation(options = {}) {
@@ -14,7 +15,8 @@ function generateIAMCloudFormation(options = {}) {
         appName = 'Frigg',
         features = {},
         userPrefix = 'frigg-deployment-user',
-        stackName = 'frigg-deployment-iam'
+        stackName = 'frigg-deployment-iam',
+        ssmKmsKeyArn
     } = options;
 
     const deploymentUserName = userPrefix;
@@ -681,6 +683,32 @@ function generateIAMCloudFormation(options = {}) {
                                         'arn:aws:ssm:*:${AWS::AccountId}:parameter/*frigg*/*',
                                 },
                             ],
+                        },
+                        {
+                            // SecureString offload: SSM performs the KMS encrypt/decrypt
+                            // on the caller's behalf, so the grant is scoped to ViaService ssm.*
+                            Sid: 'FriggSSMParameterKMSEncryption',
+                            Effect: 'Allow',
+                            Action: [
+                                'kms:Encrypt',
+                                'kms:GenerateDataKey',
+                                'kms:Decrypt',
+                            ],
+                            Resource: ssmKmsKeyArn
+                                ? [ssmKmsKeyArn]
+                                : [
+                                      {
+                                          'Fn::Sub':
+                                              'arn:aws:kms:*:${AWS::AccountId}:key/*',
+                                      },
+                                  ],
+                            Condition: {
+                                StringEquals: {
+                                    'kms:ViaService': [
+                                        'ssm.*.amazonaws.com',
+                                    ],
+                                },
+                            },
                         },
                     ],
                 },

--- a/packages/devtools/infrastructure/domains/security/iam-generator.js
+++ b/packages/devtools/infrastructure/domains/security/iam-generator.js
@@ -703,7 +703,10 @@ function generateIAMCloudFormation(options = {}) {
                                       },
                                   ],
                             Condition: {
-                                StringEquals: {
+                                // StringLike: kms:ViaService is regional
+                                // (ssm.us-east-1.amazonaws.com), so the wildcard
+                                // must be matched, not compared literally.
+                                StringLike: {
                                     'kms:ViaService': [
                                         'ssm.*.amazonaws.com',
                                     ],

--- a/packages/devtools/infrastructure/domains/security/iam-generator.test.js
+++ b/packages/devtools/infrastructure/domains/security/iam-generator.test.js
@@ -166,6 +166,16 @@ describe('IAM Generator', () => {
             expect(yaml).toContain('ssm.*.amazonaws.com');
             // No customer-managed key configured: falls back to the account key wildcard
             expect(yaml).toContain('arn:aws:kms:*:${AWS::AccountId}:key/*');
+
+            // The regional ViaService wildcard must be matched with StringLike;
+            // StringEquals would compare literally and never match
+            // ssm.<region>.amazonaws.com, denying the SecureString KMS call.
+            const ssmKmsBlock = yaml.slice(
+                yaml.indexOf('FriggSSMParameterKMSEncryption'),
+                yaml.indexOf('FriggSSMParameterKMSEncryption') + 600
+            );
+            expect(ssmKmsBlock).toContain('StringLike');
+            expect(ssmKmsBlock).not.toContain('StringEquals');
         });
 
         it('should scope the SSM KMS grant to ssm.kmsKeyArn when provided', () => {

--- a/packages/devtools/infrastructure/domains/security/iam-generator.test.js
+++ b/packages/devtools/infrastructure/domains/security/iam-generator.test.js
@@ -38,6 +38,34 @@ describe('IAM Generator', () => {
             expect(summary.features.ssm).toBe(false);
             expect(summary.features.websockets).toBe(false);
         });
+
+        it('should surface ssm.kmsKeyArn from the app definition', () => {
+            const appDefinition = {
+                name: 'test-app',
+                ssm: {
+                    enable: true,
+                    kmsKeyArn:
+                        'arn:aws:kms:us-east-1:123456789012:key/abcd-1234'
+                }
+            };
+
+            const summary = getFeatureSummary(appDefinition);
+
+            expect(summary.ssmKmsKeyArn).toBe(
+                'arn:aws:kms:us-east-1:123456789012:key/abcd-1234'
+            );
+        });
+
+        it('should leave ssmKmsKeyArn undefined when not configured', () => {
+            const appDefinition = {
+                name: 'test-app',
+                ssm: { enable: true }
+            };
+
+            const summary = getFeatureSummary(appDefinition);
+
+            expect(summary.ssmKmsKeyArn).toBeUndefined();
+        });
     });
 
     describe('generateIAMCloudFormation', () => {

--- a/packages/devtools/infrastructure/domains/security/iam-generator.test.js
+++ b/packages/devtools/infrastructure/domains/security/iam-generator.test.js
@@ -120,6 +120,51 @@ describe('IAM Generator', () => {
             expect(yaml).toContain('EnableSSMSupport');
         });
 
+        it('should grant SSM-mediated KMS access via ssm.*.amazonaws.com when SSM is enabled', () => {
+            const appDefinition = {
+                name: 'test-app',
+                integrations: [],
+                ssm: { enable: true }
+            };
+
+            const summary = getFeatureSummary(appDefinition);
+            const yaml = generateIAMCloudFormation({
+                appName: summary.appName,
+                features: summary.features
+            });
+
+            expect(yaml).toContain('FriggSSMParameterKMSEncryption');
+            expect(yaml).toContain('kms:Encrypt');
+            expect(yaml).toContain('ssm.*.amazonaws.com');
+            // No customer-managed key configured: falls back to the account key wildcard
+            expect(yaml).toContain('arn:aws:kms:*:${AWS::AccountId}:key/*');
+        });
+
+        it('should scope the SSM KMS grant to ssm.kmsKeyArn when provided', () => {
+            const appDefinition = {
+                name: 'test-app',
+                integrations: [],
+                ssm: {
+                    enable: true,
+                    kmsKeyArn:
+                        'arn:aws:kms:us-east-1:123456789012:key/abcd-1234'
+                }
+            };
+
+            const summary = getFeatureSummary(appDefinition);
+            const yaml = generateIAMCloudFormation({
+                appName: summary.appName,
+                features: summary.features,
+                ssmKmsKeyArn: appDefinition.ssm.kmsKeyArn
+            });
+
+            expect(yaml).toContain('FriggSSMParameterKMSEncryption');
+            expect(yaml).toContain(
+                'arn:aws:kms:us-east-1:123456789012:key/abcd-1234'
+            );
+            expect(yaml).not.toContain('arn:aws:kms:*:${AWS::AccountId}:key/*');
+        });
+
         it('should set correct default parameter values based on features', () => {
             const appDefinition = {
                 name: 'test-app',

--- a/packages/devtools/infrastructure/domains/security/templates/frigg-deployment-iam-stack.yaml
+++ b/packages/devtools/infrastructure/domains/security/templates/frigg-deployment-iam-stack.yaml
@@ -343,6 +343,7 @@ Resources:
                 'kms:ViaService':
                   - 'lambda.*.amazonaws.com'
                   - 's3.*.amazonaws.com'
+                  - 'ssm.*.amazonaws.com'
 
   # SSM Parameter Store permissions
   FriggSSMPolicy:

--- a/packages/devtools/infrastructure/domains/security/templates/frigg-deployment-iam-stack.yaml
+++ b/packages/devtools/infrastructure/domains/security/templates/frigg-deployment-iam-stack.yaml
@@ -375,7 +375,9 @@ Resources:
             Resource:
               - !Sub 'arn:aws:kms:*:${AWS::AccountId}:key/*'
             Condition:
-              StringEquals:
+              # StringLike: kms:ViaService is regional (ssm.us-east-1.amazonaws.com),
+              # so the wildcard must be matched, not compared literally.
+              StringLike:
                 'kms:ViaService':
                   - 'ssm.*.amazonaws.com'
 

--- a/packages/devtools/infrastructure/domains/security/templates/frigg-deployment-iam-stack.yaml
+++ b/packages/devtools/infrastructure/domains/security/templates/frigg-deployment-iam-stack.yaml
@@ -360,6 +360,9 @@ Resources:
               - 'ssm:GetParameter'
               - 'ssm:GetParameters'
               - 'ssm:GetParametersByPath'
+              - 'ssm:PutParameter'
+              - 'ssm:DeleteParameter'
+              - 'ssm:AddTagsToResource'
             Resource:
               - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:parameter/*frigg*'
               - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:parameter/*frigg*/*'

--- a/packages/devtools/infrastructure/domains/security/templates/frigg-deployment-iam-stack.yaml
+++ b/packages/devtools/infrastructure/domains/security/templates/frigg-deployment-iam-stack.yaml
@@ -343,7 +343,6 @@ Resources:
                 'kms:ViaService':
                   - 'lambda.*.amazonaws.com'
                   - 's3.*.amazonaws.com'
-                  - 'ssm.*.amazonaws.com'
 
   # SSM Parameter Store permissions
   FriggSSMPolicy:
@@ -367,6 +366,18 @@ Resources:
             Resource:
               - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:parameter/*frigg*'
               - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:parameter/*frigg*/*'
+          - Sid: 'FriggSSMParameterKMSEncryption'
+            Effect: Allow
+            Action:
+              - 'kms:Encrypt'
+              - 'kms:GenerateDataKey'
+              - 'kms:Decrypt'
+            Resource:
+              - !Sub 'arn:aws:kms:*:${AWS::AccountId}:key/*'
+            Condition:
+              StringEquals:
+                'kms:ViaService':
+                  - 'ssm.*.amazonaws.com'
 
   # Store access key in Secrets Manager
   FriggDeploymentCredentials:

--- a/packages/devtools/infrastructure/domains/security/templates/iam-policy-full.json
+++ b/packages/devtools/infrastructure/domains/security/templates/iam-policy-full.json
@@ -277,7 +277,10 @@
       "Action": [
         "ssm:GetParameter",
         "ssm:GetParameters",
-        "ssm:GetParametersByPath"
+        "ssm:GetParametersByPath",
+        "ssm:PutParameter",
+        "ssm:DeleteParameter",
+        "ssm:AddTagsToResource"
       ],
       "Resource": [
         "arn:aws:ssm:*:*:parameter/*frigg*",

--- a/packages/devtools/infrastructure/domains/security/templates/iam-policy-full.json
+++ b/packages/devtools/infrastructure/domains/security/templates/iam-policy-full.json
@@ -266,7 +266,8 @@
         "StringEquals": {
           "kms:ViaService": [
             "lambda.*.amazonaws.com",
-            "s3.*.amazonaws.com"
+            "s3.*.amazonaws.com",
+            "ssm.*.amazonaws.com"
           ]
         }
       }

--- a/packages/devtools/infrastructure/domains/security/templates/iam-policy-full.json
+++ b/packages/devtools/infrastructure/domains/security/templates/iam-policy-full.json
@@ -256,6 +256,7 @@
       "Sid": "FriggKMSEncryptionPermissions",
       "Effect": "Allow",
       "Action": [
+        "kms:Encrypt",
         "kms:GenerateDataKey",
         "kms:Decrypt"
       ],

--- a/packages/devtools/infrastructure/domains/security/templates/iam-policy-full.json
+++ b/packages/devtools/infrastructure/domains/security/templates/iam-policy-full.json
@@ -264,7 +264,7 @@
         "arn:aws:kms:*:*:key/*"
       ],
       "Condition": {
-        "StringEquals": {
+        "StringLike": {
           "kms:ViaService": [
             "lambda.*.amazonaws.com",
             "s3.*.amazonaws.com",

--- a/packages/devtools/infrastructure/domains/shared/builder-orchestrator.js
+++ b/packages/devtools/infrastructure/domains/shared/builder-orchestrator.js
@@ -144,6 +144,7 @@ class BuilderOrchestrator {
             iamStatements: [],
             environment: {},
             functions: {},
+            functionEnvironments: {},
             layers: {},
             plugins: [],
             custom: {},
@@ -170,6 +171,19 @@ class BuilderOrchestrator {
             // Merge functions
             if (result.functions) {
                 Object.assign(merged.functions, result.functions);
+            }
+
+            // Merge function-scoped environment maps (applied by the
+            // composer once base + builder functions all exist)
+            if (result.functionEnvironments) {
+                for (const [fnName, env] of Object.entries(
+                    result.functionEnvironments
+                )) {
+                    merged.functionEnvironments[fnName] = {
+                        ...merged.functionEnvironments[fnName],
+                        ...env,
+                    };
+                }
             }
 
             // Merge layers

--- a/packages/devtools/infrastructure/domains/shared/builder-orchestrator.test.js
+++ b/packages/devtools/infrastructure/domains/shared/builder-orchestrator.test.js
@@ -208,6 +208,51 @@ describe('BuilderOrchestrator', () => {
 
             await expect(orchestrator.buildAll({})).rejects.toThrow('Build failed');
         });
+
+        it('should merge functionEnvironments per function, later builder winning on key conflict', async () => {
+            class ScopedEnvBuilderA extends InfrastructureBuilder {
+                getName() { return 'ScopedEnvBuilderA'; }
+                shouldExecute() { return true; }
+                validate() { return new ValidationResult(); }
+                async build() {
+                    return {
+                        functionEnvironments: {
+                            auth: { QUEUE_A: 'url-a', SHARED: 'from-a' },
+                            workerA: { QUEUE_A: 'url-a' },
+                        },
+                    };
+                }
+            }
+            class ScopedEnvBuilderB extends InfrastructureBuilder {
+                getName() { return 'ScopedEnvBuilderB'; }
+                shouldExecute() { return true; }
+                validate() { return new ValidationResult(); }
+                getDependencies() { return ['ScopedEnvBuilderA']; }
+                async build() {
+                    return {
+                        functionEnvironments: {
+                            auth: { QUEUE_B: 'url-b', SHARED: 'from-b' },
+                        },
+                    };
+                }
+            }
+
+            orchestrator = new BuilderOrchestrator([
+                new ScopedEnvBuilderA(),
+                new ScopedEnvBuilderB(),
+            ]);
+
+            const result = await orchestrator.buildAll({});
+
+            expect(result.merged.functionEnvironments).toEqual({
+                auth: {
+                    QUEUE_A: 'url-a',
+                    QUEUE_B: 'url-b',
+                    SHARED: 'from-b',
+                },
+                workerA: { QUEUE_A: 'url-a' },
+            });
+        });
     });
 });
 

--- a/packages/devtools/infrastructure/domains/shared/environment-builder.js
+++ b/packages/devtools/infrastructure/domains/shared/environment-builder.js
@@ -9,12 +9,19 @@
  * 3. Generated resource references
  */
 
+const { isSsmOffloadActive } = require('../parameters/offload-utils');
+
 /**
  * Get environment variables from AppDefinition
- * 
+ *
  * Extracts environment variable definitions where value is true,
  * and creates Serverless variable references.
- * 
+ *
+ * A value of 'ssm' offloads the variable to Parameter Store when offload is
+ * active (see SsmBuilder), keeping it out of the Lambda env map. When offload
+ * is not active (local mode / ssm disabled) it falls back to the same
+ * `${env:KEY, ''}` reference as `true` so `frigg start` + dotenv keeps working.
+ *
  * @param {Object} appDefinition - Application definition
  * @returns {Object} Environment variable mappings
  */
@@ -45,9 +52,15 @@ function getAppEnvironmentVars(appDefinition) {
     console.log('📋 Loading environment variables from appDefinition...');
     const envKeys = [];
     const skippedKeys = [];
+    const offloadedKeys = [];
+    const offloadActive = isSsmOffloadActive(appDefinition);
 
     for (const [key, value] of Object.entries(appDefinition.environment)) {
-        if (value !== true) continue;
+        if (value === 'ssm' && offloadActive) {
+            offloadedKeys.push(key);
+            continue;
+        }
+        if (value !== true && value !== 'ssm') continue;
         if (reservedVars.has(key)) {
             skippedKeys.push(key);
             continue;
@@ -67,6 +80,13 @@ function getAppEnvironmentVars(appDefinition) {
         console.log(
             `   ⚠️  Skipped ${skippedKeys.length
             } reserved AWS Lambda variables: ${skippedKeys.join(', ')}`
+        );
+    }
+    if (offloadedKeys.length > 0) {
+        console.log(
+            `   🔒 Offloaded ${offloadedKeys.length} variables to SSM: ${offloadedKeys.join(
+                ', '
+            )}`
         );
     }
 

--- a/packages/devtools/infrastructure/domains/shared/environment-builder.js
+++ b/packages/devtools/infrastructure/domains/shared/environment-builder.js
@@ -9,7 +9,7 @@
  * 3. Generated resource references
  */
 
-const { isSsmOffloadActive } = require('../parameters/offload-utils');
+const { isSsmOffloadActive, getOffloadedKeys } = require('../parameters/offload-utils');
 
 /**
  * Get environment variables from AppDefinition
@@ -45,9 +45,7 @@ function getAppEnvironmentVars(appDefinition) {
         'AWS_SESSION_TOKEN',
     ]);
 
-    if (!appDefinition.environment) {
-        return envVars;
-    }
+    const environment = appDefinition.environment || {};
 
     console.log('📋 Loading environment variables from appDefinition...');
     const envKeys = [];
@@ -55,12 +53,30 @@ function getAppEnvironmentVars(appDefinition) {
     const offloadedKeys = [];
     const offloadActive = isSsmOffloadActive(appDefinition);
 
-    for (const [key, value] of Object.entries(appDefinition.environment)) {
+    for (const [key, value] of Object.entries(environment)) {
         if (value === 'ssm' && offloadActive) {
             offloadedKeys.push(key);
             continue;
         }
         if (value !== true && value !== 'ssm') continue;
+        if (reservedVars.has(key)) {
+            skippedKeys.push(key);
+            continue;
+        }
+        envVars[key] = `\${env:${key}, ''}`;
+        envKeys.push(key);
+    }
+
+    // Keys declared only in ssm.parameters (no matching `environment` entry)
+    // get the same local-fallback treatment as `environment`-valued 'ssm' keys.
+    const ssmOnlyKeys = getOffloadedKeys(appDefinition).filter(
+        (key) => !(key in environment)
+    );
+    for (const key of ssmOnlyKeys) {
+        if (offloadActive) {
+            offloadedKeys.push(key);
+            continue;
+        }
         if (reservedVars.has(key)) {
             skippedKeys.push(key);
             continue;

--- a/packages/devtools/infrastructure/domains/shared/environment-builder.test.js
+++ b/packages/devtools/infrastructure/domains/shared/environment-builder.test.js
@@ -155,6 +155,53 @@ describe('Environment Builder', () => {
 
             expect(result.FOO).toBe("${env:FOO, ''}");
         });
+
+        it('falls back to env reference for a key declared only in ssm.parameters when FRIGG_SKIP_AWS_DISCOVERY is set', () => {
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = 'true';
+            const appDefinition = {
+                ssm: {
+                    enable: true,
+                    parameters: { HUBSPOT_CLIENT_SECRET: { type: 'SecureString' } },
+                },
+            };
+
+            const result = getAppEnvironmentVars(appDefinition);
+
+            expect(result.HUBSPOT_CLIENT_SECRET).toBe("${env:HUBSPOT_CLIENT_SECRET, ''}");
+        });
+
+        it('excludes a key declared only in ssm.parameters when offload is active', () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            const appDefinition = {
+                ssm: {
+                    enable: true,
+                    parameters: { HUBSPOT_CLIENT_SECRET: { type: 'SecureString' } },
+                },
+            };
+
+            const result = getAppEnvironmentVars(appDefinition);
+
+            expect(result.HUBSPOT_CLIENT_SECRET).toBeUndefined();
+        });
+
+        it("does not double-process a key present in both environment:'ssm' and ssm.parameters", () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            const appDefinition = {
+                ssm: {
+                    enable: true,
+                    parameters: { FOO: { type: 'SecureString' } },
+                },
+                environment: { FOO: 'ssm' },
+            };
+
+            const result = getAppEnvironmentVars(appDefinition);
+
+            expect(result.FOO).toBeUndefined();
+
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = 'true';
+            const fallbackResult = getAppEnvironmentVars(appDefinition);
+            expect(fallbackResult.FOO).toBe("${env:FOO, ''}");
+        });
     });
 
     describe('buildEnvironment()', () => {

--- a/packages/devtools/infrastructure/domains/shared/environment-builder.test.js
+++ b/packages/devtools/infrastructure/domains/shared/environment-builder.test.js
@@ -38,7 +38,7 @@ describe('Environment Builder', () => {
             expect(result.DISABLED_VAR).toBeUndefined();
         });
 
-        it('should ignore environment variables with non-boolean values', () => {
+        it("ignores non-boolean values other than the meaningful 'ssm' marker", () => {
             const appDefinition = {
                 environment: {
                     VALID: true,
@@ -105,6 +105,55 @@ describe('Environment Builder', () => {
 
             // Should use serverless variable syntax with empty string fallback
             expect(result.MY_VAR).toBe("${env:MY_VAR, ''}");
+        });
+    });
+
+    describe("getAppEnvironmentVars() - 'ssm' offload", () => {
+        const originalSkipDiscovery = process.env.FRIGG_SKIP_AWS_DISCOVERY;
+
+        afterEach(() => {
+            if (originalSkipDiscovery === undefined) {
+                delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            } else {
+                process.env.FRIGG_SKIP_AWS_DISCOVERY = originalSkipDiscovery;
+            }
+        });
+
+        it("excludes 'ssm' keys when offload is active", () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            const appDefinition = {
+                ssm: { enable: true },
+                environment: { FOO: 'ssm', BAR: true },
+            };
+
+            const result = getAppEnvironmentVars(appDefinition);
+
+            expect(result.FOO).toBeUndefined();
+            expect(result.BAR).toBe("${env:BAR, ''}");
+        });
+
+        it("falls back to env reference for 'ssm' keys when FRIGG_SKIP_AWS_DISCOVERY is set", () => {
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = 'true';
+            const appDefinition = {
+                ssm: { enable: true },
+                environment: { FOO: 'ssm' },
+            };
+
+            const result = getAppEnvironmentVars(appDefinition);
+
+            expect(result.FOO).toBe("${env:FOO, ''}");
+        });
+
+        it("falls back to env reference for 'ssm' keys when ssm is disabled", () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            const appDefinition = {
+                ssm: { enable: false },
+                environment: { FOO: 'ssm' },
+            };
+
+            const result = getAppEnvironmentVars(appDefinition);
+
+            expect(result.FOO).toBe("${env:FOO, ''}");
         });
     });
 

--- a/packages/devtools/infrastructure/domains/shared/function-environments.js
+++ b/packages/devtools/infrastructure/domains/shared/function-environments.js
@@ -1,0 +1,97 @@
+/**
+ * Per-function environment scoping (ADR-027)
+ *
+ * Builders emit `result.functionEnvironments` — a map of function name to
+ * env vars — instead of broadcasting framework vars app-wide through
+ * `result.environment`. The composer applies the merged map onto the final
+ * function definitions after every function (base + builder) exists.
+ */
+
+/**
+ * Whether builders should scope framework env vars per function. Skipped in
+ * local mode: the serverless-plugin injects LocalStack queue URLs at
+ * provider level only, and function-level values would shadow them.
+ *
+ * @param {Object} appDefinition
+ * @returns {boolean}
+ */
+function isScopedEnvironmentActive(appDefinition = {}) {
+    if (process.env.FRIGG_SKIP_AWS_DISCOVERY === 'true') return false;
+    return appDefinition.lambda?.scopedEnvironment === true;
+}
+
+/**
+ * Apply a merged functionEnvironments map onto the composed functions.
+ * A key a builder already set directly on a function wins (e.g. the
+ * admin-script router's own SCHEDULER_ROLE_ARN must not be clobbered by
+ * the integration-scheduler value). An unknown function name is a hard
+ * error — silently dropping a var would surface as a runtime failure.
+ *
+ * @param {Object} functions - definition.functions (mutated)
+ * @param {Object} functionEnvironments - { fnName: { KEY: value } }
+ */
+function applyFunctionEnvironments(functions, functionEnvironments = {}) {
+    for (const [fnName, env] of Object.entries(functionEnvironments)) {
+        const fn = functions[fnName];
+        if (!fn) {
+            throw new Error(
+                `functionEnvironments targets unknown function '${fnName}' (known: ${Object.keys(
+                    functions
+                ).join(', ')})`
+            );
+        }
+        fn.environment = { ...env, ...(fn.environment || {}) };
+    }
+}
+
+/**
+ * Function names the integration builder creates for one integration.
+ * Wire contract: must stay in sync with
+ * IntegrationBuilder.createFunctionDefinitions — a drift here surfaces as a
+ * hard unknown-function error at compose time, not a silent var drop.
+ *
+ * @param {Object} integration - entry from appDefinition.integrations
+ * @returns {string[]}
+ */
+function getIntegrationFunctionNames(integration) {
+    const name = integration.Definition.name;
+    const names = [name, `${name}QueueWorker`];
+
+    const webhooks = integration.Definition.webhooks;
+    if (webhooks === true || webhooks?.enabled === true) {
+        names.splice(1, 0, `${name}Webhook`);
+    }
+
+    for (const [bindingKey, binding] of Object.entries(
+        integration.Definition.extensions || {}
+    )) {
+        const routes = binding?.extension?.routes || [];
+        if (routes.length === 0) continue;
+        names.push(`${name}__${String(bindingKey).replace(/[^A-Za-z0-9]/g, '')}`);
+    }
+
+    return names;
+}
+
+/**
+ * Admin-script functions, when the feature is on (mirrors
+ * AdminScriptBuilder.shouldExecute). Both can instantiate arbitrary
+ * integrations, so they belong in every integration's queue-URL consumer
+ * set.
+ *
+ * @param {Object} appDefinition
+ * @returns {string[]}
+ */
+function getAdminFunctionNames(appDefinition = {}) {
+    return Array.isArray(appDefinition.adminScripts) &&
+        appDefinition.adminScripts.length > 0
+        ? ['adminScriptRouter', 'adminScriptExecutor']
+        : [];
+}
+
+module.exports = {
+    isScopedEnvironmentActive,
+    applyFunctionEnvironments,
+    getIntegrationFunctionNames,
+    getAdminFunctionNames,
+};

--- a/packages/devtools/infrastructure/domains/shared/function-environments.test.js
+++ b/packages/devtools/infrastructure/domains/shared/function-environments.test.js
@@ -1,0 +1,146 @@
+const {
+    isScopedEnvironmentActive,
+    applyFunctionEnvironments,
+} = require('./function-environments');
+
+describe('function-environments', () => {
+    const originalSkipDiscovery = process.env.FRIGG_SKIP_AWS_DISCOVERY;
+
+    afterEach(() => {
+        if (originalSkipDiscovery === undefined) {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+        } else {
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = originalSkipDiscovery;
+        }
+    });
+
+    describe('isScopedEnvironmentActive', () => {
+        it('is true only when lambda.scopedEnvironment is set', () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            expect(
+                isScopedEnvironmentActive({
+                    lambda: { scopedEnvironment: true },
+                })
+            ).toBe(true);
+            expect(isScopedEnvironmentActive({})).toBe(false);
+            expect(
+                isScopedEnvironmentActive({
+                    lambda: { scopedEnvironment: false },
+                })
+            ).toBe(false);
+        });
+
+        it('is false in local mode: the serverless-plugin injects LocalStack queue URLs at provider level only', () => {
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = 'true';
+            expect(
+                isScopedEnvironmentActive({
+                    lambda: { scopedEnvironment: true },
+                })
+            ).toBe(false);
+        });
+    });
+
+    describe('getIntegrationFunctionNames', () => {
+        const { getIntegrationFunctionNames } = require('./function-environments');
+
+        it('always includes the router and queue worker', () => {
+            expect(
+                getIntegrationFunctionNames({ Definition: { name: 'hubspot' } })
+            ).toEqual(['hubspot', 'hubspotQueueWorker']);
+        });
+
+        it('includes the webhook handler when webhooks are enabled', () => {
+            expect(
+                getIntegrationFunctionNames({
+                    Definition: { name: 'hubspot', webhooks: true },
+                })
+            ).toContain('hubspotWebhook');
+            expect(
+                getIntegrationFunctionNames({
+                    Definition: { name: 'hubspot', webhooks: { enabled: true } },
+                })
+            ).toContain('hubspotWebhook');
+            expect(
+                getIntegrationFunctionNames({
+                    Definition: { name: 'hubspot', webhooks: { enabled: false } },
+                })
+            ).not.toContain('hubspotWebhook');
+        });
+
+        it('includes one function per routed extension binding, sanitized', () => {
+            const names = getIntegrationFunctionNames({
+                Definition: {
+                    name: 'hubspot',
+                    extensions: {
+                        'my-ext': { extension: { routes: [{ path: '/x', method: 'GET' }] } },
+                        routeless: { extension: { routes: [] } },
+                    },
+                },
+            });
+            expect(names).toContain('hubspot__myext');
+            expect(names).not.toContain('hubspot__routeless');
+        });
+    });
+
+    describe('getAdminFunctionNames', () => {
+        const { getAdminFunctionNames } = require('./function-environments');
+
+        it('returns the admin functions only when admin scripts are configured', () => {
+            expect(
+                getAdminFunctionNames({ adminScripts: [{ Definition: { name: 'x' } }] })
+            ).toEqual(['adminScriptRouter', 'adminScriptExecutor']);
+            expect(getAdminFunctionNames({})).toEqual([]);
+            expect(getAdminFunctionNames({ adminScripts: [] })).toEqual([]);
+        });
+    });
+
+    describe('applyFunctionEnvironments', () => {
+        const makeFunctions = () => ({
+            auth: { handler: 'auth.handler' },
+            hubspot: {
+                handler: 'hubspot.handler',
+                environment: { EXISTING: 'builder-set' },
+            },
+        });
+
+        it('assigns scoped env vars onto the target functions', () => {
+            const functions = makeFunctions();
+            applyFunctionEnvironments(functions, {
+                auth: { HUBSPOT_QUEUE_URL: 'url-1' },
+                hubspot: { HUBSPOT_QUEUE_URL: 'url-1' },
+            });
+
+            expect(functions.auth.environment).toEqual({
+                HUBSPOT_QUEUE_URL: 'url-1',
+            });
+            expect(functions.hubspot.environment).toEqual({
+                EXISTING: 'builder-set',
+                HUBSPOT_QUEUE_URL: 'url-1',
+            });
+        });
+
+        it('never clobbers a key a builder already set directly on the function', () => {
+            const functions = makeFunctions();
+            applyFunctionEnvironments(functions, {
+                hubspot: { EXISTING: 'scoped-value', OTHER: 'x' },
+            });
+
+            expect(functions.hubspot.environment.EXISTING).toBe('builder-set');
+            expect(functions.hubspot.environment.OTHER).toBe('x');
+        });
+
+        it('throws on an unknown function name instead of silently dropping vars', () => {
+            expect(() =>
+                applyFunctionEnvironments(makeFunctions(), {
+                    typoFunction: { A: '1' },
+                })
+            ).toThrow(/typoFunction/);
+        });
+
+        it('is a no-op for an empty map', () => {
+            const functions = makeFunctions();
+            applyFunctionEnvironments(functions, {});
+            expect(functions.auth.environment).toBeUndefined();
+        });
+    });
+});

--- a/packages/devtools/infrastructure/infrastructure-composer.js
+++ b/packages/devtools/infrastructure/infrastructure-composer.js
@@ -20,6 +20,7 @@ const { SchedulerBuilder } = require('./domains/scheduler/scheduler-builder');
 const { AdminScriptBuilder } = require('./domains/admin-scripts/admin-script-builder');
 
 // Utilities
+const { applyFunctionEnvironments } = require('./domains/shared/function-environments');
 const { modifyHandlerPaths } = require('./domains/shared/utilities/handler-path-resolver');
 const { createBaseDefinition } = require('./domains/shared/utilities/base-definition-factory');
 const { ensurePrismaLayerExists } = require('./domains/shared/utilities/prisma-layer-manager');
@@ -75,6 +76,10 @@ const composeServerlessDefinition = async (AppDefinition) => {
     definition.provider.iamRoleStatements.push(...merged.iamStatements);
     Object.assign(definition.provider.environment, merged.environment);
     Object.assign(definition.functions, merged.functions);
+    applyFunctionEnvironments(
+        definition.functions,
+        merged.functionEnvironments
+    );
 
     if (merged.vpcConfig) {
         definition.provider.vpc = merged.vpcConfig;

--- a/packages/devtools/infrastructure/infrastructure-composer.js
+++ b/packages/devtools/infrastructure/infrastructure-composer.js
@@ -32,17 +32,30 @@ const {
  * present at /var/task. esbuild-bundled functions (e.g. defaultWebsocket,
  * adopter custom functions) do NOT ship it — and a missing --import target is a
  * fatal Node startup error — so they are left with the handler-time loader
- * fallback instead. Set at function scope (function env wins over provider env).
+ * fallback instead.
+ *
+ * Set at function scope (function env wins over provider env), APPENDED to any
+ * NODE_OPTIONS already on the function or provider — so an app's own flags
+ * (OTel auto-instrumentation, source maps, memory tuning) survive instead of
+ * being clobbered. A function-level assignment shadows provider env in Lambda,
+ * so the provider value must be folded in here. Only a value already in the
+ * definition is appended — never a synthesized ${env:NODE_OPTIONS}, which would
+ * leak the deploy host's shell into every Lambda.
  */
-function applySsmPreloadNodeOptions(appDefinition, functions) {
+function applySsmPreloadNodeOptions(appDefinition, functions, providerEnvironment = {}) {
     if (!isSsmOffloadActive(appDefinition)) {
         return;
     }
     for (const fn of Object.values(functions)) {
-        if (fn.skipEsbuild) {
-            fn.environment = fn.environment || {};
-            fn.environment.NODE_OPTIONS = SSM_PRELOAD_NODE_OPTIONS;
+        if (!fn.skipEsbuild) {
+            continue;
         }
+        fn.environment = fn.environment || {};
+        const existing =
+            fn.environment.NODE_OPTIONS ?? providerEnvironment.NODE_OPTIONS;
+        fn.environment.NODE_OPTIONS = existing
+            ? `${existing} ${SSM_PRELOAD_NODE_OPTIONS}`
+            : SSM_PRELOAD_NODE_OPTIONS;
     }
 }
 const { modifyHandlerPaths } = require('./domains/shared/utilities/handler-path-resolver');
@@ -104,7 +117,11 @@ const composeServerlessDefinition = async (AppDefinition) => {
         definition.functions,
         merged.functionEnvironments
     );
-    applySsmPreloadNodeOptions(AppDefinition, definition.functions);
+    applySsmPreloadNodeOptions(
+        AppDefinition,
+        definition.functions,
+        definition.provider.environment
+    );
 
     if (merged.vpcConfig) {
         definition.provider.vpc = merged.vpcConfig;
@@ -147,5 +164,5 @@ const composeServerlessDefinition = async (AppDefinition) => {
     return definition;
 };
 
-module.exports = { composeServerlessDefinition };
+module.exports = { composeServerlessDefinition, applySsmPreloadNodeOptions };
 

--- a/packages/devtools/infrastructure/infrastructure-composer.js
+++ b/packages/devtools/infrastructure/infrastructure-composer.js
@@ -21,6 +21,30 @@ const { AdminScriptBuilder } = require('./domains/admin-scripts/admin-script-bui
 
 // Utilities
 const { applyFunctionEnvironments } = require('./domains/shared/function-environments');
+const {
+    isSsmOffloadActive,
+    SSM_PRELOAD_NODE_OPTIONS,
+} = require('./domains/parameters/offload-utils');
+
+/**
+ * Load the SSM INIT preload (NODE_OPTIONS=--import) on skipEsbuild handlers
+ * only. Those package the full node_modules tree, so the preload .mjs is
+ * present at /var/task. esbuild-bundled functions (e.g. defaultWebsocket,
+ * adopter custom functions) do NOT ship it — and a missing --import target is a
+ * fatal Node startup error — so they are left with the handler-time loader
+ * fallback instead. Set at function scope (function env wins over provider env).
+ */
+function applySsmPreloadNodeOptions(appDefinition, functions) {
+    if (!isSsmOffloadActive(appDefinition)) {
+        return;
+    }
+    for (const fn of Object.values(functions)) {
+        if (fn.skipEsbuild) {
+            fn.environment = fn.environment || {};
+            fn.environment.NODE_OPTIONS = SSM_PRELOAD_NODE_OPTIONS;
+        }
+    }
+}
 const { modifyHandlerPaths } = require('./domains/shared/utilities/handler-path-resolver');
 const { createBaseDefinition } = require('./domains/shared/utilities/base-definition-factory');
 const { ensurePrismaLayerExists } = require('./domains/shared/utilities/prisma-layer-manager');
@@ -80,6 +104,7 @@ const composeServerlessDefinition = async (AppDefinition) => {
         definition.functions,
         merged.functionEnvironments
     );
+    applySsmPreloadNodeOptions(AppDefinition, definition.functions);
 
     if (merged.vpcConfig) {
         definition.provider.vpc = merged.vpcConfig;

--- a/packages/devtools/infrastructure/infrastructure-composer.test.js
+++ b/packages/devtools/infrastructure/infrastructure-composer.test.js
@@ -1,4 +1,10 @@
-const { composeServerlessDefinition } = require('./infrastructure-composer');
+const {
+    composeServerlessDefinition,
+    applySsmPreloadNodeOptions,
+} = require('./infrastructure-composer');
+const {
+    SSM_PRELOAD_NODE_OPTIONS,
+} = require('./domains/parameters/offload-utils');
 
 // Helper to build discovery responses with overridable fields
 const createDiscoveryResponse = (overrides = {}) => ({
@@ -1947,5 +1953,90 @@ describe('composeServerlessDefinition', () => {
 
             await expect(composeServerlessDefinition(appDefinition)).rejects.toThrow('Invalid integration: missing Definition or name');
         });
+    });
+});
+
+describe('applySsmPreloadNodeOptions', () => {
+    const appDefinition = {
+        ssm: { enable: true },
+        environment: { FOO: 'ssm' },
+    };
+    const savedSkip = process.env.FRIGG_SKIP_AWS_DISCOVERY;
+
+    beforeEach(() => {
+        delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+    });
+
+    afterEach(() => {
+        if (savedSkip === undefined) {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+        } else {
+            process.env.FRIGG_SKIP_AWS_DISCOVERY = savedSkip;
+        }
+    });
+
+    it('sets the preload NODE_OPTIONS on a skipEsbuild function with no existing value', () => {
+        const functions = { auth: { skipEsbuild: true } };
+        applySsmPreloadNodeOptions(appDefinition, functions);
+        expect(functions.auth.environment.NODE_OPTIONS).toBe(
+            SSM_PRELOAD_NODE_OPTIONS
+        );
+    });
+
+    it('appends to an existing function-level NODE_OPTIONS instead of clobbering it', () => {
+        const functions = {
+            auth: {
+                skipEsbuild: true,
+                environment: { NODE_OPTIONS: '--enable-source-maps' },
+            },
+        };
+        applySsmPreloadNodeOptions(appDefinition, functions);
+        expect(functions.auth.environment.NODE_OPTIONS).toBe(
+            `--enable-source-maps ${SSM_PRELOAD_NODE_OPTIONS}`
+        );
+    });
+
+    it('folds in a provider-level NODE_OPTIONS (which the function env would otherwise shadow)', () => {
+        const functions = { auth: { skipEsbuild: true } };
+        applySsmPreloadNodeOptions(appDefinition, functions, {
+            NODE_OPTIONS: '--require ./otel.js',
+        });
+        expect(functions.auth.environment.NODE_OPTIONS).toBe(
+            `--require ./otel.js ${SSM_PRELOAD_NODE_OPTIONS}`
+        );
+    });
+
+    it('prefers a function-level value over the provider-level one', () => {
+        const functions = {
+            auth: {
+                skipEsbuild: true,
+                environment: { NODE_OPTIONS: '--fn-flag' },
+            },
+        };
+        applySsmPreloadNodeOptions(appDefinition, functions, {
+            NODE_OPTIONS: '--provider-flag',
+        });
+        expect(functions.auth.environment.NODE_OPTIONS).toBe(
+            `--fn-flag ${SSM_PRELOAD_NODE_OPTIONS}`
+        );
+    });
+
+    it('never touches esbuild-bundled functions', () => {
+        const functions = {
+            websocket: { environment: { NODE_OPTIONS: '--keep-me' } },
+        };
+        applySsmPreloadNodeOptions(appDefinition, functions, {
+            NODE_OPTIONS: '--provider',
+        });
+        expect(functions.websocket.environment.NODE_OPTIONS).toBe('--keep-me');
+    });
+
+    it('is a no-op when offload is inactive', () => {
+        const functions = { auth: { skipEsbuild: true } };
+        applySsmPreloadNodeOptions(
+            { ssm: { enable: true } }, // no offloaded keys → inactive
+            functions
+        );
+        expect(functions.auth.environment).toBeUndefined();
     });
 });

--- a/packages/devtools/infrastructure/infrastructure-composer.test.js
+++ b/packages/devtools/infrastructure/infrastructure-composer.test.js
@@ -1062,7 +1062,18 @@ describe('composeServerlessDefinition', () => {
     });
 
     describe('SSM Configuration', () => {
-        it('should add SSM configuration when ssm.enable is true', async () => {
+        const originalSkipDiscovery = process.env.FRIGG_SKIP_AWS_DISCOVERY;
+
+        afterEach(() => {
+            if (originalSkipDiscovery === undefined) {
+                delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            } else {
+                process.env.FRIGG_SKIP_AWS_DISCOVERY = originalSkipDiscovery;
+            }
+        });
+
+        it('should add the broad SSM read grant when ssm.enable is true without offload', async () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
             const appDefinition = {
                 ssm: { enable: true },
                 integrations: []
@@ -1070,12 +1081,10 @@ describe('composeServerlessDefinition', () => {
 
             const result = await composeServerlessDefinition(appDefinition);
 
-            // Check lambda layers
-            expect(result.provider.layers).toEqual([
-                'arn:aws:lambda:${self:provider.region}:177933569100:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11'
-            ]);
+            // We deliberately do NOT use the AWS Parameters-and-Secrets extension layer
+            expect(result.provider.layers).toBeUndefined();
 
-            // Check IAM permissions
+            // Broad read grant present
             const ssmPermission = result.provider.iamRoleStatements.find(
                 statement => statement.Action.includes('ssm:GetParameter')
             );
@@ -1086,13 +1095,56 @@ describe('composeServerlessDefinition', () => {
                     'ssm:GetParameters',
                     'ssm:GetParametersByPath'
                 ],
-                Resource: [
-                    'arn:aws:ssm:${self:provider.region}:*:parameter/${self:service}/${self:provider.stage}/*'
-                ]
+                Resource: {
+                    'Fn::Sub': 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
+                }
             });
 
-            // Check environment variable
-            expect(result.provider.environment.SSM_PARAMETER_PREFIX).toBe('/${self:service}/${self:provider.stage}');
+            // No offload markers -> no offload env vars
+            expect(result.provider.environment.SSM_PARAMETER_PREFIX).toBeUndefined();
+            expect(result.provider.environment.FRIGG_SSM_OFFLOADED_KEYS).toBeUndefined();
+        });
+
+        it('should offload marked keys and expose prefix + offloaded keys env vars', async () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            const appDefinition = {
+                ssm: { enable: true },
+                environment: { FOO: 'ssm', BAR: true },
+                integrations: []
+            };
+
+            const result = await composeServerlessDefinition(appDefinition);
+
+            // BAR stays in the Lambda env, FOO is offloaded out of it
+            expect(result.provider.environment.BAR).toBe("${env:BAR, ''}");
+            expect(result.provider.environment.FOO).toBeUndefined();
+
+            // Offload env contract
+            expect(result.provider.environment.SSM_PARAMETER_PREFIX).toBe(
+                '/frigg/${self:service}/${self:provider.stage}'
+            );
+            expect(result.provider.environment.FRIGG_SSM_OFFLOADED_KEYS).toBe('FOO');
+
+            // Prefix-scoped read grant present alongside the broad grant
+            const scoped = result.provider.iamRoleStatements.find(
+                statement => statement.Resource === 'arn:aws:ssm:${self:provider.region}:${aws:accountId}:parameter/frigg/${self:service}/${self:provider.stage}/*'
+            );
+            expect(scoped).toBeDefined();
+        });
+
+        it('should not add offload env vars when ssm.enable is true but nothing is marked', async () => {
+            delete process.env.FRIGG_SKIP_AWS_DISCOVERY;
+            const appDefinition = {
+                ssm: { enable: true },
+                environment: { BAR: true },
+                integrations: []
+            };
+
+            const result = await composeServerlessDefinition(appDefinition);
+
+            expect(result.provider.environment.BAR).toBe("${env:BAR, ''}");
+            expect(result.provider.environment.SSM_PARAMETER_PREFIX).toBeUndefined();
+            expect(result.provider.environment.FRIGG_SSM_OFFLOADED_KEYS).toBeUndefined();
         });
 
         it('should not add SSM configuration when ssm.enable is false', async () => {
@@ -1397,9 +1449,12 @@ describe('composeServerlessDefinition', () => {
             expect(result.provider.environment.KMS_KEY_ARN).toBeDefined();
             expect(result.custom.kmsGrants).toBeDefined();
 
-            // SSM
-            expect(result.provider.layers).toBeDefined();
-            expect(result.provider.environment.SSM_PARAMETER_PREFIX).toBeDefined();
+            // SSM (enabled without offload markers -> broad grant only, no offload env vars)
+            const ssmPermission = result.provider.iamRoleStatements.find(
+                statement => statement.Action && statement.Action.includes('ssm:GetParameter')
+            );
+            expect(ssmPermission).toBeDefined();
+            expect(result.provider.environment.SSM_PARAMETER_PREFIX).toBeUndefined();
 
             // Integration
             expect(result.functions.testIntegration).toBeDefined();

--- a/packages/devtools/infrastructure/integration.test.js
+++ b/packages/devtools/infrastructure/integration.test.js
@@ -108,11 +108,9 @@ describe('VPC/KMS/SSM Integration Tests', () => {
             );
             expect(kmsPermission).toBeDefined();
 
-            // Verify SSM configuration
-            expect(serverlessConfig.provider.layers).toEqual([
-                'arn:aws:lambda:${self:provider.region}:177933569100:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11'
-            ]);
-            expect(serverlessConfig.provider.environment.SSM_PARAMETER_PREFIX).toBe('/${self:service}/${self:provider.stage}');
+            // Verify SSM configuration (enabled without offload markers -> broad grant only)
+            expect(serverlessConfig.provider.layers).toBeUndefined();
+            expect(serverlessConfig.provider.environment.SSM_PARAMETER_PREFIX).toBeUndefined();
 
             // Verify SSM IAM permissions
             const ssmPermission = serverlessConfig.provider.iamRoleStatements.find(

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -21,6 +21,7 @@
     "@aws-sdk/client-rds": "^3.906.0",
     "@aws-sdk/client-s3": "^3.917.0",
     "@aws-sdk/client-secrets-manager": "^3.906.0",
+    "@aws-sdk/client-ssm": "^3.906.0",
     "@aws-sdk/client-sts": "^3.835.0",
     "@babel/eslint-parser": "^7.18.9",
     "@babel/parser": "^7.25.3",

--- a/packages/schemas/schemas/app-definition.schema.json
+++ b/packages/schemas/schemas/app-definition.schema.json
@@ -41,18 +41,27 @@
     },
     "environment": {
       "type": "object",
-      "description": "Environment variable configuration (key: true/false flags)",
+      "description": "Environment variable configuration. true includes the variable in the Lambda environment; 'ssm' offloads it to SSM Parameter Store (requires ssm.enable) so it never counts against the Lambda 4KB env limit",
       "patternProperties": {
         "^[A-Z][A-Z0-9_]*$": {
-          "type": "boolean",
-          "description": "Set to true to include this environment variable from process.env"
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Set to true to include this environment variable from process.env"
+            },
+            {
+              "type": "string",
+              "const": "ssm",
+              "description": "Offload this variable to SSM Parameter Store; fetched at runtime instead of stored in the Lambda environment"
+            }
+          ]
         }
       },
       "additionalProperties": false,
       "examples": [
         {
           "NODE_ENV": true,
-          "API_KEY": true,
+          "API_KEY": "ssm",
           "DATABASE_URL": true
         }
       ]
@@ -450,6 +459,19 @@
           "description": "Enable SSM Parameter Store for configuration",
           "default": false
         },
+        "parameterPrefix": {
+          "type": "string",
+          "description": "Override the default parameter path prefix (/frigg/${service}/${stage}). Non-default prefixes may require widening the *frigg*-scoped deployment IAM policies"
+        },
+        "kmsKeyArn": {
+          "type": "string",
+          "description": "Customer-managed KMS key for SecureString parameters. When set, the Lambda execution role is granted kms:Decrypt on this key. Defaults to the AWS-managed aws/ssm key"
+        },
+        "restrictIamToPrefix": {
+          "type": "boolean",
+          "description": "Drop the legacy broad parameter/* read grant and only allow reads under the parameter prefix",
+          "default": false
+        },
         "parameters": {
           "type": "object",
           "description": "SSM parameter definitions",
@@ -480,6 +502,18 @@
         "enable": {
           "type": "boolean",
           "description": "Enable AWS Secrets Manager for secure credential storage",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "lambda": {
+      "type": "object",
+      "description": "Lambda function generation options",
+      "properties": {
+        "scopedEnvironment": {
+          "type": "boolean",
+          "description": "Scope framework-generated environment variables (queue URLs, migration/scheduler vars) to the functions that consume them instead of broadcasting to every function. Reduces per-function env size against the Lambda 4KB limit",
           "default": false
         }
       },

--- a/packages/schemas/schemas/app-definition.schema.json
+++ b/packages/schemas/schemas/app-definition.schema.json
@@ -476,13 +476,19 @@
           "type": "object",
           "description": "SSM parameter definitions",
           "patternProperties": {
-            "^[a-zA-Z0-9/_.-]+$": {
+            "^[A-Z][A-Z0-9_]*$": {
               "type": "object",
               "properties": {
                 "type": {
                   "type": "string",
                   "enum": ["String", "StringList", "SecureString"],
                   "default": "String"
+                },
+                "tier": {
+                  "type": "string",
+                  "description": "Parameter Store tier for this key: 'standard' caps the value at 4KB, 'advanced' at 8KB (billed by AWS)",
+                  "enum": ["standard", "advanced"],
+                  "default": "standard"
                 },
                 "description": {
                   "type": "string"

--- a/packages/schemas/tests/app-definition-ssm-offload.test.js
+++ b/packages/schemas/tests/app-definition-ssm-offload.test.js
@@ -86,6 +86,57 @@ describe('app-definition schema: SSM offload surface', () => {
             });
             expect(result.valid).toBe(false);
         });
+
+        it('accepts a per-key parameter tier', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                ssm: {
+                    enable: true,
+                    parameters: {
+                        MY_SECRET: {
+                            type: 'SecureString',
+                            tier: 'advanced',
+                        },
+                    },
+                },
+            });
+            expect(result.valid).toBe(true);
+        });
+
+        it('rejects an invalid parameter tier', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                ssm: {
+                    enable: true,
+                    parameters: {
+                        MY_SECRET: { tier: 'premium' },
+                    },
+                },
+            });
+            expect(result.valid).toBe(false);
+        });
+
+        it('rejects lowercase parameter keys', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                ssm: {
+                    enable: true,
+                    parameters: { 'my-secret': { type: 'String' } },
+                },
+            });
+            expect(result.valid).toBe(false);
+        });
+
+        it('rejects parameter keys containing slashes', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                ssm: {
+                    enable: true,
+                    parameters: { 'path/to/secret': { type: 'String' } },
+                },
+            });
+            expect(result.valid).toBe(false);
+        });
     });
 
     describe('lambda section', () => {

--- a/packages/schemas/tests/app-definition-ssm-offload.test.js
+++ b/packages/schemas/tests/app-definition-ssm-offload.test.js
@@ -1,0 +1,116 @@
+const { validateAppDefinition } = require('../index');
+
+const baseDefinition = {
+    name: 'test-app',
+    provider: 'aws',
+    integrations: [],
+};
+
+describe('app-definition schema: SSM offload surface', () => {
+    describe('environment values', () => {
+        it('accepts boolean values (existing behavior)', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                environment: { MY_VAR: true, OTHER_VAR: false },
+            });
+            expect(result.valid).toBe(true);
+        });
+
+        it("accepts the 'ssm' marker to offload a variable", () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                ssm: { enable: true },
+                environment: { MY_SECRET: 'ssm', PLAIN_VAR: true },
+            });
+            expect(result.valid).toBe(true);
+        });
+
+        it('rejects arbitrary string values', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                environment: { MY_VAR: 'yes' },
+            });
+            expect(result.valid).toBe(false);
+        });
+    });
+
+    describe('ssm section', () => {
+        it('accepts parameterPrefix', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                ssm: { enable: true, parameterPrefix: '/custom/prefix' },
+            });
+            expect(result.valid).toBe(true);
+        });
+
+        it('accepts kmsKeyArn', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                ssm: {
+                    enable: true,
+                    kmsKeyArn:
+                        'arn:aws:kms:us-east-1:123456789012:key/abc-123',
+                },
+            });
+            expect(result.valid).toBe(true);
+        });
+
+        it('accepts restrictIamToPrefix', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                ssm: { enable: true, restrictIamToPrefix: true },
+            });
+            expect(result.valid).toBe(true);
+        });
+
+        it('still accepts typed parameters', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                ssm: {
+                    enable: true,
+                    parameters: {
+                        MY_SECRET: {
+                            type: 'SecureString',
+                            description: 'An API key',
+                        },
+                    },
+                },
+            });
+            expect(result.valid).toBe(true);
+        });
+
+        it('rejects unknown ssm properties', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                ssm: { enable: true, bogus: true },
+            });
+            expect(result.valid).toBe(false);
+        });
+    });
+
+    describe('lambda section', () => {
+        it('accepts lambda.scopedEnvironment', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                lambda: { scopedEnvironment: true },
+            });
+            expect(result.valid).toBe(true);
+        });
+
+        it('rejects unknown lambda properties', () => {
+            const result = validateAppDefinition({
+                ...baseDefinition,
+                lambda: { bogus: true },
+            });
+            expect(result.valid).toBe(false);
+        });
+    });
+
+    it('still rejects unknown top-level properties', () => {
+        const result = validateAppDefinition({
+            ...baseDefinition,
+            notARealSection: {},
+        });
+        expect(result.valid).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Solves AWS Lambda's hard **4 KB environment-variable limit** for multi-integration Frigg apps. Today Frigg broadcasts one app-wide `provider.environment` block to every Lambda, so a multi-integration app sits at the ceiling on every function — quo-integrations measured base functions at 3817/4096 B, `dbMigrationRouter` 3881, `adminScriptRouter` 4009, and a ~243 B OTEL addition tipped the heaviest functions over, rolling back the whole stack.

Two composable mechanisms (see [ADR-027](docs/architecture-decisions/027-ssm-parameter-offload-and-env-scoping.md)):

### 1. SSM Parameter Store offload (payload axis)
Mark a variable `environment: { KEY: 'ssm' }` (or declare it typed under `ssm.parameters`) and its value lives in Parameter Store instead of the Lambda env — fetched at cold start, never counted against 4 KB.
- **Build**: offloaded keys excluded from `provider.environment`; `SsmBuilder` emits only `SSM_PARAMETER_PREFIX` + `FRIGG_SSM_OFFLOADED_KEYS`, a prefix-scoped read grant (broad `parameter/*` kept unless `ssm.restrictIamToPrefix`), and `kms:Decrypt` when `ssm.kmsKeyArn` is set. SSM VPC interface endpoint added when VPC + offload.
- **Runtime** (`@friggframework/core`): `parametersToEnv()` runs in the `createHandler` bootstrap after `secretsToEnv()` — batched `GetParameters` (decrypted), populates `process.env`, per-container TTL cache (`FRIGG_SSM_CACHE_TTL`, default 300 s). Precedence **real env > Secrets Manager > SSM**; a real env var always wins (console-override debugging works); loader-owned keys refresh on TTL; a failed refresh keeps stale values; missing declared params fail fast by name.
- **Provisioning**: `frigg ssm push` (and auto-push inside `frigg deploy`, before the serverless deploy so params exist before new code cold-starts) writes values from CI/`.env` via `PutParameter`. Per-key `ssm.parameters[KEY].tier` (standard 4 KB / advanced 8 KB), SecureString via `ssm.parameters[KEY].type` + optional CMK, `--region`, `--allow-empty`. Deployment IAM gains scoped SSM write + KMS-via-SSM grants.

### 2. Per-function env scoping (count axis) — opt-in `lambda.scopedEnvironment: true`
Framework-generated vars stop broadcasting to functions that don't use them. `<NAME>_QUEUE_URL` → `auth` + admin-script functions + the owning integration's functions; scheduler vars → same union minus `adminScriptRouter`; migration bucket/queue vars → the migration functions; `DB_TYPE` stays global. Default off; skipped in local mode.

**Result:** worst function 4009 B → ~1,640 B with offload alone; base functions ~500–700 B with both.

## Test plan
- [x] `@friggframework/core`: `parameters-to-env` + `create-handler` — 26/26
- [x] `@friggframework/devtools`: security / environment-builder / parameters / ssm-command — 154/154
- [x] `@friggframework/schemas`: full suite — 98/98
- [x] Composer e2e asserts offloaded keys leave `provider.environment`, scoped consumer sets are exact, and flag-off output is byte-identical to today
- [ ] **Follow-up spike (ADR-027 decision 8):** confirm on a dev stack that SecureString reads with the *default* `aws/ssm` key work with only `ssm:GetParameter*` on the Lambda role (apps using a `ssm.kmsKeyArn` CMK get an explicit `kms:Decrypt` grant already)

The feature is inert until an app opts in (`'ssm'` markers / `lambda.scopedEnvironment`); no existing app changes behavior on upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.625.eaeb79b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/admin-scripts@2.0.0--canary.625.eaeb79b.0
  npm install @friggframework/core@2.0.0--canary.625.eaeb79b.0
  npm install @friggframework/devtools@2.0.0--canary.625.eaeb79b.0
  npm install @friggframework/eslint-config@2.0.0--canary.625.eaeb79b.0
  npm install @friggframework/prettier-config@2.0.0--canary.625.eaeb79b.0
  npm install @friggframework/schemas@2.0.0--canary.625.eaeb79b.0
  npm install @friggframework/serverless-plugin@2.0.0--canary.625.eaeb79b.0
  npm install @friggframework/test@2.0.0--canary.625.eaeb79b.0
  npm install @friggframework/ui@2.0.0--canary.625.eaeb79b.0
  # or 
  yarn add @friggframework/admin-scripts@2.0.0--canary.625.eaeb79b.0
  yarn add @friggframework/core@2.0.0--canary.625.eaeb79b.0
  yarn add @friggframework/devtools@2.0.0--canary.625.eaeb79b.0
  yarn add @friggframework/eslint-config@2.0.0--canary.625.eaeb79b.0
  yarn add @friggframework/prettier-config@2.0.0--canary.625.eaeb79b.0
  yarn add @friggframework/schemas@2.0.0--canary.625.eaeb79b.0
  yarn add @friggframework/serverless-plugin@2.0.0--canary.625.eaeb79b.0
  yarn add @friggframework/test@2.0.0--canary.625.eaeb79b.0
  yarn add @friggframework/ui@2.0.0--canary.625.eaeb79b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.0-next.102`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/core`, `@friggframework/devtools`, `@friggframework/schemas`
    - feat: Extend support for SSM parameter offload + per-function env scoping (Lambda 4KB env limit) [#625](https://github.com/friggframework/frigg/pull/625) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/admin-scripts`, `@friggframework/core`, `@friggframework/devtools`, `@friggframework/eslint-config`, `@friggframework/prettier-config`, `@friggframework/schemas`, `@friggframework/serverless-plugin`, `@friggframework/test`, `@friggframework/ui`
    - fix(requester): grace-retry non-refreshable 401s and surface diagnostic detail on invalid-credential errors [#623](https://github.com/friggframework/frigg/pull/623) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - docs(adr): accept 010/011; add migration ADRs 012 (db schema) + 013 (integration version) [#617](https://github.com/friggframework/frigg/pull/617) ([@claude](https://github.com/claude) [@seanspeaks](https://github.com/seanspeaks))
  - `@friggframework/core`
    - docs(adr): consolidate named ADRs into the numbered register (015–026) [#621](https://github.com/friggframework/frigg/pull/621) ([@claude](https://github.com/claude) [@seanspeaks](https://github.com/seanspeaks))
  
  #### Authors: 3
  
  - Claude ([@claude](https://github.com/claude))
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
