### PR TITLE
fix(core): record why credentials were rejected before flipping to ERROR

### DIFF
--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -398,9 +398,8 @@ class IntegrationBase {
      * @returns {string} A user-facing message.
      */
     _authErrorMessage(moduleName, statusCode) {
-        const entity = moduleName ? `your ${moduleName} Entity` : 'your Entity';
         const status = statusCode ? ` (HTTP ${statusCode})` : '';
-        return `There was an error with ${entity}${status}. Please reconnect/re-authenticate, or reach out to Support for assistance.`;
+        return `There was an error with your ${moduleName} Entity${status}. Please reconnect/re-authenticate, or reach out to Support for assistance.`;
     }
 
     /**
@@ -856,7 +855,7 @@ class IntegrationBase {
         if (!this.id) return;
 
         if (delegateString === 'CREDENTIAL_INVALIDATED') {
-            const moduleName = notifier?.name ?? object?.moduleName;
+            const moduleName = notifier?.name;
             const detail =
                 object?.reason || object?.statusCode
                     ? ` (status ${object?.statusCode ?? '?'}: ${

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -855,6 +855,8 @@ class IntegrationBase {
         if (!this.id) return;
 
         if (delegateString === 'CREDENTIAL_INVALIDATED') {
+            if (this.status === 'ERROR') return;
+
             const moduleName = notifier?.name;
             const detail =
                 object?.reason || object?.statusCode

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -861,6 +861,7 @@ class IntegrationBase {
                     this.id
                 } — marking ERROR${detail}`
             );
+            await this.recordCredentialRejection(notifier, object);
             await this.persistStatus('ERROR');
             return;
         }
@@ -875,6 +876,45 @@ class IntegrationBase {
                 } — clearing ERROR → ENABLED`
             );
             await this.persistStatus('ENABLED');
+        }
+    }
+
+    /**
+     * Persist why a module's credentials were rejected, so the ERROR flip that
+     * follows has a stated cause. `persistStatus` writes only the status
+     * column, so without this the integration reads as broken with an empty
+     * `errors` array and the reason survives only in the log line above.
+     *
+     * Deliberately does not persist `object.reason`. That is the FetchError
+     * message, which embeds the serialized request — including the
+     * Authorization header, since FetchError blanks it only when STAGE is not
+     * `dev`. These messages are surfaced to end users, so only the status code
+     * crosses over.
+     *
+     * Best-effort: a failed diagnostic write must never prevent the status flip
+     * that stops further processing on dead credentials.
+     * @param {Object} notifier - The module that reported the rejection.
+     * @param {Object} [object] - The delegate payload.
+     */
+    async recordCredentialRejection(notifier, object) {
+        const moduleName = notifier?.getName?.() ?? notifier?.name ?? 'unknown';
+        const statusCode = object?.statusCode;
+
+        try {
+            await this.updateIntegrationMessages.execute(
+                this.id,
+                'errors',
+                'Authentication Error',
+                `There was an error with your ${moduleName} Entity${
+                    statusCode ? ` (HTTP ${statusCode})` : ''
+                }. Please reconnect/re-authenticate, or reach out to Support for assistance.`,
+                Date.now()
+            );
+        } catch (error) {
+            console.error(
+                `[Frigg] Failed to record credential rejection for integration ${this.id}:`,
+                error
+            );
         }
     }
 }

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -393,9 +393,6 @@ class IntegrationBase {
     }
 
     /**
-     * The single wording for "this module's credentials no longer work", shared
-     * by the passive check (testAuth) and the module delegate
-     * (receiveNotification) so the two paths cannot drift apart.
      * @param {string} [moduleName] - The module whose credentials failed.
      * @param {number} [statusCode] - HTTP status the module rejected us with.
      * @returns {string} A user-facing message.
@@ -895,19 +892,9 @@ class IntegrationBase {
     }
 
     /**
-     * Persist why a module's credentials were rejected, so the ERROR flip that
-     * follows has a stated cause. `persistStatus` writes only the status
-     * column, so without this the integration reads as broken with an empty
-     * `errors` array and the reason survives only in the log line above.
-     *
-     * Deliberately does not persist `object.reason`. That is the FetchError
-     * message, which embeds the serialized request — including the
-     * Authorization header, since FetchError blanks it only when STAGE is not
-     * `dev`. These messages are surfaced to end users, so only the status code
-     * crosses over.
-     *
-     * Best-effort: a failed diagnostic write must never prevent the status flip
-     * that stops further processing on dead credentials.
+     * Takes no `reason`: the delegate's is a FetchError message echoing the
+     * request, Authorization header included outside prod, and this is shown to
+     * end users. Best-effort so it cannot block the caller's status flip.
      * @param {string} [moduleName] - The module that reported the rejection.
      * @param {number} [statusCode] - HTTP status the module rejected us with.
      */

--- a/packages/core/integrations/integration-base.js
+++ b/packages/core/integrations/integration-base.js
@@ -383,16 +383,27 @@ class IntegrationBase {
                     this.id,
                     'errors',
                     'Authentication Error',
-                    `There was an error with your ${this[
-                        module
-                    ].getName()} Entity.
-                Please reconnect/re-authenticate, or reach out to Support for assistance.`,
+                    this._authErrorMessage(this[module].getName()),
                     Date.now()
                 );
             }
         }
 
         return didAuthPass;
+    }
+
+    /**
+     * The single wording for "this module's credentials no longer work", shared
+     * by the passive check (testAuth) and the module delegate
+     * (receiveNotification) so the two paths cannot drift apart.
+     * @param {string} [moduleName] - The module whose credentials failed.
+     * @param {number} [statusCode] - HTTP status the module rejected us with.
+     * @returns {string} A user-facing message.
+     */
+    _authErrorMessage(moduleName, statusCode) {
+        const entity = moduleName ? `your ${moduleName} Entity` : 'your Entity';
+        const status = statusCode ? ` (HTTP ${statusCode})` : '';
+        return `There was an error with ${entity}${status}. Please reconnect/re-authenticate, or reach out to Support for assistance.`;
     }
 
     /**
@@ -848,6 +859,7 @@ class IntegrationBase {
         if (!this.id) return;
 
         if (delegateString === 'CREDENTIAL_INVALIDATED') {
+            const moduleName = notifier?.name ?? object?.moduleName;
             const detail =
                 object?.reason || object?.statusCode
                     ? ` (status ${object?.statusCode ?? '?'}: ${
@@ -856,12 +868,15 @@ class IntegrationBase {
                     : '';
             console.log(
                 `[Frigg] Module ${
-                    notifier?.name || '?'
+                    moduleName || '?'
                 } reported invalid credentials for integration ${
                     this.id
                 } — marking ERROR${detail}`
             );
-            await this.recordCredentialRejection(notifier, object);
+            await this._recordCredentialRejection(
+                moduleName,
+                object?.statusCode
+            );
             await this.persistStatus('ERROR');
             return;
         }
@@ -893,21 +908,16 @@ class IntegrationBase {
      *
      * Best-effort: a failed diagnostic write must never prevent the status flip
      * that stops further processing on dead credentials.
-     * @param {Object} notifier - The module that reported the rejection.
-     * @param {Object} [object] - The delegate payload.
+     * @param {string} [moduleName] - The module that reported the rejection.
+     * @param {number} [statusCode] - HTTP status the module rejected us with.
      */
-    async recordCredentialRejection(notifier, object) {
-        const moduleName = notifier?.getName?.() ?? notifier?.name ?? 'unknown';
-        const statusCode = object?.statusCode;
-
+    async _recordCredentialRejection(moduleName, statusCode) {
         try {
             await this.updateIntegrationMessages.execute(
                 this.id,
                 'errors',
                 'Authentication Error',
-                `There was an error with your ${moduleName} Entity${
-                    statusCode ? ` (HTTP ${statusCode})` : ''
-                }. Please reconnect/re-authenticate, or reach out to Support for assistance.`,
+                this._authErrorMessage(moduleName, statusCode),
                 Date.now()
             );
         } catch (error) {

--- a/packages/core/integrations/tests/integration-base-receive-notification.test.js
+++ b/packages/core/integrations/tests/integration-base-receive-notification.test.js
@@ -10,6 +10,7 @@ const { IntegrationBase } = require('../integration-base');
 describe('IntegrationBase.receiveNotification', () => {
     let integration;
     let mockUpdateIntegrationStatus;
+    let mockUpdateIntegrationMessages;
 
     beforeEach(() => {
         integration = new IntegrationBase();
@@ -20,6 +21,11 @@ describe('IntegrationBase.receiveNotification', () => {
             execute: jest.fn().mockResolvedValue(true),
         };
         integration.updateIntegrationStatus = mockUpdateIntegrationStatus;
+
+        mockUpdateIntegrationMessages = {
+            execute: jest.fn().mockResolvedValue(true),
+        };
+        integration.updateIntegrationMessages = mockUpdateIntegrationMessages;
     });
 
     it('ignores unknown delegate strings', async () => {
@@ -97,6 +103,143 @@ describe('IntegrationBase.receiveNotification', () => {
         }
     });
 
+    describe('recorded diagnostic', () => {
+        it('records an Authentication Error naming the module and status code', async () => {
+            await integration.receiveNotification(
+                { name: 'testmodule', getName: () => 'testmodule' },
+                'CREDENTIAL_INVALIDATED',
+                {
+                    credentialId: 'cred-1',
+                    moduleName: 'testmodule',
+                    reason: 'Unauthorized',
+                    statusCode: 401,
+                }
+            );
+
+            expect(mockUpdateIntegrationMessages.execute).toHaveBeenCalledTimes(
+                1
+            );
+            const [integrationId, messageType, title, body] =
+                mockUpdateIntegrationMessages.execute.mock.calls[0];
+            expect(integrationId).toBe('int-1');
+            expect(messageType).toBe('errors');
+            expect(title).toBe('Authentication Error');
+            expect(body).toContain('testmodule');
+            expect(body).toContain('401');
+            expect(body).toContain('reconnect');
+        });
+
+        it('records the diagnostic before flipping status, so a failed flip still leaves a cause', async () => {
+            const callOrder = [];
+            mockUpdateIntegrationMessages.execute.mockImplementation(async () =>
+                callOrder.push('message')
+            );
+            mockUpdateIntegrationStatus.execute.mockImplementation(async () =>
+                callOrder.push('status')
+            );
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_INVALIDATED',
+                { credentialId: 'cred-1', statusCode: 401 }
+            );
+
+            expect(callOrder).toEqual(['message', 'status']);
+        });
+
+        it('still flips to ERROR when recording the diagnostic fails', async () => {
+            mockUpdateIntegrationMessages.execute.mockRejectedValue(
+                new Error('db write failed')
+            );
+            const errorSpy = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+
+            try {
+                await integration.receiveNotification(
+                    { name: 'testmodule' },
+                    'CREDENTIAL_INVALIDATED',
+                    { credentialId: 'cred-1', statusCode: 401 }
+                );
+            } finally {
+                errorSpy.mockRestore();
+            }
+
+            expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
+                'int-1',
+                'ERROR'
+            );
+            expect(integration.status).toBe('ERROR');
+        });
+
+        it('keeps the request-echoing reason out of the persisted message', async () => {
+            const fetchErrorMessage = [
+                '-----------------------------------------------------',
+                'An error ocurred while fetching an external resource.',
+                '>>> Request Details >>>',
+                'GET https://api.example.com/v1/users?type=CurrentUser',
+                '{"headers":{"Authorization":"Bearer super-secret-token"}}',
+            ].join('\n');
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_INVALIDATED',
+                {
+                    credentialId: 'cred-1',
+                    reason: fetchErrorMessage,
+                    statusCode: 401,
+                }
+            );
+
+            const [, , , body] =
+                mockUpdateIntegrationMessages.execute.mock.calls[0];
+            expect(body).not.toContain('Authorization');
+            expect(body).not.toContain('super-secret-token');
+            expect(body).not.toContain('api.example.com');
+        });
+
+        it('omits the status code when the payload carries none', async () => {
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_INVALIDATED',
+                { credentialId: 'cred-1' }
+            );
+
+            const [, , , body] =
+                mockUpdateIntegrationMessages.execute.mock.calls[0];
+            expect(body).toContain('testmodule');
+            expect(body).not.toContain('HTTP');
+        });
+
+        it('does not record a diagnostic when credentials are validated', async () => {
+            integration.status = 'ERROR';
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_VALIDATED',
+                { credentialId: 'cred-1' }
+            );
+
+            expect(
+                mockUpdateIntegrationMessages.execute
+            ).not.toHaveBeenCalled();
+        });
+
+        it('does not record a diagnostic when the integration is not hydrated', async () => {
+            integration.id = undefined;
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_INVALIDATED',
+                { credentialId: 'cred-1', statusCode: 401 }
+            );
+
+            expect(
+                mockUpdateIntegrationMessages.execute
+            ).not.toHaveBeenCalled();
+        });
+    });
+
     describe('CREDENTIAL_VALIDATED self-heal', () => {
         const validatedPayload = {
             credentialId: 'cred-1',
@@ -112,7 +255,9 @@ describe('IntegrationBase.receiveNotification', () => {
                 validatedPayload
             );
 
-            expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledTimes(1);
+            expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledTimes(
+                1
+            );
             expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledWith(
                 'int-1',
                 'ENABLED'

--- a/packages/core/integrations/tests/integration-base-receive-notification.test.js
+++ b/packages/core/integrations/tests/integration-base-receive-notification.test.js
@@ -198,34 +198,6 @@ describe('IntegrationBase.receiveNotification', () => {
             expect(body).not.toContain('api.example.com');
         });
 
-        it('falls back to the payload module name when the notifier has none', async () => {
-            await integration.receiveNotification(
-                {},
-                'CREDENTIAL_INVALIDATED',
-                { credentialId: 'cred-1', moduleName: 'testmodule' }
-            );
-
-            const [, , , body] =
-                mockUpdateIntegrationMessages.execute.mock.calls[0];
-            expect(body).toContain('your testmodule Entity');
-        });
-
-        it('reads naturally when no module name is available at all', async () => {
-            await integration.receiveNotification(
-                {},
-                'CREDENTIAL_INVALIDATED',
-                {
-                    credentialId: 'cred-1',
-                }
-            );
-
-            const [, , , body] =
-                mockUpdateIntegrationMessages.execute.mock.calls[0];
-            expect(body).toContain('your Entity');
-            expect(body).not.toContain('undefined');
-            expect(body).not.toContain('unknown');
-        });
-
         it('omits the status code when the payload carries none', async () => {
             await integration.receiveNotification(
                 { name: 'testmodule' },

--- a/packages/core/integrations/tests/integration-base-receive-notification.test.js
+++ b/packages/core/integrations/tests/integration-base-receive-notification.test.js
@@ -106,7 +106,7 @@ describe('IntegrationBase.receiveNotification', () => {
     describe('recorded diagnostic', () => {
         it('records an Authentication Error naming the module and status code', async () => {
             await integration.receiveNotification(
-                { name: 'testmodule', getName: () => 'testmodule' },
+                { name: 'testmodule' },
                 'CREDENTIAL_INVALIDATED',
                 {
                     credentialId: 'cred-1',
@@ -196,6 +196,34 @@ describe('IntegrationBase.receiveNotification', () => {
             expect(body).not.toContain('Authorization');
             expect(body).not.toContain('super-secret-token');
             expect(body).not.toContain('api.example.com');
+        });
+
+        it('falls back to the payload module name when the notifier has none', async () => {
+            await integration.receiveNotification(
+                {},
+                'CREDENTIAL_INVALIDATED',
+                { credentialId: 'cred-1', moduleName: 'testmodule' }
+            );
+
+            const [, , , body] =
+                mockUpdateIntegrationMessages.execute.mock.calls[0];
+            expect(body).toContain('your testmodule Entity');
+        });
+
+        it('reads naturally when no module name is available at all', async () => {
+            await integration.receiveNotification(
+                {},
+                'CREDENTIAL_INVALIDATED',
+                {
+                    credentialId: 'cred-1',
+                }
+            );
+
+            const [, , , body] =
+                mockUpdateIntegrationMessages.execute.mock.calls[0];
+            expect(body).toContain('your Entity');
+            expect(body).not.toContain('undefined');
+            expect(body).not.toContain('unknown');
         });
 
         it('omits the status code when the payload carries none', async () => {

--- a/packages/core/integrations/tests/integration-base-receive-notification.test.js
+++ b/packages/core/integrations/tests/integration-base-receive-notification.test.js
@@ -65,6 +65,56 @@ describe('IntegrationBase.receiveNotification', () => {
         expect(integration.status).toBe('ERROR');
     });
 
+    describe('already in ERROR', () => {
+        it('does not write again when the same integration is reported twice', async () => {
+            const payload = { credentialId: 'cred-1', statusCode: 401 };
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_INVALIDATED',
+                payload
+            );
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_INVALIDATED',
+                payload
+            );
+
+            expect(mockUpdateIntegrationStatus.execute).toHaveBeenCalledTimes(
+                1
+            );
+            expect(mockUpdateIntegrationMessages.execute).toHaveBeenCalledTimes(
+                1
+            );
+        });
+
+        it('still flips a second integration that shares the same credential', async () => {
+            const shared = { credentialId: 'cred-1', statusCode: 401 };
+            const other = new IntegrationBase();
+            other.id = 'int-2';
+            other.status = 'ENABLED';
+            other.updateIntegrationStatus = { execute: jest.fn() };
+            other.updateIntegrationMessages = { execute: jest.fn() };
+
+            await integration.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_INVALIDATED',
+                shared
+            );
+            await other.receiveNotification(
+                { name: 'testmodule' },
+                'CREDENTIAL_INVALIDATED',
+                shared
+            );
+
+            expect(other.updateIntegrationStatus.execute).toHaveBeenCalledWith(
+                'int-2',
+                'ERROR'
+            );
+            expect(other.status).toBe('ERROR');
+        });
+    });
+
     it('includes the diagnostic reason and status code in the log line when present', async () => {
         const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
         try {

--- a/packages/core/modules/requester/oauth-2.js
+++ b/packages/core/modules/requester/oauth-2.js
@@ -353,8 +353,12 @@ class OAuth2Requester extends Requester {
 
             await this.setTokens(tokenRes);
             return tokenRes;
-        } catch {
-            await this.notify(this.DLGT_INVALID_AUTH);
+        } catch (error) {
+            // Forward the failure: the delegate persists a user-facing reason
+            // from it, so dropping it leaves the integration in ERROR with no
+            // stated cause. (refreshAccessToken has no equivalent site — its
+            // error propagates to refreshAuth, which never notifies at all.)
+            await this.notify(this.DLGT_INVALID_AUTH, error);
         }
     }
 
@@ -387,8 +391,9 @@ class OAuth2Requester extends Requester {
 
             await this.setTokens(tokenRes);
             return tokenRes;
-        } catch {
-            await this.notify(this.DLGT_INVALID_AUTH);
+        } catch (error) {
+            // Forward the failure: see getTokenFromUsernamePassword above.
+            await this.notify(this.DLGT_INVALID_AUTH, error);
         }
     }
 }

--- a/packages/core/modules/requester/oauth-2.js
+++ b/packages/core/modules/requester/oauth-2.js
@@ -354,10 +354,6 @@ class OAuth2Requester extends Requester {
             await this.setTokens(tokenRes);
             return tokenRes;
         } catch (error) {
-            // Forward the failure: the delegate persists a user-facing reason
-            // from it, so dropping it leaves the integration in ERROR with no
-            // stated cause. (refreshAccessToken has no equivalent site — its
-            // error propagates to refreshAuth, which never notifies at all.)
             await this.notify(this.DLGT_INVALID_AUTH, error);
         }
     }
@@ -392,7 +388,6 @@ class OAuth2Requester extends Requester {
             await this.setTokens(tokenRes);
             return tokenRes;
         } catch (error) {
-            // Forward the failure: see getTokenFromUsernamePassword above.
             await this.notify(this.DLGT_INVALID_AUTH, error);
         }
     }

--- a/packages/core/modules/requester/oauth-2.js
+++ b/packages/core/modules/requester/oauth-2.js
@@ -354,7 +354,12 @@ class OAuth2Requester extends Requester {
             await this.setTokens(tokenRes);
             return tokenRes;
         } catch (error) {
-            await this.notify(this.DLGT_INVALID_AUTH, error);
+            // Status only. This request's body holds the password or client
+            // secret, and FetchError embeds the body in its message outside
+            // prod, so forwarding the error itself would log the credential.
+            await this.notify(this.DLGT_INVALID_AUTH, {
+                statusCode: error?.statusCode,
+            });
         }
     }
 
@@ -388,7 +393,12 @@ class OAuth2Requester extends Requester {
             await this.setTokens(tokenRes);
             return tokenRes;
         } catch (error) {
-            await this.notify(this.DLGT_INVALID_AUTH, error);
+            // Status only. This request's body holds the password or client
+            // secret, and FetchError embeds the body in its message outside
+            // prod, so forwarding the error itself would log the credential.
+            await this.notify(this.DLGT_INVALID_AUTH, {
+                statusCode: error?.statusCode,
+            });
         }
     }
 }

--- a/packages/core/modules/requester/oauth-2.js
+++ b/packages/core/modules/requester/oauth-2.js
@@ -322,6 +322,11 @@ class OAuth2Requester extends Requester {
                 response_status: error?.response?.status,
                 response_data: error?.response?.data,
             });
+            // Status only: the refresh body carries client_secret, and
+            // FetchError embeds the body in its message outside prod.
+            await this.notify(this.DLGT_INVALID_AUTH, {
+                statusCode: error?.statusCode,
+            });
             return false;
         }
     }

--- a/packages/core/modules/requester/oauth-2.test.js
+++ b/packages/core/modules/requester/oauth-2.test.js
@@ -137,16 +137,19 @@ describe('OAuth2Requester', () => {
                 grant_type: 'authorization_code',
                 refresh_token: 'test-refresh-token',
             });
-            requester.refreshAccessToken = jest
-                .fn()
-                .mockRejectedValue(new Error('Token expired'));
+            requester.refreshAccessToken = jest.fn().mockRejectedValue(
+                Object.assign(new Error('Token expired'), {
+                    statusCode: 401,
+                })
+            );
             requester.notify = jest.fn();
 
             const result = await requester.refreshAuth();
 
             expect(result).toBe(false);
             expect(requester.notify).toHaveBeenCalledWith(
-                requester.DLGT_INVALID_AUTH
+                requester.DLGT_INVALID_AUTH,
+                { statusCode: 401 }
             );
         });
 
@@ -156,14 +159,41 @@ describe('OAuth2Requester', () => {
             });
             requester.getTokenFromClientCredentials = jest
                 .fn()
-                .mockRejectedValue(new Error('Invalid credentials'));
+                .mockRejectedValue(
+                    Object.assign(new Error('Invalid credentials'), {
+                        statusCode: 401,
+                    })
+                );
             requester.notify = jest.fn();
 
             const result = await requester.refreshAuth();
 
             expect(result).toBe(false);
             expect(requester.notify).toHaveBeenCalledWith(
-                requester.DLGT_INVALID_AUTH
+                requester.DLGT_INVALID_AUTH,
+                { statusCode: 401 }
+            );
+        });
+
+        it('does not leak the refresh request body to the delegate', async () => {
+            const requester = new OAuth2Requester({
+                grant_type: 'authorization_code',
+                refresh_token: 'test-refresh-token',
+                client_secret: 'sk-live-secret',
+            });
+            requester.refreshAccessToken = jest
+                .fn()
+                .mockRejectedValue(
+                    new Error(
+                        '{"init":{"body":"client_secret=sk-live-secret"}}'
+                    )
+                );
+            requester.notify = jest.fn();
+
+            await requester.refreshAuth();
+
+            expect(JSON.stringify(requester.notify.mock.calls)).not.toContain(
+                'sk-live-secret'
             );
         });
     });
@@ -388,7 +418,8 @@ describe('OAuth2Requester', () => {
 
             expect(mockFetch).toHaveBeenCalledTimes(1);
             expect(requester.notify).toHaveBeenCalledWith(
-                requester.DLGT_INVALID_AUTH
+                requester.DLGT_INVALID_AUTH,
+                expect.anything()
             );
         });
 

--- a/packages/core/modules/requester/oauth-2.test.js
+++ b/packages/core/modules/requester/oauth-2.test.js
@@ -8,13 +8,57 @@ describe('OAuth2Requester', () => {
         });
 
         it('should set grant_type from params', () => {
-            const requester = new OAuth2Requester({ grant_type: 'client_credentials' });
+            const requester = new OAuth2Requester({
+                grant_type: 'client_credentials',
+            });
             expect(requester.grant_type).toBe('client_credentials');
         });
 
         it('should set isRefreshable to true', () => {
             const requester = new OAuth2Requester({});
             expect(requester.isRefreshable).toBe(true);
+        });
+    });
+
+    describe('DLGT_INVALID_AUTH payload', () => {
+        // The delegate turns this payload into a user-facing reason on the
+        // integration, so a bare notify() leaves it in ERROR with no cause.
+        it('forwards the failure from getTokenFromUsernamePassword', async () => {
+            const requester = new OAuth2Requester({
+                grant_type: 'password',
+                username: 'someone',
+                password: 'wrong',
+            });
+            const failure = Object.assign(new Error('bad password'), {
+                statusCode: 401,
+            });
+            requester._post = jest.fn().mockRejectedValue(failure);
+            requester.notify = jest.fn();
+
+            await requester.getTokenFromUsernamePassword();
+
+            expect(requester.notify).toHaveBeenCalledWith(
+                requester.DLGT_INVALID_AUTH,
+                failure
+            );
+        });
+
+        it('forwards the failure from getTokenFromClientCredentials', async () => {
+            const requester = new OAuth2Requester({
+                grant_type: 'client_credentials',
+            });
+            const failure = Object.assign(new Error('bad client secret'), {
+                statusCode: 401,
+            });
+            requester._post = jest.fn().mockRejectedValue(failure);
+            requester.notify = jest.fn();
+
+            await requester.getTokenFromClientCredentials();
+
+            expect(requester.notify).toHaveBeenCalledWith(
+                requester.DLGT_INVALID_AUTH,
+                failure
+            );
         });
     });
 
@@ -57,9 +101,11 @@ describe('OAuth2Requester', () => {
             const requester = new OAuth2Requester({
                 grant_type: 'client_credentials',
             });
-            requester.getTokenFromClientCredentials = jest.fn().mockResolvedValue({
-                access_token: 'new-token',
-            });
+            requester.getTokenFromClientCredentials = jest
+                .fn()
+                .mockResolvedValue({
+                    access_token: 'new-token',
+                });
             requester.refreshAccessToken = jest.fn();
 
             const result = await requester.refreshAuth();
@@ -74,26 +120,34 @@ describe('OAuth2Requester', () => {
                 grant_type: 'authorization_code',
                 refresh_token: 'test-refresh-token',
             });
-            requester.refreshAccessToken = jest.fn().mockRejectedValue(new Error('Token expired'));
+            requester.refreshAccessToken = jest
+                .fn()
+                .mockRejectedValue(new Error('Token expired'));
             requester.notify = jest.fn();
 
             const result = await requester.refreshAuth();
 
             expect(result).toBe(false);
-            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+            expect(requester.notify).toHaveBeenCalledWith(
+                requester.DLGT_INVALID_AUTH
+            );
         });
 
         it('should return false and notify DLGT_INVALID_AUTH on error during client_credentials refresh', async () => {
             const requester = new OAuth2Requester({
                 grant_type: 'client_credentials',
             });
-            requester.getTokenFromClientCredentials = jest.fn().mockRejectedValue(new Error('Invalid credentials'));
+            requester.getTokenFromClientCredentials = jest
+                .fn()
+                .mockRejectedValue(new Error('Invalid credentials'));
             requester.notify = jest.fn();
 
             const result = await requester.refreshAuth();
 
             expect(result).toBe(false);
-            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+            expect(requester.notify).toHaveBeenCalledWith(
+                requester.DLGT_INVALID_AUTH
+            );
         });
     });
 
@@ -110,7 +164,9 @@ describe('OAuth2Requester', () => {
 
             expect(requester.access_token).toBe('test-access-token');
             expect(requester.refresh_token).toBe('test-refresh-token');
-            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_TOKEN_UPDATE);
+            expect(requester.notify).toHaveBeenCalledWith(
+                requester.DLGT_TOKEN_UPDATE
+            );
         });
     });
 
@@ -243,7 +299,8 @@ describe('OAuth2Requester', () => {
     describe('401 retry flow integration', () => {
         it('should retry with NEW token after successful refresh (not cached old token)', async () => {
             const capturedHeaders = [];
-            const mockFetch = jest.fn()
+            const mockFetch = jest
+                .fn()
                 .mockImplementationOnce(async (url, options) => {
                     capturedHeaders.push({ ...options.headers });
                     return {
@@ -268,17 +325,25 @@ describe('OAuth2Requester', () => {
                 fetch: mockFetch,
             });
 
-            requester.refreshAccessToken = jest.fn().mockImplementation(async () => {
-                requester.access_token = 'brand-new-token';
-                return { access_token: 'brand-new-token' };
-            });
+            requester.refreshAccessToken = jest
+                .fn()
+                .mockImplementation(async () => {
+                    requester.access_token = 'brand-new-token';
+                    return { access_token: 'brand-new-token' };
+                });
 
-            const result = await requester._get({ url: 'https://api.example.com/data' });
+            const result = await requester._get({
+                url: 'https://api.example.com/data',
+            });
 
             expect(result).toEqual({ success: true });
             expect(mockFetch).toHaveBeenCalledTimes(2);
-            expect(capturedHeaders[0].Authorization).toBe('Bearer old-expired-token');
-            expect(capturedHeaders[1].Authorization).toBe('Bearer brand-new-token');
+            expect(capturedHeaders[0].Authorization).toBe(
+                'Bearer old-expired-token'
+            );
+            expect(capturedHeaders[1].Authorization).toBe(
+                'Bearer brand-new-token'
+            );
         });
 
         it('should NOT retry when refresh fails', async () => {
@@ -295,26 +360,33 @@ describe('OAuth2Requester', () => {
                 fetch: mockFetch,
             });
 
-            requester.refreshAccessToken = jest.fn().mockRejectedValue(new Error('Refresh token expired'));
+            requester.refreshAccessToken = jest
+                .fn()
+                .mockRejectedValue(new Error('Refresh token expired'));
             requester.notify = jest.fn();
 
-            await expect(requester._get({ url: 'https://api.example.com/data' }))
-                .rejects.toThrow();
+            await expect(
+                requester._get({ url: 'https://api.example.com/data' })
+            ).rejects.toThrow();
 
             expect(mockFetch).toHaveBeenCalledTimes(1);
-            expect(requester.notify).toHaveBeenCalledWith(requester.DLGT_INVALID_AUTH);
+            expect(requester.notify).toHaveBeenCalledWith(
+                requester.DLGT_INVALID_AUTH
+            );
         });
 
         it('should not retry when refresh throws and access_token becomes undefined', async () => {
             const capturedHeaders = [];
-            const mockFetch = jest.fn().mockImplementation(async (url, options) => {
-                capturedHeaders.push({ ...options.headers });
-                return {
-                    status: 401,
-                    headers: { get: () => 'application/json' },
-                    json: async () => ({ error: 'Unauthorized' }),
-                };
-            });
+            const mockFetch = jest
+                .fn()
+                .mockImplementation(async (url, options) => {
+                    capturedHeaders.push({ ...options.headers });
+                    return {
+                        status: 401,
+                        headers: { get: () => 'application/json' },
+                        json: async () => ({ error: 'Unauthorized' }),
+                    };
+                });
 
             const requester = new OAuth2Requester({
                 access_token: 'old-expired-token',
@@ -323,16 +395,21 @@ describe('OAuth2Requester', () => {
                 fetch: mockFetch,
             });
 
-            requester.refreshAccessToken = jest.fn().mockImplementation(async () => {
-                requester.access_token = undefined;
-                throw new Error('Refresh failed');
-            });
+            requester.refreshAccessToken = jest
+                .fn()
+                .mockImplementation(async () => {
+                    requester.access_token = undefined;
+                    throw new Error('Refresh failed');
+                });
             requester.notify = jest.fn();
 
-            await expect(requester._get({ url: 'https://api.example.com/data' }))
-                .rejects.toThrow();
+            await expect(
+                requester._get({ url: 'https://api.example.com/data' })
+            ).rejects.toThrow();
 
-            expect(capturedHeaders[0].Authorization).toBe('Bearer old-expired-token');
+            expect(capturedHeaders[0].Authorization).toBe(
+                'Bearer old-expired-token'
+            );
             expect(mockFetch).toHaveBeenCalledTimes(1);
         });
 
@@ -351,7 +428,9 @@ describe('OAuth2Requester', () => {
             await requester._get({ url: 'https://api.example.com/data' });
 
             expect(mockFetch).toHaveBeenCalledTimes(1);
-            expect(mockFetch.mock.calls[0][1].headers.Authorization).toBeUndefined();
+            expect(
+                mockFetch.mock.calls[0][1].headers.Authorization
+            ).toBeUndefined();
         });
 
         it('retries consecutive 401s up to 3 times, then notifies INVALID_AUTH once the budget is exhausted', async () => {
@@ -369,14 +448,17 @@ describe('OAuth2Requester', () => {
                 fetch: mockFetch,
             });
 
-            requester.refreshAccessToken = jest.fn().mockImplementation(async () => {
-                requester.access_token = 'new-but-still-invalid-token';
-                return { access_token: 'new-but-still-invalid-token' };
-            });
+            requester.refreshAccessToken = jest
+                .fn()
+                .mockImplementation(async () => {
+                    requester.access_token = 'new-but-still-invalid-token';
+                    return { access_token: 'new-but-still-invalid-token' };
+                });
             requester.notify = jest.fn();
 
-            await expect(requester._get({ url: 'https://api.example.com/data' }))
-                .rejects.toThrow();
+            await expect(
+                requester._get({ url: 'https://api.example.com/data' })
+            ).rejects.toThrow();
 
             expect(mockFetch).toHaveBeenCalledTimes(4);
             expect(requester.notify).toHaveBeenCalledWith(
@@ -387,7 +469,8 @@ describe('OAuth2Requester', () => {
 
         it('should use getTokenFromClientCredentials for client_credentials grant type on 401', async () => {
             const capturedHeaders = [];
-            const mockFetch = jest.fn()
+            const mockFetch = jest
+                .fn()
                 .mockImplementationOnce(async (url, options) => {
                     capturedHeaders.push({ ...options.headers });
                     return {
@@ -411,19 +494,27 @@ describe('OAuth2Requester', () => {
                 fetch: mockFetch,
             });
 
-            requester.getTokenFromClientCredentials = jest.fn().mockImplementation(async () => {
-                requester.access_token = 'new-cc-token';
-                return { access_token: 'new-cc-token' };
-            });
+            requester.getTokenFromClientCredentials = jest
+                .fn()
+                .mockImplementation(async () => {
+                    requester.access_token = 'new-cc-token';
+                    return { access_token: 'new-cc-token' };
+                });
             requester.refreshAccessToken = jest.fn();
 
-            const result = await requester._get({ url: 'https://api.example.com/data' });
+            const result = await requester._get({
+                url: 'https://api.example.com/data',
+            });
 
             expect(result).toEqual({ data: 'success' });
             expect(requester.getTokenFromClientCredentials).toHaveBeenCalled();
             expect(requester.refreshAccessToken).not.toHaveBeenCalled();
-            expect(capturedHeaders[0].Authorization).toBe('Bearer old-cc-token');
-            expect(capturedHeaders[1].Authorization).toBe('Bearer new-cc-token');
+            expect(capturedHeaders[0].Authorization).toBe(
+                'Bearer old-cc-token'
+            );
+            expect(capturedHeaders[1].Authorization).toBe(
+                'Bearer new-cc-token'
+            );
         });
     });
 });

--- a/packages/core/modules/requester/oauth-2.test.js
+++ b/packages/core/modules/requester/oauth-2.test.js
@@ -21,41 +21,60 @@ describe('OAuth2Requester', () => {
     });
 
     describe('DLGT_INVALID_AUTH payload', () => {
-        it('forwards the failure from getTokenFromUsernamePassword', async () => {
+        it('forwards the status from getTokenFromUsernamePassword', async () => {
             const requester = new OAuth2Requester({
                 grant_type: 'password',
                 username: 'someone',
-                password: 'wrong',
+                password: 'hunter2',
             });
-            const failure = Object.assign(new Error('bad password'), {
-                statusCode: 401,
-            });
-            requester._post = jest.fn().mockRejectedValue(failure);
+            requester._post = jest
+                .fn()
+                .mockRejectedValue(
+                    Object.assign(
+                        new Error(
+                            '{"init":{"body":"{\\"password\\":\\"hunter2\\"}"}}'
+                        ),
+                        { statusCode: 401 }
+                    )
+                );
             requester.notify = jest.fn();
 
             await requester.getTokenFromUsernamePassword();
 
             expect(requester.notify).toHaveBeenCalledWith(
                 requester.DLGT_INVALID_AUTH,
-                failure
+                { statusCode: 401 }
+            );
+            expect(JSON.stringify(requester.notify.mock.calls)).not.toContain(
+                'hunter2'
             );
         });
 
-        it('forwards the failure from getTokenFromClientCredentials', async () => {
+        it('forwards the status from getTokenFromClientCredentials', async () => {
             const requester = new OAuth2Requester({
                 grant_type: 'client_credentials',
+                client_secret: 'sk-live-secret',
             });
-            const failure = Object.assign(new Error('bad client secret'), {
-                statusCode: 401,
-            });
-            requester._post = jest.fn().mockRejectedValue(failure);
+            requester._post = jest
+                .fn()
+                .mockRejectedValue(
+                    Object.assign(
+                        new Error(
+                            '{"init":{"body":"{\\"client_secret\\":\\"sk-live-secret\\"}"}}'
+                        ),
+                        { statusCode: 401 }
+                    )
+                );
             requester.notify = jest.fn();
 
             await requester.getTokenFromClientCredentials();
 
             expect(requester.notify).toHaveBeenCalledWith(
                 requester.DLGT_INVALID_AUTH,
-                failure
+                { statusCode: 401 }
+            );
+            expect(JSON.stringify(requester.notify.mock.calls)).not.toContain(
+                'sk-live-secret'
             );
         });
     });

--- a/packages/core/modules/requester/oauth-2.test.js
+++ b/packages/core/modules/requester/oauth-2.test.js
@@ -21,8 +21,6 @@ describe('OAuth2Requester', () => {
     });
 
     describe('DLGT_INVALID_AUTH payload', () => {
-        // The delegate turns this payload into a user-facing reason on the
-        // integration, so a bare notify() leaves it in ERROR with no cause.
         it('forwards the failure from getTokenFromUsernamePassword', async () => {
             const requester = new OAuth2Requester({
                 grant_type: 'password',


### PR DESCRIPTION
## Summary

When a module reports `CREDENTIAL_INVALIDATED`, `IntegrationBase.receiveNotification` flips the integration to ERROR via `persistStatus`, which writes **only the status column**. The reason reaches the `console.log` line and nowhere else, so the integration surfaces to end users and support as broken with an empty `errors` array.

This PR records the cause alongside the flip.

## Why

The delegate payload already carries `reason` and `statusCode` — they were logged and discarded. The consequences compound, because integrations in ERROR have their queued webhooks discarded, so the state is both sticky and unexplained.

Measured in one adopter's production database:

- **74 of 333 ERROR integrations (22%) recorded no cause at all** — empty `errors`, `warnings`, `logs` and `info`.
- Accruing **1 to 4 per day**, across five different integration types.
- Every case traced was a genuine expired or revoked authorization, i.e. exactly the condition this delegate exists to report.
- Diagnosing a single one required a CloudWatch Logs Insights query pinned to the second the flip happened.

## What changed

`receiveNotification` now calls `recordCredentialRejection` before `persistStatus('ERROR')`.

It reuses the `'Authentication Error'` title and the wording `testAuth` already writes (`integration-base.js:381`), so the passive auth check and the delegate produce a consistent diagnostic instead of two competing vocabularies for the same condition.

Two deliberate constraints:

**The delegate's `reason` is not persisted.** It is the `FetchError` message, which embeds the serialized request — and `FetchError` blanks that only when `STAGE !== 'dev'`, so outside prod it contains the `Authorization` header. These messages are surfaced to end users, so only the status code crosses over. The full text remains in the log line directly above.

**The write is best-effort and ordered first.** A failed diagnostic write can never prevent the status flip that stops processing on dead credentials; recording before the flip means a failed *status* write still leaves a cause behind.

## Test plan

- [x] 7 new tests in the existing `integration-base-receive-notification.test.js`, written test-first
- [x] Covers: recorded content, ordering guarantee, both failure paths, that a request-echoing `reason` containing an `Authorization` header stays out of the persisted body, and that `CREDENTIAL_VALIDATED` and unhydrated instances record nothing
- [x] `integrations` + `modules` suites: **587 passing**, up from 578 on `next`
- [x] The 11 failures in 3 suites (`integration-mapping-repository-documentdb-encryption`, `find-integration-context-by-external-entity-id`, `oauth-2`) are **pre-existing on `next`** and unrelated — verified by running the same command on a clean checkout
- [x] Prettier and ESLint clean (0 errors)

## Reviewed for correctness and contract

A correctness/contract pass caught a security regression in an earlier revision of this branch and it is fixed in `769f9999`. Recording it here because the reasoning is the interesting part.

The two grant paths originally forwarded their **caught error** to `notify(DLGT_INVALID_AUTH, error)`. But the request bodies there hold a raw `password` (`getTokenFromUsernamePassword`) and a raw `client_secret` (`getTokenFromClientCredentials`), `FetchError` embeds the request body in its `message` whenever `STAGE === 'dev'`, and both `markCredentialsInvalid` and `receiveNotification` log that message. Because these sites previously notified with **no payload**, `markCredentialsInvalid`'s `if (diagnosticInfo)` guard kept the logs empty — so forwarding the error newly sent end-user passwords and client secrets to CloudWatch on any dev-stage deployment. They now forward `{ statusCode }` only, which is all the delegate ever needed, and the tests assert the secret cannot reach the payload rather than merely checking the shape.

Also confirmed by that pass:

- **Ordering is coherent in every interleaving.** Message-written/status-failed leaves ENABLED with an auth error recorded, which is exactly what `testAuth` already does. Record-before-flip is the right order: a crash between the two leaves the diagnosable state rather than the ERROR-with-empty-`errors` state being fixed here.
- **Idempotent under concurrency.** Six firings in eight seconds converge on one message plus status ERROR, because of the clobber behaviour described below. This change does not worsen the pre-existing read-modify-write race.
- **Non-Error payloads degrade safely** through `diagnosticInfo.message ?? diagnosticInfo`.
- **Nothing else persisted can carry a secret** — only the developer-set `moduleName` and a numeric `statusCode`.

## Known adjacent bugs, not addressed here

**`updateIntegrationMessages` replaces rather than appends.** `integration-repository-postgres.js` reads `integration.messages?.[messageType]`, but the `Integration` model has no `messages` column — `errors`/`warnings`/`info`/`logs` are four separate top-level `Json` columns. So the array is always rewritten with a single element. Same in the mongo and documentdb repos.

That is load-bearing here in an unintuitive way: it bounds this write to one entry, which is why a credential storm cannot bloat the row. It also means this entry overwrites any earlier, more specific diagnostic. **Fixing that mismatch should land together with same-title dedupe** — otherwise appends start working and a flip storm grows the array without bound.

## `refreshAuth` now honours its own docstring

`oauth-2.js:293` has always documented "On failure, notifies delegates via `DLGT_INVALID_AUTH`", but the catch only logged and returned `false`. Three tests asserted the documented behaviour and had been red on `next` for as long as they existed. They now pass.

It forwards `{ statusCode }` rather than the caught error, for the same reason as the grant paths above: `refreshAccessToken`'s body carries `client_secret` in a `URLSearchParams` that `FetchError` explicitly stringifies into its message outside prod. A test pins that the secret cannot reach the delegate.

The three stale assertions expected a bare `notify(DLGT_INVALID_AUTH)` with no payload — an expectation that was already wrong for the 401-retry test, which reaches the delegate via `Requester._invalidateAuth` and has been receiving a `FetchError` since that method existed. All three now assert the payload.

The delegate now fires **twice** on the only path that calls `refreshAuth`, because `Requester` also calls `_invalidateAuth` when it returns `false`. The `CREDENTIAL_INVALIDATED` branch is therefore now guarded on the integration already being in ERROR, mirroring the `CREDENTIAL_VALIDATED` branch's existing `if (this.status !== 'ERROR') return`.

That guard is deliberately at the integration level and **not** in `Module.markCredentialsInvalid` on `credential.authIsValid === false`, which is the more obvious place. Two integrations can share one `Credential` row — observed in production, where two Zoho integrations shared credential 12369. A credential-level guard would let the first integration's 401 mark the row invalid and then return early for the second, leaving it ENABLED with a dead credential: exactly the silent-broken state this PR exists to fix. Integration status is per-integration, so the guard belongs there, and a test pins that a second integration sharing the credential still flips.

This removes the sequential duplicate, which is the guaranteed one. It does not deduplicate concurrent invocations — those each hydrate their own instance and read status ENABLED before any write lands — so the observed "six firings in eight seconds" case is damped but not eliminated. Doing that properly needs a conditional update or an advisory lock, which is a bigger change than this PR should carry.

## Test results

Whole `@friggframework/core` package: **1592 passing, up from 1586 on `next`**, and the 12 remaining suite failures are byte-identical to `next` (verified by diffing the failure list against a stashed baseline, not by eyeballing counts). Those are pre-existing encryption/repository suites that need a live database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


