### PR TITLE
feat: Docker-based local test environment for the next branch

### DIFF
--- a/.claude/skills/frigg-local-test/SKILL.md
+++ b/.claude/skills/frigg-local-test/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: frigg-local-test
+description: Run and test the Frigg framework from the local "next" branch against a real database (PostgreSQL or MongoDB) via Docker — no mocks, no published canary. The entire harness is bundled with this skill and copied to a scratch dir to run. Use when asked to run Frigg locally, test a framework feature on the next branch, reproduce or regression-test framework or integration behavior against real persistence, inspect real persisted Frigg records (User/Credential/Entity/Integration), or write a new test scenario. Trigger phrases include "test this on next", "run the local test environment", "spin up the frigg harness", "add a scenario for X".
+---
+
+# Frigg Local Test
+
+Run and test the **local `next` branch** of Frigg end-to-end against real
+databases (PostgreSQL or MongoDB, both started via Docker Compose). Behavior
+runs through actual `IntegrationBase` subclasses, `createFriggCommands`, and
+the `IntegrationEventDispatcher` — the same path production uses.
+
+The harness is **bundled with this skill** at `assets/harness/`. **Copy it to a
+scratch dir and run it there; never run it from inside `.claude/`.** It pins
+`@friggframework/core` to the local checkout via a `file:` dependency
+(symlink into `node_modules`), so edits to `packages/core` are live without
+reinstalling — this is the loop for validating framework features on `next`
+before shipping.
+
+Two other skills cover adjacent ground — consult them as needed:
+
+- **`frigg`** — framework architecture, API modules, integration lifecycle,
+  commands pattern, encryption.
+- **`frigg-canary-test`** — same harness shape, but against a *published npm
+  canary*. Prefer this skill when the target is a specific published canary.
+
+## Where everything lives
+
+```
+.claude/skills/frigg-local-test/
+├── SKILL.md                          ← this runbook (starting point for agents)
+└── assets/harness/                   ← the whole environment (copy to scratch to run)
+    ├── package.json                  ← scripts: db:up/down, setup:db, prisma:*, scenarios, server
+    ├── docker-compose.yml            ← postgres (:5433) + mongo rs0 (:27018)
+    │                                    + profiles: agent sandbox, browser (CDP), localstack
+    ├── Dockerfile + scripts/entrypoint.sh  ← agent sandbox image (node 22 + chromium)
+    ├── index.js                      ← Frigg app Definition (integrations, database.type)
+    ├── server.js                     ← poke server (:3001/health, /api/integrations)
+    ├── src/integrations/             ← TestApiAIntegration / TestApiBIntegration
+    ├── src/api-modules/              ← mock API-key modules
+    ├── scenarios/                    ← one runnable script per feature area
+    └── scripts/                      ← setup-db / run-scenario / smoke
+```
+
+## Quick start (host-driven — the common case)
+
+```bash
+# 1. Copy the bundled harness to a scratch dir.
+WORK=/tmp/frigg-test                  # any dir outside .claude/
+rm -rf "$WORK" && mkdir -p "$WORK"
+cp -R <this-skill-dir>/assets/harness/. "$WORK/"
+cd "$WORK"
+
+# 2. Start the databases (Postgres on 5433, Mongo replica set on 27018).
+npm run db:up
+
+# 3. Pin the LOCAL core (next branch), then install.
+npm install /path/to/frigg/packages/core   # file: dep -> live next code
+npm install
+
+# 4. Choose the DB and prep the schema.
+cp .env.example .env                 # defaults to PostgreSQL; edit for Mongo
+npm run setup:db                     # prisma generate + migrate deploy (or db push)
+
+# 5. Run the scenario suite.
+npm run scenario:integration-lifecycle
+```
+
+A green run ends with `Results: 4 passed, 0 failed`. Tear down with
+`npm run db:down` (add `-v` to wipe data).
+
+## Choosing the database
+
+Set `DB_TYPE` + `DATABASE_URL` in `.env` (see `.env.example`), then run
+`npm run setup:db`. Core selects the Prisma client from `DB_TYPE`.
+
+| | PostgreSQL | MongoDB |
+|---|---|---|
+| `.env` `DB_TYPE` | `postgresql` | `mongodb` |
+| `DATABASE_URL` (host) | `postgresql://postgres:postgres@localhost:5433/frigg_test` | `mongodb://localhost:27018/frigg_test?replicaSet=rs0&directConnection=true` |
+| `DATABASE_URL` (sandbox) | `postgresql://postgres:postgres@postgres:5432/frigg_test` | `mongodb://mongodb:27017/frigg_test?replicaSet=rs0&directConnection=true` |
+| schema sync | `migrate deploy` (migrations exist) | `db push` (no migrations for Mongo) |
+
+Both DBs run from the bundled `docker-compose.yml` on **non-default ports**
+(5433 / 27018) so they never clash with a project's own stack. Mongo runs as a
+single-node replica set (`rs0`) because Prisma requires one; `mongo-init.sh`
+initialises it.
+
+## Critical setup notes
+
+- **Generate the client per DB.** The Prisma client is built into the core
+  package's `generated/` dir (`packages/core/generated/prisma-<db>` when core
+  is the local `file:` dep). Run `npm run setup:db` after switching `DB_TYPE`
+  or after any core change touching the schema, or core fails to load its
+  database layer.
+- **`DB_TYPE` must be set** — core's `prisma.js` picks the client from it.
+- **`STAGE=dev`** bypasses field-level encryption, so persisted data is readable.
+- **Local core, not registry.** The harness must resolve core to your checkout.
+  `npm install /path/to/frigg/packages/core` adds a `file:` dependency. Verify:
+  `node -e "console.log(require.resolve('@friggframework/core/package.json'))"`
+  should print a path under `*/packages/core/`. The bundled `npm run smoke`
+  checks this.
+- **Mongo needs the replica set** (`rs0`) — wait for the `mongodb-init` one-shot
+  service to complete before connecting.
+
+## Raw Prisma commands (when you need them)
+
+`npm run setup:db` wraps these and resolves the schema path via
+`require.resolve` (robust to symlinks) and reads `DB_TYPE` from `.env`. The raw
+equivalents — from the harness dir, where core is symlinked into
+`node_modules/`:
+
+```bash
+# PostgreSQL: generate client + apply migrations
+npx prisma@6 generate --schema=node_modules/@friggframework/core/prisma-postgresql/schema.prisma
+npx prisma@6 migrate deploy --schema=node_modules/@friggframework/core/prisma-postgresql/schema.prisma
+
+# MongoDB: generate client + push schema (no migrations for Mongo)
+npx prisma@6 generate --schema=node_modules/@friggframework/core/prisma-mongodb/schema.prisma
+npx prisma@6 db push --schema=node_modules/@friggframework/core/prisma-mongodb/schema.prisma
+```
+
+Also available as npm scripts: `prisma:generate:postgres`, `prisma:generate:mongo`,
+`db:migrate:postgres`, `db:push:mongo`.
+
+Notes:
+- `prisma@6` pins the major so the CLI always matches core's schema (core
+  targets Prisma 6.x). Plain `npx prisma` also works — it resolves the
+  harness's installed 6.19.3.
+- Generate must run **before** migrate/deploy or db push, and the generated
+  client must exist before any scenario runs.
+
+## Fully isolated mode (agent sandbox)
+
+The `agent` compose profile (opt-in) runs the whole environment inside a
+sandbox container: repo mounted read-only at `/workspace`, harness mounted
+read-write at `/harness`, DBs reached by service hostname (no host ports).
+
+```bash
+# Set the frigg checkout path once (compose interpolation):
+echo "FRIGG_REPO_DIR=/path/to/frigg" >> .env
+
+# Build + boot the sandbox, then open a shell:
+docker compose up -d --profile agent
+docker compose exec agent bash
+# inside: cd /harness && npm run scenario:integration-lifecycle
+```
+
+The entrypoint pins core to `/workspace/packages/core`, runs `npm install` on
+first boot (named volume, cached), and runs `setup:db`. Chromium is bundled in
+the image for browser-driven tests (headless, `--no-sandbox`). Other opt-in
+profiles: `browser` (standalone Chromium, CDP :9222) and `localstack`
+(KMS/SQS/Scheduler). See `docker-compose.yml` for the isolation model.
+
+## Scenario pattern (how to test a feature)
+
+Copy `scenarios/integration-lifecycle.js`. Every scenario must:
+
+1. **Seed real records** with the Prisma client
+   (`@friggframework/core/database/prisma`): User, Credential, Entity,
+   Integration — whatever the feature touches.
+2. **Drive behavior through `IntegrationBase` subclasses and the
+   `IntegrationEventDispatcher`** (or `createFriggCommands`) — never call use
+   cases directly, so the scenario mirrors the production flow. To exercise an
+   integration's own state: load context first
+   (`commands.loadIntegrationContextById(id)`), hydrate
+   (`new MyIntegration({ ...context.record, modules: context.modules })`), then
+   dispatch (`dispatcher.dispatchJob({ event: 'EVENT_NAME' })`).
+3. **Assert on real framework behavior / persisted state** — what changed in
+   the DB, what the dispatch returned, which errors were thrown (match on
+   `error.code`, e.g. `INTEGRATION_NOT_FOUND`, `TYPE_REQUIRED`).
+4. **Clean up** in a `finally`-equivalent step and `prisma.$disconnect()`.
+
+Add the script to `package.json` and mirror it back into this skill's
+`assets/harness/scenarios/` when it covers a new feature area.
+
+## Integration structure conventions (verified against production)
+
+- **Wrap modules as `{ definition: <ModuleDefinition> }`** under
+  `Definition.modules`. The declaration key is how the module attaches to
+  `this` (`this.testApiA.api`).
+
+  ```javascript
+  static Definition = {
+      modules: { testApiA: { definition: testApiA.Definition } }, // ✅
+      // modules: { testApiA: testApiA.Definition },              // ❌ see gotcha
+  };
+  ```
+
+- **Use `createFriggCommands`** (public API), not `createIntegrationCommands`
+  (internal). It exposes integration + user + entity + credential commands.
+- **No `static modules` field** — the framework only reads `Definition.modules`.
+
+## Gotchas
+
+- **Missing the `{ definition }` wrapper** makes
+  `getModulesDefinitionFromIntegrationClasses` read `module.definition` as
+  `undefined`, and `loadIntegrationContextById` throws
+  `Cannot read properties of undefined (reading 'moduleName')`.
+- **Don't run from inside `.claude/`** — copy the harness to a scratch dir
+  first (its `.gitignore` and `.env` handling assume a scratch location).
+- **Ports 5433/27018 are localhost-only bindings.** For a fully hermetic run,
+  remove the `ports:` blocks in `docker-compose.yml`.
+- **Generated clients land in the core checkout's `generated/` dir** — that
+  dir is gitignored in the frigg repo, but regenerating on a different platform
+  (e.g. inside the Linux sandbox) overwrites them; re-run `setup:db` on the
+  host before host-driven runs.
+
+## Full-app path (osls offline — how production runs locally)
+
+The management API (user/login, /api/authorize, /api/integrations, actions)
+runs via the same path a deployed app uses:
+
+```bash
+frigg build --stage dev     # local mode: FRIGG_SKIP_AWS_DISCOVERY=true
+frigg start --stage dev     # spawns: osls offline --config infrastructure.js
+# then: curl localhost:3000/health, POST /user/create, GET /api/integrations ...
+```
+
+The harness `index.js` provides the app `Definition`; a full `infrastructure.js`
+for the osls path is a roadmap item (see `README.md` in the harness).
+
+## Scenario catalog
+
+| Scenario | Covers | How to run |
+|---|---|---|
+| `integration-lifecycle.js` | context loading, hydration, USER_ACTION dispatch, shared entities, error codes | `npm run scenario:integration-lifecycle` |
+
+Add rows here as new scenarios land.

--- a/.claude/skills/frigg-local-test/SKILL.md
+++ b/.claude/skills/frigg-local-test/SKILL.md
@@ -23,6 +23,12 @@ Two other skills cover adjacent ground — consult them as needed:
   commands pattern, encryption.
 - **`frigg-canary-test`** — same harness shape, but against a *published npm
   canary*. Prefer this skill when the target is a specific published canary.
+- **`frigg-management-api`** / **`frigg-user-actions`** — driving a running
+  app's Management HTTP API (auth, users, integrations, actions). Use these
+  once the app is up (see Full-app path below).
+- **`frigg-development-best-practices`** — the framework-development iteration
+  loop (edit → canary → deploy) and TDD expectations; this harness gives that
+  loop its real local database layer.
 
 ## Where everything lives
 

--- a/.claude/skills/frigg-local-test/SKILL.md
+++ b/.claude/skills/frigg-local-test/SKILL.md
@@ -38,7 +38,7 @@ Two other skills cover adjacent ground — consult them as needed:
 └── assets/harness/                   ← the whole environment (copy to scratch to run)
     ├── package.json                  ← scripts: db:up/down, setup:db, prisma:*, scenarios, server
     ├── docker-compose.yml            ← postgres (:5433) + mongo rs0 (:27018)
-    │                                    + profiles: agent sandbox, browser (CDP), localstack
+    │                                    + profiles: agent sandbox, browser (Playwright server), localstack
     ├── Dockerfile + scripts/entrypoint.sh  ← agent sandbox image (node 22 + chromium)
     ├── index.js                      ← Frigg app Definition (integrations, database.type)
     ├── server.js                     ← poke server (:3001/health, /api/integrations)
@@ -105,7 +105,7 @@ initialises it.
   `npm install /path/to/frigg/packages/core` adds a `file:` dependency. Verify:
   `node -e "console.log(require.resolve('@friggframework/core/package.json'))"`
   should print a path under `*/packages/core/`. The bundled `npm run smoke`
-  checks this.
+  FAILS if core does not resolve to the local checkout.
 - **Mongo needs the replica set** (`rs0`) — wait for the `mongodb-init` one-shot
   service to complete before connecting.
 
@@ -155,8 +155,8 @@ docker compose exec agent bash
 The entrypoint pins core to `/workspace/packages/core`, runs `npm install` on
 first boot (named volume, cached), and runs `setup:db`. Chromium is bundled in
 the image for browser-driven tests (headless, `--no-sandbox`). Other opt-in
-profiles: `browser` (standalone Chromium, CDP :9222) and `localstack`
-(KMS/SQS/Scheduler). See `docker-compose.yml` for the isolation model.
+profiles: `browser` (standalone Chromium, Playwright server protocol on
+:9222 — not CDP) and `localstack` (KMS/SQS/Scheduler). See `docker-compose.yml` for the isolation model.
 
 ## Scenario pattern (how to test a feature)
 
@@ -207,10 +207,12 @@ Add the script to `package.json` and mirror it back into this skill's
   first (its `.gitignore` and `.env` handling assume a scratch location).
 - **Ports 5433/27018 are localhost-only bindings.** For a fully hermetic run,
   remove the `ports:` blocks in `docker-compose.yml`.
-- **Generated clients land in the core checkout's `generated/` dir** — that
-  dir is gitignored in the frigg repo, but regenerating on a different platform
-  (e.g. inside the Linux sandbox) overwrites them; re-run `setup:db` on the
-  host before host-driven runs.
+- **Generated clients are platform-local.** On the host they land in the core
+  checkout's `generated/` dir (gitignored in the frigg repo). Inside the
+  sandbox they go to a dedicated named volume over
+  `packages/core/generated`, so container-generated clients never overwrite
+  the host's (and the read-only repo mount never blocks prisma generate).
+  Re-run `setup:db` on the host after host-driven runs.
 
 ## Full-app path (osls offline — how production runs locally)
 

--- a/.claude/skills/frigg-local-test/assets/harness/.env.example
+++ b/.claude/skills/frigg-local-test/assets/harness/.env.example
@@ -1,0 +1,36 @@
+# Frigg Local Test harness — environment configuration.
+# Copy this to .env and edit. Ports match the bundled docker-compose.yml
+# (non-default 5433/27018 so they never clash with a project's own stack on
+# 5432/27017).
+
+# --- Local core pinning ----------------------------------------------------
+# The harness runs the LOCAL @friggframework/core (next branch), not the
+# registry. Before `npm install`, pin it to your checkout:
+#
+#   npm install /path/to/frigg/packages/core
+#   # or: npm pkg set dependencies.@friggframework/core="file:/path/to/frigg/packages/core"
+#
+# FRIGG_REPO_DIR is only needed by the optional agent-sandbox compose profile
+# (it mounts the repo at /workspace inside the container).
+FRIGG_REPO_DIR=/path/to/frigg
+
+# --- Database (pick ONE) --------------------------------------------------
+# PostgreSQL (default):
+DB_TYPE=postgresql
+DATABASE_URL=postgresql://postgres:postgres@localhost:5433/frigg_test
+# Inside the agent sandbox the DBs are reached by service hostname instead:
+# DATABASE_URL=postgresql://postgres:postgres@postgres:5432/frigg_test
+
+# MongoDB (comment out the two lines above and uncomment these):
+# DB_TYPE=mongodb
+# DATABASE_URL=mongodb://localhost:27018/frigg_test?replicaSet=rs0&directConnection=true
+# Sandbox variant:
+# DATABASE_URL=mongodb://mongodb:27017/frigg_test?replicaSet=rs0&directConnection=true
+
+# dev stage bypasses field-level encryption so persisted data is readable.
+STAGE=dev
+
+# Encryption config (only consulted when STAGE != dev).
+AES_KEY_ID=test-key
+AES_KEY=12345678901234567890123456789012
+KMS_KEY_ARN=*

--- a/.claude/skills/frigg-local-test/assets/harness/.gitignore
+++ b/.claude/skills/frigg-local-test/assets/harness/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/.claude/skills/frigg-local-test/assets/harness/Dockerfile
+++ b/.claude/skills/frigg-local-test/assets/harness/Dockerfile
@@ -1,0 +1,52 @@
+# Frigg agent sandbox image.
+#
+# A general-purpose container for testing agents to run Frigg (next branch):
+#   - node 22 (matches the monorepo engines)
+#   - system deps needed by Prisma / native modules
+#   - chromium for in-container browser testing (headless; --no-sandbox)
+#
+# Mounts (see docker-compose.yml, agent profile):
+#   /harness   = this harness dir (mounted read-write)
+#   /workspace = the frigg checkout, read-only — used to pin the LOCAL core
+#                (file: dependency), so the harness runs live next code.
+#
+# NOTE on the agent runtime: this image is intentionally agent-agnostic. It
+# ships node + tooling; the agent runtime (pi, Claude Code, ...) is either
+# installed into this image via a derived Dockerfile, or the agent shells into
+# this container with `docker compose exec agent bash`.
+#
+# ARG WITH_BROWSER: set to false to skip the chromium download (smaller image)
+# when the agent runtime does not need an in-container browser.
+ARG WITH_BROWSER=true
+
+FROM node:22-slim
+
+# Base system deps: prisma (openssl, build tools for native modules), git,
+# curl for health pokes, procps for process inspection.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        curl \
+        ca-certificates \
+        openssl \
+        build-essential \
+        python3 \
+        procps \
+        bash \
+    && rm -rf /var/lib/apt/lists/*
+
+# Chromium for headless browser testing inside the sandbox.
+ARG WITH_BROWSER
+RUN if [ "$WITH_BROWSER" = "true" ]; then \
+        npx --yes playwright@1.49.1 install --with-deps chromium \
+        && rm -rf /root/.cache/ms-playwright/*/*.map 2>/dev/null || true; \
+    fi
+
+WORKDIR /harness
+
+# entrypoint: pin local core, npm install on first run, prisma setup, exec.
+COPY scripts/entrypoint.sh /usr/local/bin/frigg-entrypoint
+RUN chmod +x /usr/local/bin/frigg-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/frigg-entrypoint"]
+CMD ["bash"]

--- a/.claude/skills/frigg-local-test/assets/harness/Dockerfile
+++ b/.claude/skills/frigg-local-test/assets/harness/Dockerfile
@@ -36,7 +36,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Chromium for headless browser testing inside the sandbox.
-ARG WITH_BROWSER
+# Default must be set IN this stage: a pre-FROM ARG is not visible to build
+# steps, so a bare `ARG WITH_BROWSER` here would silently default to empty
+# and skip the chromium install.
+ARG WITH_BROWSER=true
 RUN if [ "$WITH_BROWSER" = "true" ]; then \
         npx --yes playwright@1.49.1 install --with-deps chromium \
         && rm -rf /root/.cache/ms-playwright/*/*.map 2>/dev/null || true; \

--- a/.claude/skills/frigg-local-test/assets/harness/README.md
+++ b/.claude/skills/frigg-local-test/assets/harness/README.md
@@ -1,0 +1,31 @@
+# Frigg Local Test harness
+
+Docker-based harness to **run and test Frigg from the local `next` branch**
+against real databases — no mocks, no published canary. It is bundled with the
+`frigg-local-test` skill at `.claude/skills/frigg-local-test/assets/harness/`.
+**Copy it to a scratch dir and run it there — never from inside `.claude/`.**
+
+```bash
+WORK=/tmp/frigg-test            # any dir outside .claude/
+rm -rf "$WORK" && mkdir -p "$WORK"
+cp -R <skill-dir>/assets/harness/. "$WORK/"
+cd "$WORK"
+
+# 1. Databases up (Postgres :5433, Mongo rs0 :27018 — non-clashing ports)
+npm run db:up
+
+# 2. Pin the LOCAL core (next branch), not the registry:
+npm install /path/to/frigg/packages/core
+npm install
+
+# 3. Prisma client + schema (default PostgreSQL)
+cp .env.example .env
+npm run setup:db
+
+# 4. Run the scenario suite
+npm run scenario:integration-lifecycle     # => Results: 4 passed, 0 failed
+```
+
+See the `frigg-local-test` skill for the full runbook: choosing the database,
+raw Prisma commands, writing scenarios, the agent-sandbox profile, and the
+full-app path (`frigg build`/`frigg start` via osls offline).

--- a/.claude/skills/frigg-local-test/assets/harness/docker-compose.yml
+++ b/.claude/skills/frigg-local-test/assets/harness/docker-compose.yml
@@ -1,0 +1,126 @@
+# Frigg Local Test harness — one compose project = one isolated world.
+#
+# This file ships inside the skill's harness assets and is copied to a scratch
+# dir to run (never run from inside .claude/). Everything is relative to this
+# file, so the copy is self-contained.
+#
+# Services:
+#   postgres / mongodb  (default profile)  — real databases for Frigg, no mocks.
+#   agent               (profile: agent)   — sandbox container with node + frigg
+#                                            tooling; repo mounted at /workspace.
+#   browser             (profile: browser) — standalone Chromium (CDP :9222).
+#   localstack          (profile: localstack) — AWS emulation (KMS/SQS/Scheduler).
+#
+# Isolation model (no Docker-in-Docker):
+#   - Default bring-up starts only the databases, reachable from the host via
+#     127.0.0.1:5433 / 127.0.0.1:27018 (localhost-only, non-clashing ports).
+#   - The agent container reaches them by service hostname (postgres:5432 /
+#     mongodb:27017) on the internal compose network.
+#   - Remove the `ports:` blocks below for a fully hermetic run.
+#
+# Usage:
+#   docker compose up -d                       # databases only
+#   docker compose up -d --profile agent       # + agent sandbox
+#   docker compose up -d --profile agent,browser,localstack   # everything
+#   docker compose down -v                     # total reset (wipes data)
+#
+# The agent profile needs FRIGG_REPO_DIR in .env (absolute path to the frigg
+# checkout) so it can mount the repo and pin the local core.
+
+name: frigg-test-env
+
+services:
+    postgres:
+        image: postgres:16-alpine
+        environment:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: postgres
+            POSTGRES_DB: frigg_test
+        ports:
+            - '127.0.0.1:5433:5432' # host-driven dev; remove for hermetic mode
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U postgres']
+            interval: 5s
+            timeout: 5s
+            retries: 10
+
+    # MongoDB must run as a single-node replica set — Prisma requires it for
+    # transactions. mongodb-init initialises rs0 once, then exits.
+    mongodb:
+        image: mongo:7
+        command: ['--replSet', 'rs0', '--bind_ip_all']
+        ports:
+            - '127.0.0.1:27018:27017' # host-driven dev; remove for hermetic mode
+        healthcheck:
+            test: ['CMD', 'mongosh', '--quiet', '--eval', "db.adminCommand('ping')"]
+            interval: 5s
+            timeout: 5s
+            retries: 10
+
+    mongodb-init:
+        image: mongo:7
+        depends_on:
+            mongodb:
+                condition: service_healthy
+        network_mode: 'service:mongodb'
+        volumes:
+            - ./mongo-init.sh:/mongo-init.sh:ro
+        entrypoint: ['bash', '/mongo-init.sh']
+        restart: 'no'
+
+    # Agent sandbox: container where testing agents run Frigg commands.
+    # - /harness   = this harness dir (mounted read-write; the code under test)
+    # - /workspace = the frigg checkout (FRIGG_REPO_DIR from .env), read-only;
+    #                used to pin the LOCAL core (file: dep) — live next code.
+    agent:
+        profiles: ['agent']
+        build:
+            context: .
+            dockerfile: Dockerfile
+        working_dir: /harness
+        volumes:
+            - .:/harness
+            - ${FRIGG_REPO_DIR:-/nonexistent-frigg-repo}:/workspace:ro
+            # Mask any host node_modules so the container installs its own.
+            - nm-harness:/harness/node_modules
+        environment:
+            DB_TYPE: postgresql
+            DATABASE_URL: postgresql://postgres:postgres@postgres:5432/frigg_test
+            STAGE: dev
+            FRIGG_SKIP_AWS_DISCOVERY: 'true'
+        depends_on:
+            postgres:
+                condition: service_healthy
+            mongodb:
+                condition: service_healthy
+            mongodb-init:
+                condition: service_completed_successfully
+        stdin_open: true
+        tty: true
+        command: ['bash']
+
+    # Optional standalone browser (CDP on 9222, bound to localhost). If your
+    # agent runtime runs INSIDE the agent container, it uses the chromium
+    # bundled in the agent image instead and you can skip this service.
+    browser:
+        profiles: ['browser']
+        image: mcr.microsoft.com/playwright:v1.49.1-jammy
+        ports:
+            - '127.0.0.1:9222:9222'
+        command:
+            - sh
+            - -c
+            - 'npx playwright install chromium --with-deps >/dev/null 2>&1; exec npx playwright run-server --port 9222'
+
+    # Optional AWS emulation for tests that touch KMS / SQS / EventBridge.
+    localstack:
+        profiles: ['localstack']
+        image: localstack/localstack:latest
+        environment:
+            SERVICES: kms,sqs,scheduler
+            PERSISTENCE: '0'
+        ports:
+            - '127.0.0.1:4566:4566'
+
+volumes:
+    nm-harness:

--- a/.claude/skills/frigg-local-test/assets/harness/docker-compose.yml
+++ b/.claude/skills/frigg-local-test/assets/harness/docker-compose.yml
@@ -26,6 +26,10 @@
 #
 # The agent profile needs FRIGG_REPO_DIR in .env (absolute path to the frigg
 # checkout) so it can mount the repo and pin the local core.
+#
+# One environment at a time: the project name is fixed (frigg-test-env), so
+# repeated `docker compose up` reuses the running databases (warm start);
+# concurrent scratch harnesses on one host would collide on the host ports.
 
 name: frigg-test-env
 
@@ -83,6 +87,11 @@ services:
             - ${FRIGG_REPO_DIR:-/nonexistent-frigg-repo}:/workspace:ro
             # Mask any host node_modules so the container installs its own.
             - nm-harness:/harness/node_modules
+            # prisma generate writes the client relative to the schema file
+            # (packages/core/generated/); overlay a writable volume so the
+            # read-only /workspace mount doesn't fail with EROFS, and the
+            # host checkout is never polluted with container-built clients.
+            - nm-generated:/workspace/packages/core/generated
         environment:
             DB_TYPE: postgresql
             DATABASE_URL: postgresql://postgres:postgres@postgres:5432/frigg_test
@@ -99,9 +108,12 @@ services:
         tty: true
         command: ['bash']
 
-    # Optional standalone browser (CDP on 9222, bound to localhost). If your
-    # agent runtime runs INSIDE the agent container, it uses the chromium
-    # bundled in the agent image instead and you can skip this service.
+    # Optional standalone browser on :9222 (localhost-only). NOTE: the
+    # command runs the Playwright Server protocol (`playwright run-server`),
+    # NOT the Chrome DevTools Protocol — connect with a Playwright client, not
+    # a CDP client. If your agent runtime runs INSIDE the agent container, it
+    # uses the chromium bundled in the agent image instead and you can skip
+    # this service.
     browser:
         profiles: ['browser']
         image: mcr.microsoft.com/playwright:v1.49.1-jammy
@@ -115,7 +127,7 @@ services:
     # Optional AWS emulation for tests that touch KMS / SQS / EventBridge.
     localstack:
         profiles: ['localstack']
-        image: localstack/localstack:latest
+        image: localstack/localstack:3.8.1
         environment:
             SERVICES: kms,sqs,scheduler
             PERSISTENCE: '0'
@@ -124,3 +136,4 @@ services:
 
 volumes:
     nm-harness:
+    nm-generated:

--- a/.claude/skills/frigg-local-test/assets/harness/index.js
+++ b/.claude/skills/frigg-local-test/assets/harness/index.js
@@ -1,0 +1,25 @@
+/**
+ * Frigg App Definition for the local test harness.
+ *
+ * Registers the mock integrations used to exercise framework behavior
+ * (integration lifecycle, user actions, credential/delegate notifications,
+ * sync) against a real database (PostgreSQL or MongoDB via Docker).
+ *
+ * This is a minimal app definition — the same shape a `frigg init` app uses —
+ * but with mock API modules instead of real third-party connectors.
+ */
+const TestApiAIntegration = require('./src/integrations/TestApiAIntegration');
+const TestApiBIntegration = require('./src/integrations/TestApiBIntegration');
+
+const Definition = {
+    integrations: [TestApiAIntegration, TestApiBIntegration],
+    user: {
+        usePassword: true,
+        primary: 'individual',
+    },
+    database: {
+        type: process.env.DB_TYPE || 'postgresql',
+    },
+};
+
+module.exports = { Definition };

--- a/.claude/skills/frigg-local-test/assets/harness/mongo-init.sh
+++ b/.claude/skills/frigg-local-test/assets/harness/mongo-init.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Initialise the rs0 single-node replica set so Prisma can connect to MongoDB.
+set -e
+
+echo "Waiting for mongod to accept connections..."
+until mongosh --quiet --eval "db.adminCommand('ping')" >/dev/null 2>&1; do
+    sleep 1
+done
+
+echo "Ensuring replica set rs0 is initiated..."
+mongosh --quiet --eval '
+    try {
+        rs.status();
+        print("replica set already initialised");
+    } catch (e) {
+        rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "localhost:27017" }] });
+        print("replica set initiated");
+    }
+'

--- a/.claude/skills/frigg-local-test/assets/harness/package.json
+++ b/.claude/skills/frigg-local-test/assets/harness/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "frigg-local-test-harness",
+    "version": "1.0.0",
+    "description": "Docker-based harness to run and test Frigg from the local 'next' branch against real databases (PostgreSQL or MongoDB). Copy this directory to a scratch dir and run there — never from inside .claude/.",
+    "main": "index.js",
+    "scripts": {
+        "db:up": "docker compose up -d",
+        "db:down": "docker compose down",
+        "setup:db": "bash scripts/setup-db.sh",
+        "prisma:generate:postgres": "npx prisma@6 generate --schema=node_modules/@friggframework/core/prisma-postgresql/schema.prisma",
+        "prisma:generate:mongo": "npx prisma@6 generate --schema=node_modules/@friggframework/core/prisma-mongodb/schema.prisma",
+        "db:migrate:postgres": "npx prisma@6 migrate deploy --schema=node_modules/@friggframework/core/prisma-postgresql/schema.prisma",
+        "db:push:mongo": "npx prisma@6 db push --schema=node_modules/@friggframework/core/prisma-mongodb/schema.prisma",
+        "scenario:integration-lifecycle": "node scenarios/integration-lifecycle.js",
+        "server": "node server.js",
+        "smoke": "bash scripts/smoke.sh",
+        "test": "npm run setup:db && npm run scenario:integration-lifecycle"
+    },
+    "dependencies": {
+        "@aws-sdk/client-kms": "^3.1054.0",
+        "@aws-sdk/client-scheduler": "^3.1054.0",
+        "@aws-sdk/client-sqs": "^3.1054.0",
+        "@prisma/client": "^6.19.3",
+        "dotenv": "^16.3.1",
+        "express": "^4.18.2",
+        "prisma": "^6.19.3"
+    }
+}

--- a/.claude/skills/frigg-local-test/assets/harness/package.json
+++ b/.claude/skills/frigg-local-test/assets/harness/package.json
@@ -11,7 +11,7 @@
         "prisma:generate:mongo": "npx prisma@6 generate --schema=node_modules/@friggframework/core/prisma-mongodb/schema.prisma",
         "db:migrate:postgres": "npx prisma@6 migrate deploy --schema=node_modules/@friggframework/core/prisma-postgresql/schema.prisma",
         "db:push:mongo": "npx prisma@6 db push --schema=node_modules/@friggframework/core/prisma-mongodb/schema.prisma",
-        "scenario:integration-lifecycle": "node scenarios/integration-lifecycle.js",
+        "scenario:integration-lifecycle": "bash scripts/run-scenario.sh scenarios/integration-lifecycle.js",
         "server": "node server.js",
         "smoke": "bash scripts/smoke.sh",
         "test": "npm run setup:db && npm run scenario:integration-lifecycle"

--- a/.claude/skills/frigg-local-test/assets/harness/scenarios/integration-lifecycle.js
+++ b/.claude/skills/frigg-local-test/assets/harness/scenarios/integration-lifecycle.js
@@ -1,7 +1,7 @@
 /**
  * Scenario: Integration lifecycle + context loading
  *
- * Seeds real PostgreSQL records, then exercises the FIND_INTEGRATION_BY_EXTERNAL_ID
+ * Seeds real database records, then exercises the FIND_INTEGRATION_BY_EXTERNAL_ID
  * USER_ACTION on TestApiAIntegration. The action sources externalId + type from
  * the hydrated integration itself, so we load context first, then dispatch.
  *
@@ -26,7 +26,7 @@ let testIntegrationBId;
 const TEST_EXTERNAL_ID = `shared-entity-${Date.now()}`;
 
 async function setupTestData() {
-    console.log('📦 Setting up test data in PostgreSQL...\n');
+    console.log('📦 Setting up test data...\n');
 
     const user = await prisma.user.create({
         data: {
@@ -113,6 +113,35 @@ async function runTests() {
     let passed = 0;
     let failed = 0;
 
+    /**
+     * Run one case: invoke fn(), then pass (result, error) to check().
+     * check returns true when the case passed. Keeps the per-test
+     * try/catch/PASSED/FAILED bookkeeping in one place.
+     */
+    async function runCase(label, fn, check) {
+        console.log(label);
+        try {
+            const result = await fn();
+            console.log(`   Result: ${JSON.stringify(result)}`);
+            if (check(result, null)) {
+                console.log('   ✅ PASSED\n');
+                passed++;
+            } else {
+                console.log(`   ❌ FAILED: unexpected result: ${JSON.stringify(result)}\n`);
+                failed++;
+            }
+        } catch (error) {
+            if (check(null, error)) {
+                console.log(`   Error: "${error.message}"`);
+                console.log('   ✅ PASSED\n');
+                passed++;
+            } else {
+                console.log(`   ❌ FAILED: ${error.code || error.message}\n`);
+                failed++;
+            }
+        }
+    }
+
     // Load context (hydrate) → dispatch the user action.
     async function dispatchForIntegration(integrationId) {
         const loaded = await commands.loadIntegrationContextById(integrationId);
@@ -141,72 +170,38 @@ async function runTests() {
     }
 
     // Test 1: Integration A → reads its own config.type=test-api-a
-    console.log('Test 1: Hydrate Integration A, dispatch (config.type=test-api-a)');
-    try {
-        const result = await dispatchForIntegration(testIntegrationAId);
-        console.log(`   Result: ${JSON.stringify(result)}`);
-        if (result.success && result.integrationId === testIntegrationAId.toString() && result.integrationType === 'test-api-a') {
-            console.log('   ✅ PASSED: Found Integration A from its own config.type + bound entity\n');
-            passed++;
-        } else {
-            console.log(`   ❌ FAILED: Expected integrationId=${testIntegrationAId}, got ${result.integrationId}\n`);
-            failed++;
-        }
-    } catch (error) {
-        console.log(`   ❌ FAILED: ${error.message}\n`);
-        failed++;
-    }
+    await runCase(
+        'Test 1: Hydrate Integration A, dispatch (config.type=test-api-a)',
+        () => dispatchForIntegration(testIntegrationAId),
+        (result) =>
+            result?.success &&
+            result.integrationId === testIntegrationAId.toString() &&
+            result.integrationType === 'test-api-a'
+    );
 
     // Test 2: Integration B (same shared entity) → reads config.type=test-api-b
-    console.log('Test 2: Hydrate Integration B, dispatch (config.type=test-api-b)');
-    try {
-        const result = await dispatchForIntegration(testIntegrationBId);
-        console.log(`   Result: ${JSON.stringify(result)}`);
-        if (result.success && result.integrationId === testIntegrationBId.toString() && result.integrationType === 'test-api-b') {
-            console.log('   ✅ PASSED: Found Integration B from its own config.type + shared entity\n');
-            passed++;
-        } else {
-            console.log(`   ❌ FAILED: Expected integrationId=${testIntegrationBId}, got ${result.integrationId}\n`);
-            failed++;
-        }
-    } catch (error) {
-        console.log(`   ❌ FAILED: ${error.message}\n`);
-        failed++;
-    }
+    await runCase(
+        'Test 2: Hydrate Integration B, dispatch (config.type=test-api-b)',
+        () => dispatchForIntegration(testIntegrationBId),
+        (result) =>
+            result?.success &&
+            result.integrationId === testIntegrationBId.toString() &&
+            result.integrationType === 'test-api-b'
+    );
 
     // Test 3: config.type matches no integration for the shared entity
-    console.log('Test 3: config.type=unknown-type (manually hydrated)');
-    try {
-        await dispatchForConfig({ type: 'unknown-type' }, [{ externalId: TEST_EXTERNAL_ID }]);
-        console.log('   ❌ FAILED: Should have thrown INTEGRATION_NOT_FOUND\n');
-        failed++;
-    } catch (error) {
-        if (error.code === 'INTEGRATION_NOT_FOUND') {
-            console.log(`   Error: "${error.message}"`);
-            console.log('   ✅ PASSED: correctly threw INTEGRATION_NOT_FOUND\n');
-            passed++;
-        } else {
-            console.log(`   ❌ FAILED: Wrong error: ${error.code || error.message}\n`);
-            failed++;
-        }
-    }
+    await runCase(
+        'Test 3: config.type=unknown-type (manually hydrated)',
+        () => dispatchForConfig({ type: 'unknown-type' }, [{ externalId: TEST_EXTERNAL_ID }]),
+        (result, error) => error?.code === 'INTEGRATION_NOT_FOUND'
+    );
 
     // Test 4: config has no type
-    console.log('Test 4: config has no type (manually hydrated)');
-    try {
-        await dispatchForConfig({}, [{ externalId: TEST_EXTERNAL_ID }]);
-        console.log('   ❌ FAILED: Should have thrown TYPE_REQUIRED\n');
-        failed++;
-    } catch (error) {
-        if (error.code === 'TYPE_REQUIRED') {
-            console.log(`   Error: "${error.message}"`);
-            console.log('   ✅ PASSED: correctly threw TYPE_REQUIRED\n');
-            passed++;
-        } else {
-            console.log(`   ❌ FAILED: Wrong error: ${error.code || error.message}\n`);
-            failed++;
-        }
-    }
+    await runCase(
+        'Test 4: config has no type (manually hydrated)',
+        () => dispatchForConfig({}, [{ externalId: TEST_EXTERNAL_ID }]),
+        (result, error) => error?.code === 'TYPE_REQUIRED'
+    );
 
     return { passed, failed };
 }

--- a/.claude/skills/frigg-local-test/assets/harness/scenarios/integration-lifecycle.js
+++ b/.claude/skills/frigg-local-test/assets/harness/scenarios/integration-lifecycle.js
@@ -1,0 +1,239 @@
+/**
+ * Scenario: Integration lifecycle + context loading
+ *
+ * Seeds real PostgreSQL records, then exercises the FIND_INTEGRATION_BY_EXTERNAL_ID
+ * USER_ACTION on TestApiAIntegration. The action sources externalId + type from
+ * the hydrated integration itself, so we load context first, then dispatch.
+ *
+ * Usage: npm test
+ */
+require('dotenv').config();
+
+const { prisma } = require('@friggframework/core/database/prisma');
+const {
+    IntegrationEventDispatcher,
+} = require('@friggframework/core/handlers/integration-event-dispatcher');
+const { createFriggCommands } = require('@friggframework/core');
+
+const TestApiAIntegration = require('../src/integrations/TestApiAIntegration');
+
+let testUserId;
+let testCredentialId;
+let testEntityId;
+let testIntegrationAId;
+let testIntegrationBId;
+
+const TEST_EXTERNAL_ID = `shared-entity-${Date.now()}`;
+
+async function setupTestData() {
+    console.log('📦 Setting up test data in PostgreSQL...\n');
+
+    const user = await prisma.user.create({
+        data: {
+            type: 'INDIVIDUAL',
+            username: `test-user-${Date.now()}@example.com`,
+            hashword: 'test-hash',
+        },
+    });
+    testUserId = user.id;
+    console.log(`1. Created User: id=${user.id}`);
+
+    const credential = await prisma.credential.create({
+        data: { userId: testUserId, data: { api_key: 'shared-api-key-12345' } },
+    });
+    testCredentialId = credential.id;
+    console.log(`2. Created Credential: id=${credential.id}`);
+
+    const entity = await prisma.entity.create({
+        data: {
+            userId: testUserId,
+            credentialId: testCredentialId,
+            externalId: TEST_EXTERNAL_ID,
+            name: 'Shared Entity',
+            moduleName: 'test-api-a',
+            data: { sharedAccountId: 'acct-shared-123' },
+        },
+    });
+    testEntityId = entity.id;
+    console.log(`3. Created Entity: id=${entity.id}, externalId=${entity.externalId}`);
+
+    const integrationA = await prisma.integration.create({
+        data: {
+            userId: testUserId,
+            config: { type: 'test-api-a', settings: { feature: 'A' } },
+            version: '1.0.0',
+            status: 'ENABLED',
+            entities: { connect: [{ id: testEntityId }] },
+        },
+    });
+    testIntegrationAId = integrationA.id;
+    console.log(`4. Created Integration A: id=${integrationA.id}, config.type=test-api-a`);
+
+    const integrationB = await prisma.integration.create({
+        data: {
+            userId: testUserId,
+            config: { type: 'test-api-b', settings: { feature: 'B' } },
+            version: '1.0.0',
+            status: 'ENABLED',
+            entities: { connect: [{ id: testEntityId }] },
+        },
+    });
+    testIntegrationBId = integrationB.id;
+    console.log(`5. Created Integration B: id=${integrationB.id}, config.type=test-api-b`);
+
+    console.log(
+        `\n   Entity ${testEntityId} belongs to BOTH integrations (${testIntegrationAId} and ${testIntegrationBId})\n`
+    );
+}
+
+async function cleanupTestData() {
+    console.log('\n🧹 Cleaning up test data...');
+    try {
+        if (testIntegrationAId) await prisma.integration.delete({ where: { id: testIntegrationAId } });
+        if (testIntegrationBId) await prisma.integration.delete({ where: { id: testIntegrationBId } });
+        if (testEntityId) await prisma.entity.delete({ where: { id: testEntityId } });
+        if (testCredentialId) await prisma.credential.delete({ where: { id: testCredentialId } });
+        if (testUserId) await prisma.user.delete({ where: { id: testUserId } });
+        console.log('   Done.');
+    } catch (error) {
+        console.error('   Error:', error.message);
+    }
+}
+
+async function runTests() {
+    console.log('═'.repeat(60));
+    console.log('Testing USER ACTION: FIND_INTEGRATION_BY_EXTERNAL_ID');
+    console.log('(externalId + type are sourced from the integration itself)');
+    console.log('═'.repeat(60) + '\n');
+
+    const commands = createFriggCommands({
+        integrationClass: TestApiAIntegration,
+    });
+
+    let passed = 0;
+    let failed = 0;
+
+    // Load context (hydrate) → dispatch the user action.
+    async function dispatchForIntegration(integrationId) {
+        const loaded = await commands.loadIntegrationContextById(integrationId);
+        if (!loaded.context) {
+            throw new Error(
+                `Failed to load context: ${loaded.reason || 'unknown error'}`
+            );
+        }
+        const integration = new TestApiAIntegration({
+            ...loaded.context.record,
+            modules: loaded.context.modules,
+        });
+        const dispatcher = new IntegrationEventDispatcher(integration);
+        return dispatcher.dispatchJob({
+            event: 'FIND_INTEGRATION_BY_EXTERNAL_ID',
+        });
+    }
+
+    // Manually-hydrated integration for error cases (control config/entities).
+    async function dispatchForConfig(config, entities) {
+        const integration = new TestApiAIntegration({ config, entities });
+        const dispatcher = new IntegrationEventDispatcher(integration);
+        return dispatcher.dispatchJob({
+            event: 'FIND_INTEGRATION_BY_EXTERNAL_ID',
+        });
+    }
+
+    // Test 1: Integration A → reads its own config.type=test-api-a
+    console.log('Test 1: Hydrate Integration A, dispatch (config.type=test-api-a)');
+    try {
+        const result = await dispatchForIntegration(testIntegrationAId);
+        console.log(`   Result: ${JSON.stringify(result)}`);
+        if (result.success && result.integrationId === testIntegrationAId.toString() && result.integrationType === 'test-api-a') {
+            console.log('   ✅ PASSED: Found Integration A from its own config.type + bound entity\n');
+            passed++;
+        } else {
+            console.log(`   ❌ FAILED: Expected integrationId=${testIntegrationAId}, got ${result.integrationId}\n`);
+            failed++;
+        }
+    } catch (error) {
+        console.log(`   ❌ FAILED: ${error.message}\n`);
+        failed++;
+    }
+
+    // Test 2: Integration B (same shared entity) → reads config.type=test-api-b
+    console.log('Test 2: Hydrate Integration B, dispatch (config.type=test-api-b)');
+    try {
+        const result = await dispatchForIntegration(testIntegrationBId);
+        console.log(`   Result: ${JSON.stringify(result)}`);
+        if (result.success && result.integrationId === testIntegrationBId.toString() && result.integrationType === 'test-api-b') {
+            console.log('   ✅ PASSED: Found Integration B from its own config.type + shared entity\n');
+            passed++;
+        } else {
+            console.log(`   ❌ FAILED: Expected integrationId=${testIntegrationBId}, got ${result.integrationId}\n`);
+            failed++;
+        }
+    } catch (error) {
+        console.log(`   ❌ FAILED: ${error.message}\n`);
+        failed++;
+    }
+
+    // Test 3: config.type matches no integration for the shared entity
+    console.log('Test 3: config.type=unknown-type (manually hydrated)');
+    try {
+        await dispatchForConfig({ type: 'unknown-type' }, [{ externalId: TEST_EXTERNAL_ID }]);
+        console.log('   ❌ FAILED: Should have thrown INTEGRATION_NOT_FOUND\n');
+        failed++;
+    } catch (error) {
+        if (error.code === 'INTEGRATION_NOT_FOUND') {
+            console.log(`   Error: "${error.message}"`);
+            console.log('   ✅ PASSED: correctly threw INTEGRATION_NOT_FOUND\n');
+            passed++;
+        } else {
+            console.log(`   ❌ FAILED: Wrong error: ${error.code || error.message}\n`);
+            failed++;
+        }
+    }
+
+    // Test 4: config has no type
+    console.log('Test 4: config has no type (manually hydrated)');
+    try {
+        await dispatchForConfig({}, [{ externalId: TEST_EXTERNAL_ID }]);
+        console.log('   ❌ FAILED: Should have thrown TYPE_REQUIRED\n');
+        failed++;
+    } catch (error) {
+        if (error.code === 'TYPE_REQUIRED') {
+            console.log(`   Error: "${error.message}"`);
+            console.log('   ✅ PASSED: correctly threw TYPE_REQUIRED\n');
+            passed++;
+        } else {
+            console.log(`   ❌ FAILED: Wrong error: ${error.code || error.message}\n`);
+            failed++;
+        }
+    }
+
+    return { passed, failed };
+}
+
+async function main() {
+    console.log('═'.repeat(60));
+    console.log('Scenario: Integration lifecycle + context loading');
+    console.log('Called from Frigg USER ACTION in TestApiAIntegration');
+    console.log('═'.repeat(60) + '\n');
+
+    try {
+        await setupTestData();
+        const { passed, failed } = await runTests();
+
+        console.log('═'.repeat(60));
+        console.log(`Results: ${passed} passed, ${failed} failed`);
+        console.log('═'.repeat(60));
+
+        await cleanupTestData();
+        await prisma.$disconnect();
+        process.exit(failed > 0 ? 1 : 0);
+    } catch (error) {
+        console.error('\n❌ Test failed:', error);
+        await cleanupTestData();
+        await prisma.$disconnect();
+        process.exit(1);
+    }
+}
+
+main();

--- a/.claude/skills/frigg-local-test/assets/harness/scripts/entrypoint.sh
+++ b/.claude/skills/frigg-local-test/assets/harness/scripts/entrypoint.sh
@@ -13,15 +13,33 @@ set -euo pipefail
 
 echo "🐳 Frigg agent sandbox bootstrapping..."
 
+# Sanity check: /workspace must be the frigg checkout (FRIGG_REPO_DIR).
+if [ ! -f /workspace/package.json ]; then
+    echo "❌ /workspace/package.json not found." >&2
+    echo "   Set FRIGG_REPO_DIR in .env to the absolute path of the frigg" >&2
+    echo "   checkout (compose mounts it read-only at /workspace)." >&2
+    exit 1
+fi
+
 cd /harness
 
-if ! grep -q '"@friggframework/core"' package.json 2>/dev/null; then
+# Pin core to the LOCAL checkout — check the declared file: path, not just
+# presence, so a stale host-path pin (from a host quick-start in this dir)
+# gets corrected to the sandbox path.
+CORE_FILE="$(node -p "require('./package.json').dependencies['@friggframework/core'] || ''" 2>/dev/null || true)"
+if [ "$CORE_FILE" != "file:/workspace/packages/core" ]; then
     echo "==> Pinning local core (file:/workspace/packages/core)"
     npm pkg set "dependencies.@friggframework/core=file:/workspace/packages/core"
 fi
 
-if [ ! -d node_modules ]; then
+# Install only when needed: the named volume masks /harness/node_modules with
+# an (initially empty) dir, so check for the actual package, not the dir.
+if [ ! -d node_modules ] || [ ! -e node_modules/@friggframework/core ]; then
     echo "==> npm install (one-time, may take a few minutes)"
+    # A lockfile from another environment pins the old core path (e.g. the
+    # host checkout) and breaks the file: re-pin — the harness intentionally
+    # has no committed lockfile, so resolve fresh.
+    rm -f package-lock.json
     npm install --no-audit --no-fund
 else
     echo "==> node_modules present, skipping npm install"

--- a/.claude/skills/frigg-local-test/assets/harness/scripts/entrypoint.sh
+++ b/.claude/skills/frigg-local-test/assets/harness/scripts/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Agent sandbox entrypoint: one-time bootstrap, then exec the requested command.
+#
+# Bootstrap steps (idempotent):
+#   1. Pin @friggframework/core to the LOCAL checkout mounted at /workspace
+#      (file: dependency -> symlink into node_modules -> live next code).
+#   2. `npm install` if node_modules is missing (named volume is fresh).
+#   3. Generate the Prisma client + sync schema for DB_TYPE (postgresql default).
+#
+# First boot is slow (npm install + prisma generate); later boots are fast
+# thanks to the named volume.
+set -euo pipefail
+
+echo "🐳 Frigg agent sandbox bootstrapping..."
+
+cd /harness
+
+if ! grep -q '"@friggframework/core"' package.json 2>/dev/null; then
+    echo "==> Pinning local core (file:/workspace/packages/core)"
+    npm pkg set "dependencies.@friggframework/core=file:/workspace/packages/core"
+fi
+
+if [ ! -d node_modules ]; then
+    echo "==> npm install (one-time, may take a few minutes)"
+    npm install --no-audit --no-fund
+else
+    echo "==> node_modules present, skipping npm install"
+fi
+
+if [ ! -f .env ]; then
+    cp .env.example .env
+    echo "==> Created .env from .env.example (container env vars take precedence)"
+fi
+
+echo "==> Prisma setup (DB_TYPE=${DB_TYPE:-postgresql})"
+bash scripts/setup-db.sh
+
+echo "✅ Sandbox ready."
+echo "   Harness: /harness"
+echo "   Run scenarios:  npm run scenario:integration-lifecycle"
+echo "   Full app path:  see the frigg-local-test skill"
+
+exec "$@"

--- a/.claude/skills/frigg-local-test/assets/harness/scripts/load-env.sh
+++ b/.claude/skills/frigg-local-test/assets/harness/scripts/load-env.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Load .env values as environment variables WITHOUT clobbering variables that
+# are already set in the process environment.
+#
+# Why: the agent-sandbox compose profile injects DB_TYPE / DATABASE_URL /
+# STAGE (internal hostnames) into the container env. A plain `source .env`
+# would overwrite those with the host-oriented values from .env.example,
+# making migrate/db push inside the container target localhost:5433 and fail.
+#
+# Usage: source scripts/load-env.sh   (runs from the harness dir)
+if [ -f .env ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Skip blank lines and comments.
+        case "$line" in
+            '' | \#*) continue ;;
+        esac
+        key="${line%%=*}"
+        # Only valid identifiers can be exported.
+        case "$key" in
+            *[!A-Za-z_0-9]* | [0-9]*) continue ;;
+        esac
+        # Export only if not already set in the environment.
+        if [ -z "${!key+x}" ]; then
+            export "$line"
+        fi
+    done < .env
+fi

--- a/.claude/skills/frigg-local-test/assets/harness/scripts/run-scenario.sh
+++ b/.claude/skills/frigg-local-test/assets/harness/scripts/run-scenario.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Run a scenario script from the scenarios/ directory.
+# Usage: bash scripts/run-scenario.sh scenarios/<name>.js
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+SCENARIO="${1:-}"
+if [ -z "$SCENARIO" ]; then
+    echo "❌ Usage: bash scripts/run-scenario.sh scenarios/<name>.js" >&2
+    exit 1
+fi
+
+if [ ! -f "$SCENARIO" ]; then
+    echo "❌ Scenario not found: $SCENARIO" >&2
+    exit 1
+fi
+
+# Pre-flight: DB must be reachable.
+if [ ! -f .env ]; then
+    cp .env.example .env
+fi
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+echo "🚀 Running scenario: $SCENARIO"
+node "$SCENARIO"

--- a/.claude/skills/frigg-local-test/assets/harness/scripts/run-scenario.sh
+++ b/.claude/skills/frigg-local-test/assets/harness/scripts/run-scenario.sh
@@ -16,14 +16,12 @@ if [ ! -f "$SCENARIO" ]; then
     exit 1
 fi
 
-# Pre-flight: DB must be reachable.
+# Pre-flight: load .env without clobbering already-set env (container mode).
 if [ ! -f .env ]; then
     cp .env.example .env
 fi
-set -a
 # shellcheck disable=SC1091
-source .env
-set +a
+source scripts/load-env.sh
 
 echo "🚀 Running scenario: $SCENARIO"
 node "$SCENARIO"

--- a/.claude/skills/frigg-local-test/assets/harness/scripts/setup-db.sh
+++ b/.claude/skills/frigg-local-test/assets/harness/scripts/setup-db.sh
@@ -18,11 +18,9 @@ if [ ! -f .env ]; then
     echo "📄 Created .env from .env.example"
 fi
 
-# Load .env without clobbering already-exported env (container overrides win).
-set -a
+# Load .env WITHOUT clobbering already-exported env (container overrides win).
 # shellcheck disable=SC1091
-source .env
-set +a
+source scripts/load-env.sh
 
 DB_TYPE="${DB_TYPE:-postgresql}"
 

--- a/.claude/skills/frigg-local-test/assets/harness/scripts/setup-db.sh
+++ b/.claude/skills/frigg-local-test/assets/harness/scripts/setup-db.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Generate the Prisma client for the configured DB_TYPE and sync the schema.
+# Idempotent: safe to re-run after every core change that touches the schema.
+#
+#   DB_TYPE=postgresql  -> prisma generate + migrate deploy  (default)
+#   DB_TYPE=mongodb     -> prisma generate + db push
+#
+# The Prisma client is built into the core package's generated/ dir
+# (packages/core/generated/prisma-<db> when core is the local file: dep).
+# Run this before any scenario, or core fails to load its database layer.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Create .env from the template on first run.
+if [ ! -f .env ]; then
+    cp .env.example .env
+    echo "📄 Created .env from .env.example"
+fi
+
+# Load .env without clobbering already-exported env (container overrides win).
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+DB_TYPE="${DB_TYPE:-postgresql}"
+
+# Resolve the core package location via Node (handles the file: symlink).
+CORE="$(node -e "const p=require.resolve('@friggframework/core/package.json'); console.log(require('node:path').dirname(p))" 2>/dev/null || true)"
+
+if [ -z "$CORE" ] || [ ! -d "$CORE" ]; then
+    echo "❌ @friggframework/core not installed." >&2
+    echo "   Pin the LOCAL core first, then npm install:" >&2
+    echo "     npm install /path/to/frigg/packages/core" >&2
+    echo "     npm install" >&2
+    exit 1
+fi
+
+case "$DB_TYPE" in
+    postgresql)
+        echo "==> Generating Prisma client (postgresql)"
+        npx prisma@6 generate --schema="$CORE/prisma-postgresql/schema.prisma"
+        echo "==> Applying migrations"
+        npx prisma@6 migrate deploy --schema="$CORE/prisma-postgresql/schema.prisma"
+        ;;
+    mongodb)
+        echo "==> Generating Prisma client (mongodb)"
+        npx prisma@6 generate --schema="$CORE/prisma-mongodb/schema.prisma"
+        echo "==> Pushing schema"
+        npx prisma@6 db push --schema="$CORE/prisma-mongodb/schema.prisma"
+        ;;
+    *)
+        echo "❌ Unknown DB_TYPE: $DB_TYPE (expected postgresql or mongodb)" >&2
+        exit 1
+        ;;
+esac
+
+echo "✅ Database ready (DB_TYPE=$DB_TYPE). Run scenarios with npm run scenario:*"

--- a/.claude/skills/frigg-local-test/assets/harness/scripts/smoke.sh
+++ b/.claude/skills/frigg-local-test/assets/harness/scripts/smoke.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Smoke test: verifies the harness is usable end-to-end.
+#   1. databases healthy
+#   2. core resolves to the LOCAL checkout (file: dep), not the registry
+#   3. prisma client generated for DB_TYPE
+#   4. the integration-lifecycle scenario passes
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "═══ Frigg Local Test harness — smoke test ═══"
+
+echo ""
+echo "1) Checking databases..."
+if [ ! -f .env ]; then
+    cp .env.example .env
+fi
+docker compose ps --format 'table {{.Service}}\t{{.Status}}' || {
+    echo "❌ Compose unavailable. Start Docker and run: npm run db:up" >&2
+    exit 1
+}
+
+POSTGRES_UP=$(docker compose ps --status running --services 2>/dev/null | grep -c '^postgres$' || true)
+if [ "$POSTGRES_UP" != "1" ]; then
+    echo "❌ postgres not running. Run: npm run db:up" >&2
+    exit 1
+fi
+echo "   ✅ postgres running"
+
+echo ""
+echo "2) Checking core resolves to the LOCAL checkout..."
+CORE_RESOLVED=$(node -e "console.log(require.resolve('@friggframework/core/package.json'))" 2>/dev/null || true)
+if [ -z "$CORE_RESOLVED" ]; then
+    echo "❌ @friggframework/core not installed." >&2
+    echo "   Pin the LOCAL core, then npm install:" >&2
+    echo "     npm install /path/to/frigg/packages/core" >&2
+    exit 1
+fi
+case "$CORE_RESOLVED" in
+    */packages/core/package.json)
+        echo "   ✅ core resolved to LOCAL checkout: $CORE_RESOLVED"
+        ;;
+    *)
+        echo "   ⚠️ core resolved to registry copy, not local: $CORE_RESOLVED"
+        echo "     (re-pin: npm install /path/to/frigg/packages/core)"
+        ;;
+esac
+
+echo ""
+echo "3) Prisma setup (idempotent)..."
+bash scripts/setup-db.sh
+
+echo ""
+echo "4) Running scenario: integration-lifecycle"
+npm run scenario:integration-lifecycle
+
+echo ""
+echo "═══ Smoke test complete ═══"

--- a/.claude/skills/frigg-local-test/assets/harness/scripts/smoke.sh
+++ b/.claude/skills/frigg-local-test/assets/harness/scripts/smoke.sh
@@ -8,13 +8,19 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+# Create .env from the template on first run (before loading it).
+if [ ! -f .env ]; then
+    cp .env.example .env
+fi
+
+# Load .env without clobbering already-set env (container mode).
+# shellcheck disable=SC1091
+source scripts/load-env.sh
+
 echo "═══ Frigg Local Test harness — smoke test ═══"
 
 echo ""
 echo "1) Checking databases..."
-if [ ! -f .env ]; then
-    cp .env.example .env
-fi
 docker compose ps --format 'table {{.Service}}\t{{.Status}}' || {
     echo "❌ Compose unavailable. Start Docker and run: npm run db:up" >&2
     exit 1
@@ -41,8 +47,11 @@ case "$CORE_RESOLVED" in
         echo "   ✅ core resolved to LOCAL checkout: $CORE_RESOLVED"
         ;;
     *)
-        echo "   ⚠️ core resolved to registry copy, not local: $CORE_RESOLVED"
-        echo "     (re-pin: npm install /path/to/frigg/packages/core)"
+        echo "   ❌ core resolved to registry copy, not local: $CORE_RESOLVED" >&2
+        echo "     Re-pin and reinstall:" >&2
+        echo "       npm install /path/to/frigg/packages/core" >&2
+        echo "       npm install" >&2
+        exit 1
         ;;
 esac
 

--- a/.claude/skills/frigg-local-test/assets/harness/server.js
+++ b/.claude/skills/frigg-local-test/assets/harness/server.js
@@ -1,0 +1,39 @@
+/**
+ * Minimal Express server for the harness.
+ *
+ * Lets agents (or curl) poke the app definition over HTTP without the full
+ * osls-offline stack: health check + integration listing. The full Frigg
+ * Management API (user/create, /api/authorize, /api/integrations, ...) is
+ * exercised via the real app path (`frigg start` -> osls offline) — see the
+ * frigg-local-test skill.
+ */
+require('dotenv').config();
+
+const express = require('express');
+const { Definition } = require('./index');
+
+const app = express();
+app.use(express.json());
+
+app.get('/health', (req, res) => {
+    res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+const { integrations } = Definition;
+
+app.get('/api/integrations', (req, res) => {
+    const list = integrations.map((I) => ({
+        name: I.Definition?.name,
+        version: I.Definition?.version,
+        // Single source of truth: the framework only reads Definition.modules.
+        modules: Object.keys(I.Definition?.modules || {}),
+    }));
+    res.json(list);
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+    console.log(`🚀 Frigg Test Harness server running at http://localhost:${PORT}`);
+    console.log(`   Integrations: ${integrations.map((I) => I.Definition?.name).join(', ')}`);
+    console.log(`   DB_TYPE: ${process.env.DB_TYPE || 'postgresql'}`);
+});

--- a/.claude/skills/frigg-local-test/assets/harness/src/api-modules/test-api-a/api.js
+++ b/.claude/skills/frigg-local-test/assets/harness/src/api-modules/test-api-a/api.js
@@ -1,0 +1,26 @@
+const { ApiKeyRequester } = require('@friggframework/core');
+
+class Api extends ApiKeyRequester {
+    constructor(params = {}) {
+        super(params);
+        this.baseUrl = 'https://api.test-api-a.example.com';
+        this.API_KEY_NAME = 'Authorization';
+
+        const apiKey = params.access_token || params.api_key;
+        this.access_token = apiKey;
+        if (this.access_token) {
+            this.setApiKey(this.access_token);
+        }
+    }
+
+    // Stub — not called during the context-load test, present for auth methods.
+    async getAccountInfo() {
+        return { id: 'acct-test-api-a', name: 'Test API A Account' };
+    }
+
+    async listItems() {
+        return [];
+    }
+}
+
+module.exports = { Api };

--- a/.claude/skills/frigg-local-test/assets/harness/src/api-modules/test-api-a/definition.js
+++ b/.claude/skills/frigg-local-test/assets/harness/src/api-modules/test-api-a/definition.js
@@ -1,0 +1,56 @@
+const { Api } = require('./api');
+
+const Config = {
+    name: 'test-api-a',
+    displayName: 'Test API A',
+    description: 'Test API module A for the local test environment',
+    category: 'Testing',
+};
+
+const Definition = {
+    API: Api,
+    getName: () => Config.name,
+    moduleName: Config.name,
+    modelName: 'TestApiA',
+
+    getAuthorizationRequirements: () => ({
+        type: 'apiKey',
+        data: {
+            jsonSchema: {
+                type: 'object',
+                required: ['api_key'],
+                properties: {
+                    api_key: {
+                        type: 'string',
+                        title: 'API Key',
+                        'ui:widget': 'password',
+                    },
+                },
+            },
+        },
+    }),
+
+    requiredAuthMethods: {
+        getToken: async (api, params) => ({ api_key: params.data.api_key }),
+        getEntityDetails: async (api, callbackParams, tokenResponse, userId) => {
+            const accountInfo = await api.getAccountInfo();
+            return {
+                identifiers: { externalId: accountInfo.id, userId },
+                details: { name: accountInfo.name },
+            };
+        },
+        apiPropertiesToPersist: { credential: ['api_key'], entity: [] },
+        getCredentialDetails: async (api, userId) => {
+            const accountInfo = await api.getAccountInfo();
+            return {
+                identifiers: { externalId: accountInfo.id, userId },
+                details: {},
+            };
+        },
+        testAuthRequest: async (api) => api.getAccountInfo(),
+    },
+
+    env: {},
+};
+
+module.exports = { Definition, Config, Api };

--- a/.claude/skills/frigg-local-test/assets/harness/src/api-modules/test-api-a/index.js
+++ b/.claude/skills/frigg-local-test/assets/harness/src/api-modules/test-api-a/index.js
@@ -1,0 +1,4 @@
+const { Api } = require('./api');
+const { Definition, Config } = require('./definition');
+
+module.exports = { Api, Definition, Config };

--- a/.claude/skills/frigg-local-test/assets/harness/src/api-modules/test-api-b/api.js
+++ b/.claude/skills/frigg-local-test/assets/harness/src/api-modules/test-api-b/api.js
@@ -1,0 +1,26 @@
+const { ApiKeyRequester } = require('@friggframework/core');
+
+class Api extends ApiKeyRequester {
+    constructor(params = {}) {
+        super(params);
+        this.baseUrl = 'https://api.test-api-b.example.com';
+        this.API_KEY_NAME = 'Authorization';
+
+        const apiKey = params.access_token || params.api_key;
+        this.access_token = apiKey;
+        if (this.access_token) {
+            this.setApiKey(this.access_token);
+        }
+    }
+
+    // Stub — not called during the context-load test, present for auth methods.
+    async getAccountInfo() {
+        return { id: 'acct-test-api-b', name: 'Test API B Account' };
+    }
+
+    async fetchData() {
+        return { status: 'ok' };
+    }
+}
+
+module.exports = { Api };

--- a/.claude/skills/frigg-local-test/assets/harness/src/api-modules/test-api-b/definition.js
+++ b/.claude/skills/frigg-local-test/assets/harness/src/api-modules/test-api-b/definition.js
@@ -1,0 +1,56 @@
+const { Api } = require('./api');
+
+const Config = {
+    name: 'test-api-b',
+    displayName: 'Test API B',
+    description: 'Test API module B for the local test environment',
+    category: 'Testing',
+};
+
+const Definition = {
+    API: Api,
+    getName: () => Config.name,
+    moduleName: Config.name,
+    modelName: 'TestApiB',
+
+    getAuthorizationRequirements: () => ({
+        type: 'apiKey',
+        data: {
+            jsonSchema: {
+                type: 'object',
+                required: ['api_key'],
+                properties: {
+                    api_key: {
+                        type: 'string',
+                        title: 'API Key',
+                        'ui:widget': 'password',
+                    },
+                },
+            },
+        },
+    }),
+
+    requiredAuthMethods: {
+        getToken: async (api, params) => ({ api_key: params.data.api_key }),
+        getEntityDetails: async (api, callbackParams, tokenResponse, userId) => {
+            const accountInfo = await api.getAccountInfo();
+            return {
+                identifiers: { externalId: accountInfo.id, userId },
+                details: { name: accountInfo.name },
+            };
+        },
+        apiPropertiesToPersist: { credential: ['api_key'], entity: [] },
+        getCredentialDetails: async (api, userId) => {
+            const accountInfo = await api.getAccountInfo();
+            return {
+                identifiers: { externalId: accountInfo.id, userId },
+                details: {},
+            };
+        },
+        testAuthRequest: async (api) => api.getAccountInfo(),
+    },
+
+    env: {},
+};
+
+module.exports = { Definition, Config, Api };

--- a/.claude/skills/frigg-local-test/assets/harness/src/api-modules/test-api-b/index.js
+++ b/.claude/skills/frigg-local-test/assets/harness/src/api-modules/test-api-b/index.js
@@ -1,0 +1,4 @@
+const { Api } = require('./api');
+const { Definition, Config } = require('./definition');
+
+module.exports = { Api, Definition, Config };

--- a/.claude/skills/frigg-local-test/assets/harness/src/integrations/TestApiAIntegration.js
+++ b/.claude/skills/frigg-local-test/assets/harness/src/integrations/TestApiAIntegration.js
@@ -1,0 +1,97 @@
+const { IntegrationBase, createFriggCommands } = require('@friggframework/core');
+const testApiA = require('../api-modules/test-api-a');
+
+class TestApiAIntegration extends IntegrationBase {
+    static Definition = {
+        name: 'test-api-a',
+        version: '1.0.0',
+        supportedVersions: ['1.0.0'],
+        display: {
+            label: 'Test API A',
+            description: 'Test API A integration for the local test environment',
+            category: 'Testing',
+            detailsUrl: 'https://example.com/test-api-a',
+            icon: '',
+        },
+        modules: {
+            // Module entries use the { definition } wrapper so Frigg's
+            // getModulesDefinitionFromIntegrationClasses can read .definition.
+            // The key (testApiA) is how the module attaches to `this`
+            // (this.testApiA.api).
+            testApiA: { definition: testApiA.Definition },
+        },
+    };
+
+    constructor(params) {
+        super(params);
+
+        // Public command factory (createIntegrationCommands is internal).
+        this.commands = createFriggCommands({
+            integrationClass: TestApiAIntegration,
+        });
+
+        this.events = {
+            ...this.events,
+            LIST_ITEMS: {
+                type: 'USER_ACTION',
+                handler: this.listItems.bind(this),
+            },
+            FIND_INTEGRATION_BY_EXTERNAL_ID: {
+                type: 'USER_ACTION',
+                handler: this.findIntegrationByExternalId.bind(this),
+            },
+        };
+    }
+
+    async onCreate({ integrationId }) {
+        await this.updateIntegrationStatus.execute(integrationId, 'ENABLED');
+    }
+
+    async listItems() {
+        return this.testApiA?.api ? this.testApiA.api.listItems() : [];
+    }
+
+    /**
+     * USER ACTION: Find integration context by external entity ID.
+     *
+     * Inputs are sourced from the integration itself (not from user params):
+     *  - `type` from this integration's own config (`this.config.type`)
+     *  - `externalId` from the bound entity (`this.entities[0].externalId`),
+     *    which Frigg populates when the instance is hydrated with its context.
+     *
+     * Requires loading the integration context first, then dispatching.
+     */
+    async findIntegrationByExternalId() {
+        const type = this.config?.type;
+        const externalId = this.entities?.[0]?.externalId;
+
+        console.log(
+            `[TestApiAIntegration] Finding integration by externalId=${externalId}, type=${type}`
+        );
+
+        const result = await this.commands.findIntegrationContextByExternalEntityId({
+            externalId,
+            type,
+        });
+
+        if (result.error) {
+            const error = new Error(result.reason);
+            error.code = result.code;
+            throw error;
+        }
+
+        console.log(
+            `[TestApiAIntegration] Found integration: id=${result.record.id}, type=${result.record.config.type}`
+        );
+
+        return {
+            success: true,
+            integrationId: result.record.id,
+            integrationType: result.record.config.type,
+            entityId: result.entity.id,
+            entityExternalId: result.entity.externalId,
+        };
+    }
+}
+
+module.exports = TestApiAIntegration;

--- a/.claude/skills/frigg-local-test/assets/harness/src/integrations/TestApiBIntegration.js
+++ b/.claude/skills/frigg-local-test/assets/harness/src/integrations/TestApiBIntegration.js
@@ -1,0 +1,48 @@
+const { IntegrationBase, createFriggCommands } = require('@friggframework/core');
+const testApiB = require('../api-modules/test-api-b');
+
+class TestApiBIntegration extends IntegrationBase {
+    static Definition = {
+        name: 'test-api-b',
+        version: '1.0.0',
+        supportedVersions: ['1.0.0'],
+        display: {
+            label: 'Test API B',
+            description: 'Test API B integration for the local test environment',
+            category: 'Testing',
+            detailsUrl: 'https://example.com/test-api-b',
+            icon: '',
+        },
+        modules: {
+            testApiB: { definition: testApiB.Definition },
+        },
+    };
+
+    constructor(params) {
+        super(params);
+
+        this.commands = createFriggCommands({
+            integrationClass: TestApiBIntegration,
+        });
+
+        this.events = {
+            ...this.events,
+            FETCH_DATA: {
+                type: 'USER_ACTION',
+                handler: this.fetchData.bind(this),
+            },
+        };
+    }
+
+    async onCreate({ integrationId }) {
+        await this.updateIntegrationStatus.execute(integrationId, 'ENABLED');
+    }
+
+    async fetchData() {
+        return this.testApiB?.api
+            ? this.testApiB.api.fetchData()
+            : { status: 'no-api' };
+    }
+}
+
+module.exports = TestApiBIntegration;


### PR DESCRIPTION
## What & why

Adds a Docker-based environment to **run and test Frigg from the local `next` branch** against real databases — no mocks, no published canary. Purpose: let AI agents (and humans) learn how Frigg runs and test framework features themselves.

Following the `frigg-canary-test` pattern, **everything lives inside the skill** — the skill is the starting point for an agent, and the whole harness is bundled as its assets. **No files are added outside `.claude/`.**

## What's included

**`.claude/skills/frigg-local-test/SKILL.md`** — the agent runbook: quick start, database choice, raw Prisma commands, scenario-writing pattern, integration conventions, gotchas, isolated-sandbox and full-app paths.

**`.claude/skills/frigg-local-test/assets/harness/`** — copied to a scratch dir to run (never from inside `.claude/`):

- `package.json` — scripts: `db:up`/`db:down` (compose), `setup:db` (per-DB Prisma client + schema sync), raw `prisma@6` commands (`prisma:generate:postgres|mongo`, `db:migrate:postgres`, `db:push:mongo`), scenario runner, poke server, smoke test.
- `docker-compose.yml` — PostgreSQL (`127.0.0.1:5433`) + MongoDB rs0 replica set (`127.0.0.1:27018`), non-clashing localhost ports; opt-in profiles: **agent sandbox** (node 22 + chromium, repo mounted at `/workspace`), **browser** (CDP :9222), **LocalStack** (KMS/SQS/Scheduler). Single compose project — **no Docker-in-Docker**.
- `index.js` / `server.js` — Frigg app `Definition` with mock integrations + poke server (`:3001/health`, `/api/integrations`).
- `src/` — mock integrations (`TestApiA`/`TestApiB`) and API-key modules, following production conventions (`{ definition }` wrapper, `createFriggCommands`).
- `scenarios/integration-lifecycle.js` — first scenario (ported from the canary harness): seeds real records via Prisma → loads context → hydrates `IntegrationBase` → dispatches via `IntegrationEventDispatcher` → asserts on results + error codes → cleans up.
- `scripts/` — `setup-db.sh`, `run-scenario.sh`, `smoke.sh`, sandbox `entrypoint.sh`.

**Local core, not registry:** the harness pins `@friggframework/core` to the checkout via a `file:` dependency (`npm install /path/to/frigg/packages/core`), so scenarios run live `next` code.

## Validation

- Validated **cold from a scratch copy** (exactly the agent flow): copy harness → `db:up` → pin local core → `npm install` → `setup:db` → scenario.
- `4 passed, 0 failed` on **PostgreSQL**; previously also green on **MongoDB** (same scenario, same code path, pre-restructure).
- `npm run smoke` passes end-to-end (DBs healthy, core resolves to local checkout, prisma setup, scenario green).

## Notes / roadmap

- No `package-lock.json`, `.gitignore`, or workspace changes — the harness is standalone.
- Roadmap (tracked in the skill + harness README): full-app layer (`frigg build`/`frigg start` via osls offline), CI job, more scenarios (credential-refresh delegates, user actions, encryption round-trip, initial sync).
