### PR TITLE
fix: lazy-load scheduler AWS SDK in core and repair `frigg init` scaffolding

### DIFF
--- a/packages/core/infrastructure/scheduler/eventbridge-scheduler-adapter.js
+++ b/packages/core/infrastructure/scheduler/eventbridge-scheduler-adapter.js
@@ -11,19 +11,39 @@
  * This adapter implements SchedulerServiceInterface for AWS EventBridge Scheduler.
  */
 
-const {
-    SchedulerClient,
-    CreateScheduleCommand,
-    DeleteScheduleCommand,
-    GetScheduleCommand,
-    ResourceNotFoundException,
-} = require('@aws-sdk/client-scheduler');
-
 const { SchedulerServiceInterface } = require('./scheduler-service-interface');
+
+/**
+ * Lazily load the AWS EventBridge Scheduler SDK.
+ *
+ * `@aws-sdk/client-scheduler` is an optional dependency: it is only needed when
+ * an application actually schedules jobs via EventBridge. Requiring it at module
+ * top level would force every consumer of `@friggframework/core` to install it,
+ * even those using the mock scheduler or no scheduler at all. Loading it here,
+ * on first use, keeps the AWS dependency out of the module-load path.
+ *
+ * @returns {object} The relevant exports from `@aws-sdk/client-scheduler`.
+ */
+function loadSchedulerSdk() {
+    try {
+        return require('@aws-sdk/client-scheduler');
+    } catch (error) {
+        if (error && error.code === 'MODULE_NOT_FOUND') {
+            throw new Error(
+                'The EventBridge scheduler requires the "@aws-sdk/client-scheduler" package, ' +
+                    'which is not installed. Install it (`npm install @aws-sdk/client-scheduler`) ' +
+                    'to use the EventBridge scheduler provider, or use the mock scheduler provider ' +
+                    '(SCHEDULER_PROVIDER=mock) for local development.'
+            );
+        }
+        throw error;
+    }
+}
 
 class EventBridgeSchedulerAdapter extends SchedulerServiceInterface {
     constructor({ region } = {}) {
         super();
+        const { SchedulerClient } = loadSchedulerSdk();
         this.client = new SchedulerClient({
             region: region || process.env.AWS_REGION || 'us-east-1',
         });
@@ -61,6 +81,7 @@ class EventBridgeSchedulerAdapter extends SchedulerServiceInterface {
         // Format date to AWS schedule expression (at(yyyy-mm-ddThh:mm:ss))
         const scheduleExpression = `at(${scheduleAt.toISOString().replace(/\.\d{3}Z$/, '')})`;
 
+        const { CreateScheduleCommand } = loadSchedulerSdk();
         const command = new CreateScheduleCommand({
             Name: scheduleName,
             GroupName: this.scheduleGroupName,
@@ -107,6 +128,8 @@ class EventBridgeSchedulerAdapter extends SchedulerServiceInterface {
             throw new Error('scheduleName is required');
         }
 
+        const { DeleteScheduleCommand, ResourceNotFoundException } =
+            loadSchedulerSdk();
         const command = new DeleteScheduleCommand({
             Name: scheduleName,
             GroupName: this.scheduleGroupName,
@@ -141,6 +164,8 @@ class EventBridgeSchedulerAdapter extends SchedulerServiceInterface {
             throw new Error('scheduleName is required');
         }
 
+        const { GetScheduleCommand, ResourceNotFoundException } =
+            loadSchedulerSdk();
         const command = new GetScheduleCommand({
             Name: scheduleName,
             GroupName: this.scheduleGroupName,

--- a/packages/core/infrastructure/scheduler/eventbridge-scheduler-adapter.test.js
+++ b/packages/core/infrastructure/scheduler/eventbridge-scheduler-adapter.test.js
@@ -1,0 +1,87 @@
+/**
+ * Regression tests for lazy loading of @aws-sdk/client-scheduler.
+ *
+ * @aws-sdk/client-scheduler is an OPTIONAL dependency of @friggframework/core.
+ * Merely requiring the scheduler infrastructure (and therefore core itself)
+ * must NOT pull in the AWS SDK, so consumers on the mock provider or with no
+ * scheduler at all are not forced to install it. Only instantiating the
+ * EventBridge adapter should reach for the SDK.
+ */
+
+describe('EventBridge scheduler lazy AWS SDK loading', () => {
+    const AWS_SDK = '@aws-sdk/client-scheduler';
+
+    const isSdkInstalled = () => {
+        try {
+            require.resolve(AWS_SDK);
+            return true;
+        } catch (error) {
+            return false;
+        }
+    };
+
+    beforeEach(() => {
+        jest.resetModules();
+    });
+
+    it('loads the scheduler module without requiring the AWS SDK', () => {
+        // Requiring the module must not throw even if the SDK is absent,
+        // and must not populate the SDK into the module cache.
+        // eslint-disable-next-line global-require
+        const scheduler = require('./index');
+        expect(scheduler.EventBridgeSchedulerAdapter).toBeDefined();
+        expect(scheduler.MockSchedulerAdapter).toBeDefined();
+        expect(scheduler.createSchedulerService).toBeInstanceOf(Function);
+
+        if (!isSdkInstalled()) {
+            expect(
+                Object.keys(require.cache).some((k) => k.includes('client-scheduler'))
+            ).toBe(false);
+        }
+    });
+
+    it('creates a mock scheduler without touching the AWS SDK', () => {
+        // eslint-disable-next-line global-require
+        const { createSchedulerService } = require('./index');
+        const service = createSchedulerService({ provider: 'mock' });
+        expect(service.constructor.name).toBe('MockSchedulerAdapter');
+    });
+
+    it('defaults to the mock provider in local/dev/test stages', () => {
+        const prevStage = process.env.STAGE;
+        const prevProvider = process.env.SCHEDULER_PROVIDER;
+        delete process.env.SCHEDULER_PROVIDER;
+        process.env.STAGE = 'test';
+        try {
+            // eslint-disable-next-line global-require
+            const { createSchedulerService } = require('./index');
+            const service = createSchedulerService();
+            expect(service.constructor.name).toBe('MockSchedulerAdapter');
+        } finally {
+            if (prevStage === undefined) delete process.env.STAGE;
+            else process.env.STAGE = prevStage;
+            if (prevProvider !== undefined)
+                process.env.SCHEDULER_PROVIDER = prevProvider;
+        }
+    });
+
+    it('instantiating the EventBridge adapter reaches for the SDK', () => {
+        // eslint-disable-next-line global-require
+        const {
+            EventBridgeSchedulerAdapter,
+        } = require('./eventbridge-scheduler-adapter');
+
+        if (isSdkInstalled()) {
+            const adapter = new EventBridgeSchedulerAdapter({
+                region: 'us-east-1',
+            });
+            expect(adapter.client).toBeDefined();
+        } else {
+            // Without the SDK installed, instantiation must throw a clear,
+            // actionable error naming the optional dependency.
+            expect(() => new EventBridgeSchedulerAdapter({})).toThrow(
+                /@aws-sdk\/client-scheduler/
+            );
+        }
+    });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,9 @@
         "serverless-http": "^2.7.0",
         "uuid": "^11.1.1"
     },
+    "optionalDependencies": {
+        "@aws-sdk/client-scheduler": "^3.588.0"
+    },
     "peerDependencies": {
         "@prisma/client": "^6.19.3",
         "prisma": "^6.19.3"

--- a/packages/devtools/frigg-cli/index.js
+++ b/packages/devtools/frigg-cli/index.js
@@ -91,11 +91,14 @@ const { ssmPushCommand } = require('./ssm-command');
 const program = new Command();
 
 program
-    .command('init [templateName]')
+    .command('init [projectName]')
     .description('Initialize a new Frigg application')
-    .option('-t, --template <template>', 'template to use', 'backend-only')
-    .option('-n, --name <name>', 'project name')
-    .option('-d, --directory <directory>', 'target directory')
+    .option('-n, --name <name>', 'project name (alternative to the positional argument)')
+    .option('-m, --mode <mode>', 'deployment mode: standalone or embedded')
+    .option('--no-frontend', 'skip the optional demo frontend')
+    .option('-f, --force', 'scaffold into a non-empty directory')
+    .option('-v, --verbose', 'enable verbose output')
+    .option('-t, --template <template>', 'legacy template (no longer supported)')
     .action(initCommand);
 
 program

--- a/packages/devtools/frigg-cli/init-command/index.js
+++ b/packages/devtools/frigg-cli/init-command/index.js
@@ -50,19 +50,32 @@ function checkNodeVersion() {
     }
 }
 
-async function initCommand(projectName, options) {
+async function initCommand(projectName, options = {}) {
     const verbose = options.verbose || false;
     const force = options.force || false;
-    
+
     checkNodeVersion();
 
-    const root = path.resolve(projectName);
+    // Accept the project name from the positional argument or the --name flag.
+    const targetName = projectName || options.name;
+    if (!targetName) {
+        console.error(
+            chalk.red(
+                'Please specify a project name:\n' +
+                    `  ${chalk.cyan('frigg init')} ${chalk.green('<project-name>')}\n`
+            )
+        );
+        process.exit(1);
+    }
+
+    const root = path.resolve(targetName);
     const appName = path.basename(root);
 
     checkAppName(appName);
-    
-    // Use backend-first handler by default
-    if (!options.template && !options.legacyFrontend) {
+
+    // A --template flag is legacy and no longer supported; without it, the
+    // backend-first handler is the default path for `frigg init`.
+    if (!options.template) {
         try {
             const handler = new BackendFirstHandler(root, {
                 force,

--- a/packages/devtools/frigg-cli/templates/backend/README.md
+++ b/packages/devtools/frigg-cli/templates/backend/README.md
@@ -1,0 +1,69 @@
+# Frigg Backend
+
+A [Frigg Framework](https://docs.friggframework.org) backend application, scaffolded with `frigg init`.
+
+## Project structure
+
+| File | Purpose |
+| --- | --- |
+| `index.js` | Your **app definition** — exports `Definition`, which declares integrations, the database, encryption, users, and VPC settings. This is the file you edit. |
+| `infrastructure.js` | Serverless entry point consumed by `frigg build` / `frigg deploy`. Reads `Definition` from `index.js`; you normally never edit it. |
+
+## Getting started
+
+```bash
+# 1. Install dependencies (if not already installed by `frigg init`)
+npm install
+
+# 2. Set up the database schema and generate the Prisma client
+frigg db:setup
+
+# 3. Run locally
+frigg start
+```
+
+Add an integration (installs the API module and scaffolds an integration file):
+
+```bash
+frigg install hubspot
+```
+
+Then register the generated integration class in the `integrations` array in `index.js`.
+
+## Configuration
+
+The app definition in `index.js` is validated against the Frigg app-definition schema.
+Common settings:
+
+- **Database** — enable `postgres` or `mongoDB` under `database`. The connection
+  string comes from the `DATABASE_URL` environment variable.
+- **Encryption** — `encryption.fieldLevelEncryptionMethod` is `kms` (recommended
+  for production) or `aes`. Encryption is automatically bypassed in the
+  `dev`/`test`/`local` stages.
+- **VPC** — set `vpc.enable` to `true` for production deployments in private subnets.
+
+### Environment variables
+
+Create a `.env` file for local development. Typical values:
+
+```bash
+STAGE=dev
+AWS_REGION=us-east-1
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/frigg
+# For AES encryption in any stage:
+# AES_KEY_ID=local-dev-key
+# AES_KEY=change-me-to-a-32-character-secret
+```
+
+## Deploy
+
+```bash
+frigg build --production     # build with AWS resource discovery
+frigg deploy --stage prod    # deploy via osls
+frigg doctor <stack-name>    # verify the deployed stack
+```
+
+## Learn more
+
+- Documentation: https://docs.friggframework.org
+- Issues & support: https://github.com/friggframework/frigg/issues

--- a/packages/devtools/frigg-cli/templates/backend/index.js
+++ b/packages/devtools/frigg-cli/templates/backend/index.js
@@ -1,0 +1,62 @@
+/**
+ * Frigg Application Definition
+ *
+ * This is the entry point for your Frigg backend. The exported `Definition`
+ * object is read by `infrastructure.js` (via `createFriggInfrastructure()`) to
+ * compose your serverless infrastructure, and by the Frigg runtime to wire up
+ * your integrations, database, encryption, and HTTP handlers.
+ *
+ * Add integrations with `frigg install <module>` (e.g. `frigg install hubspot`),
+ * which installs the API module and scaffolds an integration file under
+ * `src/integrations/`.
+ *
+ * See https://docs.friggframework.org for the full app-definition reference.
+ */
+
+'use strict';
+
+// Import your integrations here
+// const ExampleIntegration = require('./src/integrations/ExampleIntegration');
+
+const appDefinition = {
+    // Human-friendly name for this Frigg application.
+    name: 'frigg-app',
+
+    // The integrations this application exposes. Each entry is an
+    // IntegrationBase subclass. Install modules with `frigg install <module>`.
+    integrations: [
+        // Add your integrations here as you install them
+        // Example:
+        // ExampleIntegration,
+    ],
+
+    // User model. Password auth is enabled by default so the Management UI and
+    // API can authenticate users out of the box.
+    user: {
+        usePassword: true,
+    },
+
+    // Field-level encryption for sensitive data (credentials, tokens, mappings).
+    // KMS is recommended for production; encryption is automatically bypassed in
+    // the dev/test/local stages. Set to 'aes' to use AES with AES_KEY/AES_KEY_ID.
+    encryption: {
+        fieldLevelEncryptionMethod: 'kms',
+    },
+
+    // Database. Enable exactly one backend. PostgreSQL/Aurora is shown here;
+    // set `mongoDB: { enable: true }` instead to use MongoDB. The connection
+    // string comes from the DATABASE_URL environment variable.
+    database: {
+        postgres: {
+            enable: true,
+            management: 'discover',
+        },
+    },
+
+    // VPC deployment. Enable for production so Lambdas run in private subnets.
+    vpc: {
+        enable: false,
+    },
+};
+
+module.exports = { Definition: appDefinition };

--- a/packages/devtools/frigg-cli/templates/backend/infrastructure.js
+++ b/packages/devtools/frigg-cli/templates/backend/infrastructure.js
@@ -1,0 +1,20 @@
+/**
+ * Frigg Infrastructure Entry Point
+ *
+ * This file is the serverless configuration consumed by the Frigg CLI
+ * (`frigg build` / `frigg deploy`, which run `osls --config infrastructure.js`).
+ *
+ * `createFriggInfrastructure()` reads the `Definition` exported from `index.js`,
+ * runs AWS resource discovery (VPC, KMS, Aurora, etc.), and composes the full
+ * serverless definition. It returns a Promise that resolves to that definition,
+ * which Serverless/osls awaits automatically.
+ *
+ * You normally never need to edit this file — customize your application through
+ * the app definition in `index.js` instead.
+ */
+
+'use strict';
+
+const { createFriggInfrastructure } = require('@friggframework/devtools');
+
+module.exports = createFriggInfrastructure();

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -7,6 +7,7 @@
   },
   "files": [
     "frigg-cli/",
+    "frigg-cli/templates/",
     "infrastructure/",
     "migrations/",
     "management-ui/dist/",


### PR DESCRIPTION
## Summary

Two independent packaging bugs on `next`, both of which make a clean install unusable before any real work starts.

### Fix 1 — `@friggframework/core` should not require `@aws-sdk/client-scheduler` unless EventBridge is actually used

`infrastructure/scheduler/eventbridge-scheduler-adapter.js` did a **top-level** `require('@aws-sdk/client-scheduler')`, and `scheduler/index.js` eagerly requires that adapter (which core loads via `application → scheduler-commands`). Core never declared the package, so on a clean install merely running `require('@friggframework/core')` threw `MODULE_NOT_FOUND` — even on the mock provider or with no AWS at all. This also broke the **devtools CLI**, which loads core (verified: `frigg init --help` crashed on the unfixed registry core).

**Approach (dep made lazy, not just added):**
- `@aws-sdk/client-scheduler` is now required **lazily** through a cached `loadSchedulerSdk()` helper, called from the EventBridge adapter's constructor and methods — never at module load. Requiring the scheduler module (and thus core) no longer pulls aws-sdk; only instantiating the EventBridge adapter does. A missing package yields a clear, actionable error instead of a raw `MODULE_NOT_FOUND`.
- Declared in **`optionalDependencies`** so AWS deployments still install it by default, while non-AWS/local consumers aren't forced to. The factory already only instantiates the EventBridge adapter for the `eventbridge` provider; the mock path never touches aws-sdk.
- Added a regression test (`eventbridge-scheduler-adapter.test.js`).

**Proof (clean temp install, `--omit=optional` so client-scheduler is absent):**
```
BEFORE (top-level require): Error: Cannot find module '@aws-sdk/client-scheduler'
AFTER:  require('@friggframework/core') SUCCEEDED without @aws-sdk/client-scheduler
```
- Mock provider works and is the dev/test/local default; installing `@aws-sdk/client-scheduler` and instantiating `EventBridgeSchedulerAdapter` still constructs a real `SchedulerClient`.
- New regression test: 4 passing.

### Fix 2 — `frigg init` is broken in the 2.0-next devtools

`frigg init <name>` failed two ways:

**(a) Backend template not shipped.** The handler copies from `frigg-cli/templates/backend`, but that directory did not exist in the source tree (confirmed absent from the published `2.0.0-next.107` tarball) → "Backend template not found." Added a working backend template (`index.js` exporting `Definition`, `infrastructure.js`, `README.md`) and listed `frigg-cli/templates/` in package `files`. The template's app definition validates against the current app-definition schema, and carries the exact markers `updateAppDefinition()` rewrites when integrations are selected.

**(b) The `--template` default routed every init into the dead legacy branch.** The CLI registered `--template` with a default of `'backend-only'`, but the handler only runs the backend-first path when `!options.template`, so the truthy default always fell through to "Legacy template system is no longer supported" and exited 1. Removed the default (`--template` is now an explicit, unsupported legacy opt-in), made the positional the project name (`init [projectName]`), registered the flags the handler actually reads (`--mode`, `--no-frontend`, `--force`, `--verbose`), dropped the unused `--directory`, and removed the dangling `options.legacyFrontend` reference.

**Proof (built devtools tarball installed into a scratch dir):**
- `frigg init --help` lists the new options.
- Scaffolding `my-frigg-app` produces `index.js` / `infrastructure.js` / `package.json` / `README.md` — **no "template not found", no "legacy not supported".** Generated `index.js` exports a valid `Definition`; `infrastructure.js` resolves `createFriggInfrastructure` from devtools.
- Explicit `--template` still shows the legacy message (escape hatch preserved).

## Files changed
- `packages/core/infrastructure/scheduler/eventbridge-scheduler-adapter.js` — lazy SDK load
- `packages/core/infrastructure/scheduler/eventbridge-scheduler-adapter.test.js` — new regression test
- `packages/core/package.json` — `optionalDependencies: @aws-sdk/client-scheduler`
- `packages/devtools/frigg-cli/templates/backend/{index.js,infrastructure.js,README.md}` — new backend template
- `packages/devtools/package.json` — ship `frigg-cli/templates/`
- `packages/devtools/frigg-cli/index.js` — `init` command definition
- `packages/devtools/frigg-cli/init-command/index.js` — default routing + project-name handling

## Test plan
- [x] Clean-install core without client-scheduler → `require` succeeds (threw before)
- [x] Mock scheduler works; EventBridge adapter still functions with SDK present
- [x] Scheduler regression test passes (4/4)
- [x] `frigg init <name>` scaffolds a backend app from the built devtools tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDh45c1vm91ySYtvVv9Z65)_